### PR TITLE
fix: stabilize admin sidebar and tenant switch

### DIFF
--- a/src/app/admin/_components/admin-shell.tsx
+++ b/src/app/admin/_components/admin-shell.tsx
@@ -29,8 +29,8 @@ export function AdminShell({ children, user, tenants, activeTenantId }: AdminShe
   };
 
   return (
-    <div className="flex min-h-screen bg-muted/20">
-      <aside className="hidden border-r bg-background/95 md:block md:w-72">
+    <div className="flex h-screen overflow-hidden bg-muted/20">
+      <aside className="hidden h-full border-r bg-background/95 md:flex md:w-72 md:flex-col">
         <AdminSidebar
           user={user}
           tenants={tenants}
@@ -39,8 +39,8 @@ export function AdminShell({ children, user, tenants, activeTenantId }: AdminShe
         />
       </aside>
 
-      <div className="flex flex-1 flex-col">
-        <header className="sticky top-0 z-40 border-b bg-background/90 backdrop-blur">
+      <div className="flex flex-1 flex-col overflow-hidden">
+        <header className="z-40 border-b bg-background/90 backdrop-blur">
           <div className="flex h-16 items-center gap-3 px-4 sm:px-6 lg:px-10">
             <Sheet>
               <SheetTrigger asChild>
@@ -49,7 +49,7 @@ export function AdminShell({ children, user, tenants, activeTenantId }: AdminShe
                   <span className="sr-only">Open navigation</span>
                 </Button>
               </SheetTrigger>
-              <SheetContent side="left" className="w-72 p-0">
+              <SheetContent side="left" className="flex w-72 flex-col p-0">
                 <AdminSidebar
                   user={user}
                   tenants={tenants}
@@ -88,7 +88,7 @@ export function AdminShell({ children, user, tenants, activeTenantId }: AdminShe
             </div>
           </div>
         </header>
-        <main className="flex-1 px-4 py-6 sm:px-6 lg:px-10">
+        <main className="flex-1 overflow-y-auto px-4 py-6 sm:px-6 lg:px-10">
           <div className="mx-auto w-full max-w-5xl space-y-8">{children}</div>
         </main>
       </div>

--- a/src/app/admin/_components/sidebar-nav.tsx
+++ b/src/app/admin/_components/sidebar-nav.tsx
@@ -18,7 +18,10 @@ export function SidebarNav({ items }: { items: NavItem[] }) {
   return (
     <ul className="space-y-1.5">
       {items.map((item) => {
-        const isActive = pathname === item.href || pathname.startsWith(`${item.href}/`);
+        const isRootPath = item.href === "/admin";
+        const isActive = isRootPath
+          ? pathname === item.href
+          : pathname === item.href || pathname.startsWith(`${item.href}/`);
         return (
           <li key={item.href}>
             <Link

--- a/src/app/admin/_components/sidebar.tsx
+++ b/src/app/admin/_components/sidebar.tsx
@@ -68,14 +68,9 @@ export function AdminSidebar({ user, tenants, activeTenantId, onAddTenant }: Pro
         </div>
       </ScrollArea>
       <div className="border-t px-4 py-5">
-        <div className="flex items-center justify-between gap-3">
+        <div className="space-y-4">
           <UserBadge user={user} />
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            onClick={handleLogout}
-          >
+          <Button type="button" variant="outline" className="w-full" onClick={handleLogout}>
             <LogOut className="mr-2 h-4 w-4" />
             Logout
           </Button>

--- a/tests/e2e/tenants-switch.spec.ts
+++ b/tests/e2e/tenants-switch.spec.ts
@@ -28,13 +28,14 @@ test.describe("tenant switching", () => {
     await switchTenant(page, seed.tenantAId, seed.tenantAName);
     await expectClientsVisible(page, seed.clientsA.map((client) => client.name));
     await expectClientsHidden(page, seed.clientsB.map((client) => client.name));
+    await expectTenantCookie(page, seed.tenantAId);
+    await expectActiveTenant(page, seed.tenantAId);
 
     await switchTenant(page, seed.tenantBId, seed.tenantBName);
     await expectClientsVisible(page, seed.clientsB.map((client) => client.name));
     await expectClientsHidden(page, seed.clientsA.map((client) => client.name));
-
-    const activeTenantId = await getActiveTenantId(page);
-    expect(activeTenantId).toBe(seed.tenantBId);
+    await expectTenantCookie(page, seed.tenantBId);
+    await expectActiveTenant(page, seed.tenantBId);
   });
 });
 
@@ -75,8 +76,8 @@ const expectClientsHidden = async (page: Page, clientNames: string[]) => {
   }
 };
 
-const getActiveTenantId = async (page: Page) => {
-  return page.evaluate<string | null>(async () => {
+const expectActiveTenant = async (page: Page, tenantId: string) => {
+  const activeTenantId = await page.evaluate<string | null>(async () => {
     const response = await fetch("/admin/api/test/active-tenant", {
       credentials: "include",
     });
@@ -86,6 +87,14 @@ const getActiveTenantId = async (page: Page) => {
     const payload = (await response.json()) as { activeTenantId: string | null };
     return payload.activeTenantId;
   });
+  expect(activeTenantId).toBe(tenantId);
+};
+
+const expectTenantCookie = async (page: Page, tenantId: string) => {
+  await expect.poll(async () => {
+    const cookies = await page.context().cookies();
+    return cookies.find((cookie) => cookie.name === "admin_active_tenant")?.value ?? null;
+  }, { timeout: 10_000 }).toBe(tenantId);
 };
 
 const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");


### PR DESCRIPTION
## Summary
- keep the admin sidebar fixed-height with a dedicated footer, move logout under the user badge, and ensure layout scrolls only the main content while the header/sidebar stay put
- tighten the sidebar nav highlighting so only "Clients" is active on /admin/clients and update AdminShell spacing for the tunnel width constraints
- add gated /admin/api/test helpers plus a tenants-switch Playwright spec (with cookie + API assertions) so we can validate tenant-specific client lists during tunnel verification

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test
- PLAYWRIGHT_BROWSERS_PATH=0 pnpm test:e2e

Closes #6