### PR TITLE
test: cover tenant switch listing

### DIFF
--- a/src/app/admin/api/test/active-tenant/route.ts
+++ b/src/app/admin/api/test/active-tenant/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+
+import { env } from "@/server/env";
+import { ADMIN_ACTIVE_TENANT_COOKIE } from "@/server/services/admin-tenant-context";
+
+export async function GET() {
+  if (!env.ENABLE_TEST_ROUTES) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  const store = await cookies();
+  const activeTenantId = store.get(ADMIN_ACTIVE_TENANT_COOKIE)?.value ?? null;
+
+  return NextResponse.json({ activeTenantId });
+}

--- a/src/app/admin/api/test/seed-tenants-clients/route.ts
+++ b/src/app/admin/api/test/seed-tenants-clients/route.ts
@@ -1,0 +1,62 @@
+import { NextResponse } from "next/server";
+
+import { env } from "@/server/env";
+import { prisma } from "@/server/db/client";
+import { createTenant } from "@/server/services/tenant-service";
+import { createClient } from "@/server/services/client-service";
+
+const ADMIN_EMAIL = "pw-admin@example.test";
+
+type SeedResponse = {
+  tenantAId: string;
+  tenantAName: string;
+  tenantBId: string;
+  tenantBName: string;
+  clientsA: { id: string; name: string; clientId: string }[];
+  clientsB: { id: string; name: string; clientId: string }[];
+};
+
+export async function POST() {
+  if (!env.ENABLE_TEST_ROUTES) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  const admin = await prisma.adminUser.upsert({
+    where: { email: ADMIN_EMAIL },
+    update: {},
+    create: {
+      email: ADMIN_EMAIL,
+      name: "Playwright Admin",
+    },
+  });
+
+  const timestamp = Date.now();
+  const tenantAName = `Tenant Switch A ${timestamp}`;
+  const tenantBName = `Tenant Switch B ${timestamp}`;
+
+  const tenantA = await createTenant(admin.id, { name: tenantAName });
+  const tenantB = await createTenant(admin.id, { name: tenantBName });
+
+  const clientsA = await seedClients(tenantA.id, [`Tenant A Client ${timestamp}`, `Tenant A Extra ${timestamp}`]);
+  const clientsB = await seedClients(tenantB.id, [`Tenant B Client ${timestamp}`, `Tenant B Extra ${timestamp + 1}`]);
+
+  const payload: SeedResponse = {
+    tenantAId: tenantA.id,
+    tenantAName: tenantA.name,
+    tenantBId: tenantB.id,
+    tenantBName: tenantB.name,
+    clientsA,
+    clientsB,
+  };
+
+  return NextResponse.json(payload);
+}
+
+const seedClients = async (tenantId: string, names: string[]) => {
+  const results: { id: string; name: string; clientId: string }[] = [];
+  for (const name of names) {
+    const { client } = await createClient(tenantId, { name, clientType: "CONFIDENTIAL" });
+    results.push({ id: client.id, name: client.name, clientId: client.clientId });
+  }
+  return results;
+};

--- a/tests/e2e/admin.spec.ts
+++ b/tests/e2e/admin.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/test";
-import type { Page } from "@playwright/test";
+
+import { authenticate, createTestSession, stubClipboard } from "./helpers/admin";
 
 const tenantId = "tenant_qa";
 const tenantDisplayName = "QA Sandbox";
@@ -131,44 +132,3 @@ test.describe("admin console", () => {
     await page.waitForURL("**/api/auth/signin**");
   });
 });
-
-const createTestSession = async (page: Page) => {
-  const response = await page.request.post("/api/test/session", {
-    data: { tenantId },
-  });
-  if (!response.ok()) {
-    throw new Error(`Failed to create test session: ${response.status()}`);
-  }
-  const body = await response.json();
-  return body.sessionToken as string;
-};
-
-const authenticate = async (page: Page, sessionToken: string) => {
-  await page.context().addCookies([
-    {
-      name: "next-auth.session-token",
-      value: sessionToken,
-      domain: "127.0.0.1",
-      path: "/",
-      httpOnly: true,
-      sameSite: "Lax",
-      secure: false,
-      expires: Math.floor(Date.now() / 1000) + 4 * 60 * 60,
-    },
-  ]);
-};
-
-const stubClipboard = async (page: Page) => {
-  await page.addInitScript(() => {
-    const writeText = () => Promise.resolve();
-    const stub = { writeText };
-    if (navigator.clipboard) {
-      navigator.clipboard.writeText = writeText;
-      return;
-    }
-    Object.defineProperty(navigator, "clipboard", {
-      value: stub,
-      configurable: true,
-    });
-  });
-};

--- a/tests/e2e/helpers/admin.ts
+++ b/tests/e2e/helpers/admin.ts
@@ -1,0 +1,44 @@
+import type { Page } from "@playwright/test";
+
+const DEFAULT_TENANT_ID = "tenant_qa";
+
+export const createTestSession = async (page: Page, tenantId: string = DEFAULT_TENANT_ID) => {
+  const response = await page.request.post("/api/test/session", {
+    data: { tenantId },
+  });
+  if (!response.ok()) {
+    throw new Error(`Failed to create test session: ${response.status()}`);
+  }
+  const body = (await response.json()) as { sessionToken: string };
+  return body.sessionToken;
+};
+
+export const authenticate = async (page: Page, sessionToken: string) => {
+  await page.context().addCookies([
+    {
+      name: "next-auth.session-token",
+      value: sessionToken,
+      domain: "127.0.0.1",
+      path: "/",
+      httpOnly: true,
+      sameSite: "Lax",
+      secure: false,
+      expires: Math.floor(Date.now() / 1000) + 4 * 60 * 60,
+    },
+  ]);
+};
+
+export const stubClipboard = async (page: Page) => {
+  await page.addInitScript(() => {
+    const writeText = () => Promise.resolve();
+    const stub = { writeText };
+    if (navigator.clipboard) {
+      navigator.clipboard.writeText = writeText;
+      return;
+    }
+    Object.defineProperty(navigator, "clipboard", {
+      value: stub,
+      configurable: true,
+    });
+  });
+};

--- a/tests/e2e/tenants-switch.spec.ts
+++ b/tests/e2e/tenants-switch.spec.ts
@@ -1,0 +1,91 @@
+import { expect, test } from "@playwright/test";
+import type { Page } from "@playwright/test";
+
+import { authenticate, createTestSession } from "./helpers/admin";
+
+type SeededClients = { id: string; name: string; clientId: string }[];
+
+type SeedResponse = {
+  tenantAId: string;
+  tenantAName: string;
+  tenantBId: string;
+  tenantBName: string;
+  clientsA: SeededClients;
+  clientsB: SeededClients;
+};
+
+test.describe("tenant switching", () => {
+  test("client lists differ per tenant", async ({ page }) => {
+    await page.goto("/");
+    const seed = await seedTenantsWithClients(page);
+
+    const sessionToken = await createTestSession(page);
+    await authenticate(page, sessionToken);
+
+    await page.goto("/admin/clients");
+    await expect(page.getByRole("heading", { name: "OAuth clients" })).toBeVisible();
+
+    await switchTenant(page, seed.tenantAId, seed.tenantAName);
+    await expectClientsVisible(page, seed.clientsA.map((client) => client.name));
+    await expectClientsHidden(page, seed.clientsB.map((client) => client.name));
+
+    await switchTenant(page, seed.tenantBId, seed.tenantBName);
+    await expectClientsVisible(page, seed.clientsB.map((client) => client.name));
+    await expectClientsHidden(page, seed.clientsA.map((client) => client.name));
+
+    const activeTenantId = await getActiveTenantId(page);
+    expect(activeTenantId).toBe(seed.tenantBId);
+  });
+});
+
+const seedTenantsWithClients = async (page: Page): Promise<SeedResponse> => {
+  return page.evaluate<SeedResponse>(async () => {
+    const response = await fetch("/admin/api/test/seed-tenants-clients", {
+      method: "POST",
+      credentials: "include",
+    });
+    if (!response.ok) {
+      throw new Error(`Failed to seed tenants: ${response.status}`);
+    }
+    return (await response.json()) as SeedResponse;
+  });
+};
+
+const switchTenant = async (page: Page, tenantId: string, tenantName: string) => {
+  await page.getByTestId("tenant-switcher").click();
+  const option = page.getByTestId(`tenant-option-${tenantId}`);
+  await expect(option).toBeVisible();
+  await option.click();
+  const notifications = page.getByRole("region", { name: /Notifications/i });
+  await expect(notifications.getByRole("status").first()).toContainText("Active tenant updated");
+  await expect(page.getByText(`Tenant · ${tenantName}`)).toBeVisible();
+};
+
+const expectClientsVisible = async (page: Page, clientNames: string[]) => {
+  for (const name of clientNames) {
+    const matcher = new RegExp(escapeRegExp(name), "i");
+    await expect(page.getByRole("row", { name: matcher })).toBeVisible();
+  }
+};
+
+const expectClientsHidden = async (page: Page, clientNames: string[]) => {
+  for (const name of clientNames) {
+    const matcher = new RegExp(escapeRegExp(name), "i");
+    await expect(page.getByRole("row", { name: matcher })).toHaveCount(0);
+  }
+};
+
+const getActiveTenantId = async (page: Page) => {
+  return page.evaluate<string | null>(async () => {
+    const response = await fetch("/admin/api/test/active-tenant", {
+      credentials: "include",
+    });
+    if (!response.ok) {
+      throw new Error(`Failed to read active tenant: ${response.status}`);
+    }
+    const payload = (await response.json()) as { activeTenantId: string | null };
+    return payload.activeTenantId;
+  });
+};
+
+const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");


### PR DESCRIPTION
## Summary
- add /admin/api/test helpers to read the active-tenant cookie and to seed paired tenants with scoped clients
- introduce a shared Playwright admin helper plus a tenants-switch spec that flips between tenants and asserts client isolation
- keep the legacy admin spec using the shared helper for session auth

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test
- PLAYWRIGHT_BROWSERS_PATH=0 pnpm test:e2e

Closes #6