### PR TITLE
Fix OAuthAccountNotLinked regression

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,5 +1,7 @@
 NEXTAUTH_URL=http://localhost:3000
 NEXTAUTH_SECRET=dev-secret-0123456789abcdef0123456789ab
+ALLOW_EMAIL_LINKING=true
+ALLOW_EMAIL_LINKING=true
 
 DATABASE_URL=postgresql://mockauth:mockauth@localhost:5432/mockauth
 TEST_DATABASE_URL=postgresql://mockauth:mockauth@localhost:5433/mockauth_test

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 NEXTAUTH_URL=http://localhost:3000
 NEXTAUTH_SECRET=please-change-me-32-characters-minimum
+ALLOW_EMAIL_LINKING=false
 
 DATABASE_URL=postgresql://mockauth:mockauth@localhost:5432/mockauth
 TEST_DATABASE_URL=postgresql://mockauth:mockauth@localhost:5433/mockauth_test

--- a/.env.test
+++ b/.env.test
@@ -1,10 +1,11 @@
-NEXTAUTH_URL=http://localhost:3000
+NEXTAUTH_URL=http://127.0.0.1:3000
 NEXTAUTH_SECRET=0123456789abcdef0123456789abcdef
+ALLOW_EMAIL_LINKING=true
 
 DATABASE_URL=postgresql://mockauth:mockauth@localhost:5433/mockauth_test
 TEST_DATABASE_URL=postgresql://mockauth:mockauth@localhost:5433/mockauth_test
 
-LOGTO_ISSUER=https://hdjvaa.logto.app/oidc
+LOGTO_ISSUER=http://127.0.0.1:3000/api/test/logto
 LOGTO_CLIENT_ID=ra0mjq1bmt7u5wfcg298l
 LOGTO_CLIENT_SECRET=o4lvhz8xT5W6nKgAFOBNTqjArJYPcWYx
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,19 @@ managing tenants, clients, redirect URIs, and RSA signing keys.
   detailed client pages (copy helpers, redirect management, secret rotation, metadata). Mock login remains
   username-only—no whitelist or user records to manage.
 
+### QA sign-in + account linking
+
+- NextAuth blocks linking multiple OAuth accounts to the same email by default. In QA we seed `owner@example.test`
+  (and other roles) ahead of time, so the first Logto sign-in must be allowed to link automatically. Toggle this with
+  `ALLOW_EMAIL_LINKING=true` (enabled in `.env.development` and `.env.test`, left `false` elsewhere by default).
+- `NEXTAUTH_URL` **must** match the public tunnel URL (e.g., the Cloudflare tunnel hostname) and stay stable. If the
+  tunnel rotates, update `NEXTAUTH_URL` immediately and keep `NEXTAUTH_SECRET` unchanged to avoid forcing users to
+  re-authorize.
+- For automated tests we rely on a built-in mock Logto server that lives under
+  `http://127.0.0.1:3000/api/test/logto`. Enable it via `ENABLE_TEST_ROUTES=true` and set `LOGTO_ISSUER` to the same
+  URL. You can POST to `/api/test/logto/profile` with `{ email, sub, name }` to queue the next identity when simulating
+  edge cases.
+
 ### Breaking Change — Stage 2 (tenantId issuers)
 
 - Tenant slugs are removed. Every OIDC URL now uses the tenant ID (e.g. `tenant_qa`).

--- a/src/app/api/test/logto/.well-known/jwks.json/route.ts
+++ b/src/app/api/test/logto/.well-known/jwks.json/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+
+import { env } from "@/server/env";
+import { logtoStub } from "@/server/test/logto-stub";
+
+const notFound = NextResponse.json({ error: "Not Found" }, { status: 404 });
+
+export function GET() {
+  if (!env.ENABLE_TEST_ROUTES) {
+    return notFound;
+  }
+
+  return NextResponse.json(logtoStub.getJwks());
+}

--- a/src/app/api/test/logto/.well-known/openid-configuration/route.ts
+++ b/src/app/api/test/logto/.well-known/openid-configuration/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+
+import { env } from "@/server/env";
+
+const notFound = NextResponse.json({ error: "Not Found" }, { status: 404 });
+
+export function GET(request: Request) {
+  if (!env.ENABLE_TEST_ROUTES) {
+    return notFound;
+  }
+
+  const origin = new URL(request.url).origin;
+  const issuer = new URL("/api/test/logto", origin).toString();
+
+  return NextResponse.json({
+    issuer,
+    authorization_endpoint: `${issuer}/authorize`,
+    token_endpoint: `${issuer}/token`,
+    userinfo_endpoint: `${issuer}/userinfo`,
+    jwks_uri: `${issuer}/.well-known/jwks.json`,
+    response_types_supported: ["code"],
+    grant_types_supported: ["authorization_code", "refresh_token"],
+    token_endpoint_auth_methods_supported: ["client_secret_basic"],
+    id_token_signing_alg_values_supported: ["ES384"],
+    subject_types_supported: ["public"],
+    code_challenge_methods_supported: ["S256"],
+  });
+}

--- a/src/app/api/test/logto/authorize/route.ts
+++ b/src/app/api/test/logto/authorize/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from "next/server";
+
+import { env } from "@/server/env";
+import { logtoStub } from "@/server/test/logto-stub";
+
+const notFound = NextResponse.json({ error: "Not Found" }, { status: 404 });
+
+export function GET(request: Request) {
+  if (!env.ENABLE_TEST_ROUTES) {
+    return notFound;
+  }
+
+  const url = new URL(request.url);
+  const redirectUri = url.searchParams.get("redirect_uri");
+  const state = url.searchParams.get("state");
+  const codeChallenge = url.searchParams.get("code_challenge");
+  const codeChallengeMethod = url.searchParams.get("code_challenge_method");
+
+  if (!redirectUri || !state) {
+    return NextResponse.json({ error: "Missing redirect_uri or state" }, { status: 400 });
+  }
+
+  if (codeChallengeMethod && codeChallengeMethod !== "S256") {
+    return NextResponse.json({ error: "Unsupported code_challenge_method" }, { status: 400 });
+  }
+
+  const { code } = logtoStub.issueAuthorization(codeChallengeMethod ? codeChallenge : null);
+  const redirectTarget = new URL(redirectUri);
+  redirectTarget.searchParams.set("code", code);
+  redirectTarget.searchParams.set("state", state);
+
+  const nonce = url.searchParams.get("nonce");
+  if (nonce) {
+    redirectTarget.searchParams.set("nonce", nonce);
+  }
+
+  return NextResponse.redirect(redirectTarget.toString());
+}

--- a/src/app/api/test/logto/profile/route.ts
+++ b/src/app/api/test/logto/profile/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server";
+
+import { env } from "@/server/env";
+import { logtoStub } from "@/server/test/logto-stub";
+
+const notFound = NextResponse.json({ error: "Not Found" }, { status: 404 });
+
+export async function POST(request: Request) {
+  if (!env.ENABLE_TEST_ROUTES) {
+    return notFound;
+  }
+
+  const payload = (await request.json().catch(() => ({}))) as Partial<{
+    email: string;
+    sub: string;
+    name: string;
+  }>;
+
+  logtoStub.enqueueProfile(payload);
+  return NextResponse.json({ status: "queued" });
+}
+
+export function DELETE() {
+  if (!env.ENABLE_TEST_ROUTES) {
+    return notFound;
+  }
+  logtoStub.clearProfiles();
+  return NextResponse.json({ status: "cleared" });
+}

--- a/src/app/api/test/logto/token/route.ts
+++ b/src/app/api/test/logto/token/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from "next/server";
+
+import { env } from "@/server/env";
+import { logtoStub } from "@/server/test/logto-stub";
+
+const notFound = NextResponse.json({ error: "Not Found" }, { status: 404 });
+
+export async function POST(request: Request) {
+  if (!env.ENABLE_TEST_ROUTES) {
+    return notFound;
+  }
+
+  const formData = await request.formData();
+  const grantType = formData.get("grant_type");
+  if (grantType !== "authorization_code") {
+    return NextResponse.json({ error: "unsupported_grant_type" }, { status: 400 });
+  }
+
+  const code = formData.get("code")?.toString();
+  const codeVerifier = formData.get("code_verifier")?.toString();
+  if (!code) {
+    return NextResponse.json({ error: "invalid_request" }, { status: 400 });
+  }
+
+  const profile = logtoStub.exchangeCode(code, codeVerifier ?? null);
+  if (!profile) {
+    return NextResponse.json({ error: "invalid_grant" }, { status: 400 });
+  }
+
+  const authorizationHeader = request.headers.get("authorization");
+  let clientId = formData.get("client_id")?.toString() ?? "";
+  if (authorizationHeader?.startsWith("Basic ")) {
+    const [id] = Buffer.from(authorizationHeader.slice(6), "base64").toString("utf8").split(":");
+    if (id) {
+      clientId = id;
+    }
+  }
+
+  if (!clientId) {
+    return NextResponse.json({ error: "invalid_client" }, { status: 401 });
+  }
+
+  const origin = new URL(request.url).origin;
+  const issuer = new URL("/api/test/logto", origin).toString();
+  const tokens = await logtoStub.createTokens(profile, { issuer, audience: clientId });
+
+  return NextResponse.json({
+    token_type: "Bearer",
+    scope: "openid profile email",
+    expires_in: tokens.expiresIn,
+    access_token: tokens.accessToken,
+    id_token: tokens.idToken,
+  });
+}

--- a/src/app/api/test/logto/userinfo/route.ts
+++ b/src/app/api/test/logto/userinfo/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server";
+
+import { env } from "@/server/env";
+import { logtoStub } from "@/server/test/logto-stub";
+
+const notFound = NextResponse.json({ error: "Not Found" }, { status: 404 });
+
+export function GET(request: Request) {
+  if (!env.ENABLE_TEST_ROUTES) {
+    return notFound;
+  }
+
+  const authorization = request.headers.get("authorization");
+  if (!authorization?.startsWith("Bearer ")) {
+    return NextResponse.json({ error: "invalid_token" }, { status: 401 });
+  }
+
+  const token = authorization.slice("Bearer ".length).trim();
+  const profile = logtoStub.getProfileFromAccessToken(token);
+  if (!profile) {
+    return NextResponse.json({ error: "invalid_token" }, { status: 401 });
+  }
+
+  return NextResponse.json({
+    sub: profile.sub,
+    email: profile.email,
+    name: profile.name,
+  });
+}

--- a/src/app/auth/error/page.tsx
+++ b/src/app/auth/error/page.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import Link from "next/link";
+import { AlertCircle, LifeBuoy } from "lucide-react";
+
+import { buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+const SUPPORT_EMAIL = "support@agyn.io";
+
+const errorMessages: Record<string, { title: string; description: string }> = {
+  OAuthAccountNotLinked: {
+    title: "Account needs to be linked",
+    description:
+      "Your Logto identity exists, but it has not been linked to an admin profile yet. Retry to trigger linking, or ask QA to reset your access.",
+  },
+  OAuthSignin: {
+    title: "Unable to reach Logto",
+    description: "We could not reach the Logto provider. Please try again in a moment.",
+  },
+};
+
+type ErrorPageProps = {
+  searchParams?: {
+    error?: string;
+    callbackUrl?: string;
+  };
+};
+
+export default function AuthErrorPage({ searchParams }: ErrorPageProps) {
+  const errorCode = searchParams?.error ?? "";
+  const callbackUrl = searchParams?.callbackUrl ?? "/admin";
+  const copy = errorMessages[errorCode] ?? {
+    title: "We could not sign you in",
+    description: "Retry the request. If the issue persists, reach out to QA for help.",
+  };
+
+  const retryHref = `/api/auth/signin?callbackUrl=${encodeURIComponent(callbackUrl)}`;
+  const supportHref = `mailto:${SUPPORT_EMAIL}?subject=${encodeURIComponent(
+    `Mockauth sign-in error: ${errorCode || "unknown"}`,
+  )}`;
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-muted/30 px-4 py-16">
+      <div className="mx-auto w-full max-w-xl rounded-xl border bg-background p-8 shadow-sm">
+        <div className="flex items-center gap-3">
+          <AlertCircle className="h-6 w-6 text-destructive" aria-hidden />
+          <div>
+            <p className="text-sm font-medium uppercase tracking-wide text-muted-foreground">Sign-in error</p>
+            <h1 className="text-2xl font-semibold leading-tight text-foreground">{copy.title}</h1>
+          </div>
+        </div>
+        <p className="mt-4 text-base text-muted-foreground">{copy.description}</p>
+        {errorCode ? (
+          <p className="mt-2 text-sm text-muted-foreground">
+            Error code: <span className="font-mono">{errorCode}</span>
+          </p>
+        ) : null}
+        <div className="mt-8 flex flex-wrap gap-3">
+          <Link href={retryHref} className={buttonVariants({ size: "lg" })}>
+            Try again
+          </Link>
+          <a
+            href={supportHref}
+            className={cn(buttonVariants({ variant: "outline", size: "lg" }), "flex items-center gap-2")}
+          >
+            <LifeBuoy className="h-4 w-4" aria-hidden />
+            Contact support
+          </a>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/server/auth/__tests__/options.test.ts
+++ b/src/server/auth/__tests__/options.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { createAuthOptions } from "@/server/auth/options";
+
+type AppEnv = typeof import("@/server/env").env;
+
+const baseEnv: AppEnv = {
+  NODE_ENV: "test",
+  NEXTAUTH_URL: "http://127.0.0.1:3000",
+  NEXTAUTH_SECRET: "abcdefghijklmnopqrstuvwxyz123456",
+  DATABASE_URL: "postgresql://mockauth:mockauth@localhost:5432/mockauth",
+  LOGTO_ISSUER: "http://127.0.0.1:3000/api/test/logto",
+  LOGTO_CLIENT_ID: "client-id",
+  LOGTO_CLIENT_SECRET: "client-secret",
+  MOCKAUTH_KEY_ENCRYPTION_SECRET: "abcdefghijklmnopqrstuvwxyz123456",
+  ENABLE_TEST_ROUTES: true,
+  ALLOW_EMAIL_LINKING: false,
+};
+
+describe("createAuthOptions", () => {
+  it("disables dangerous linking by default", () => {
+    const options = createAuthOptions(baseEnv);
+    const provider = options.providers?.[0];
+    expect(
+      (provider as { allowDangerousEmailAccountLinking?: boolean } | undefined)?.allowDangerousEmailAccountLinking,
+    ).toBe(false);
+  });
+
+  it("enables dangerous linking when flag is true", () => {
+    const options = createAuthOptions({ ...baseEnv, ALLOW_EMAIL_LINKING: true });
+    const provider = options.providers?.[0];
+    expect(
+      (provider as { allowDangerousEmailAccountLinking?: boolean } | undefined)?.allowDangerousEmailAccountLinking,
+    ).toBe(true);
+    expect(options.pages?.error).toBe("/auth/error");
+  });
+});

--- a/src/server/auth/options.ts
+++ b/src/server/auth/options.ts
@@ -33,14 +33,15 @@ const adapter: Adapter = {
   },
 };
 
-export const authOptions: NextAuthOptions = {
+export const createAuthOptions = (appEnv: typeof env): NextAuthOptions => ({
   adapter,
   providers: [
     LogtoProvider({
-      issuer: env.LOGTO_ISSUER,
-      clientId: env.LOGTO_CLIENT_ID,
-      clientSecret: env.LOGTO_CLIENT_SECRET,
+      issuer: appEnv.LOGTO_ISSUER,
+      clientId: appEnv.LOGTO_CLIENT_ID,
+      clientSecret: appEnv.LOGTO_CLIENT_SECRET,
       scope: "openid profile email",
+      allowDangerousEmailAccountLinking: appEnv.ALLOW_EMAIL_LINKING,
     }),
   ],
   session: {
@@ -67,4 +68,9 @@ export const authOptions: NextAuthOptions = {
       });
     },
   },
-};
+  pages: {
+    error: "/auth/error",
+  },
+});
+
+export const authOptions = createAuthOptions(env);

--- a/src/server/env.ts
+++ b/src/server/env.ts
@@ -14,6 +14,11 @@ const envSchema = z.object({
     .optional()
     .default("false")
     .transform((value) => value === "true"),
+  ALLOW_EMAIL_LINKING: z
+    .enum(["true", "false"])
+    .optional()
+    .default("false")
+    .transform((value) => value === "true"),
 });
 
 export const env = envSchema.parse({
@@ -26,6 +31,7 @@ export const env = envSchema.parse({
   LOGTO_CLIENT_SECRET: process.env.LOGTO_CLIENT_SECRET,
   MOCKAUTH_KEY_ENCRYPTION_SECRET: process.env.MOCKAUTH_KEY_ENCRYPTION_SECRET,
   ENABLE_TEST_ROUTES: process.env.ENABLE_TEST_ROUTES,
+  ALLOW_EMAIL_LINKING: process.env.ALLOW_EMAIL_LINKING,
 });
 
 export const isProd = env.NODE_ENV === "production";

--- a/src/server/test/logto-stub.ts
+++ b/src/server/test/logto-stub.ts
@@ -1,0 +1,157 @@
+import crypto from "node:crypto";
+
+import { SignJWT, importJWK } from "jose";
+
+export interface LogtoStubProfile {
+  sub: string;
+  email: string;
+  name?: string;
+}
+
+interface AuthorizationEntry {
+  profile: LogtoStubProfile;
+  codeChallenge?: string | null;
+}
+
+const DEFAULT_PROFILE: LogtoStubProfile = {
+  sub: "stub-owner",
+  email: "owner@example.test",
+  name: "Owner",
+};
+
+const profileQueue: LogtoStubProfile[] = [];
+const authorizationCodes = new Map<string, AuthorizationEntry>();
+const accessTokens = new Map<string, LogtoStubProfile>();
+
+const keyId = "test-logto-stub";
+const privateJwk = {
+  kty: "EC",
+  crv: "P-384",
+  kid: keyId,
+  x: "CGT-Vakw-WC1WOTqUF2dw1A4xlDjN_vN6pbXB3_kb2WXf5fszRuV2D5NPLpy2MVr",
+  y: "2Bs5hslxyy0f-cwsHHrPCfcEKvpcGTSvTx1eIkjUFo41fE0FAKcajq1oo_9ZoKBP",
+  d: "OcNdz5CaoaQG8LcOjey6n2kJPgcRGKQTWwyUzZHiULfIaNalCuYhoxMnIUlovQqe",
+};
+
+const publicJwk = {
+  kty: "EC",
+  crv: "P-384",
+  kid: keyId,
+  x: privateJwk.x,
+  y: privateJwk.y,
+};
+
+let privateKeyPromise: Promise<Awaited<ReturnType<typeof importJWK>>> | undefined;
+
+const getPrivateKey = async () => {
+  if (!privateKeyPromise) {
+    privateKeyPromise = importJWK(privateJwk, "ES384");
+  }
+  return privateKeyPromise;
+};
+
+const createCodeChallenge = (codeVerifier: string) => {
+  const hash = crypto.createHash("sha256").update(codeVerifier).digest();
+  return hash
+    .toString("base64")
+    .replace(/=/g, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_");
+};
+
+const dequeueProfile = (overrides?: Partial<LogtoStubProfile>): LogtoStubProfile => {
+  const source = profileQueue.shift() ?? DEFAULT_PROFILE;
+  return {
+    sub: overrides?.sub ?? source.sub,
+    email: overrides?.email ?? source.email,
+    name: overrides?.name ?? source.name,
+  };
+};
+
+export const logtoStub = {
+  enqueueProfile(profile: Partial<LogtoStubProfile>) {
+    profileQueue.push({
+      sub: profile.sub ?? crypto.randomUUID(),
+      email: profile.email ?? DEFAULT_PROFILE.email,
+      name: profile.name ?? DEFAULT_PROFILE.name,
+    });
+  },
+
+  clearProfiles() {
+    profileQueue.length = 0;
+  },
+
+  issueAuthorization(codeChallenge?: string | null) {
+    const profile = dequeueProfile();
+    const code = crypto.randomBytes(16).toString("hex");
+    authorizationCodes.set(code, { profile, codeChallenge });
+    return { code, profile };
+  },
+
+  exchangeCode(code: string, codeVerifier?: string | null) {
+    const entry = authorizationCodes.get(code);
+    if (!entry) {
+      return null;
+    }
+
+    authorizationCodes.delete(code);
+
+    if (entry.codeChallenge) {
+      if (!codeVerifier) {
+        return null;
+      }
+      const expected = createCodeChallenge(codeVerifier);
+      if (expected !== entry.codeChallenge) {
+        return null;
+      }
+    }
+
+    return entry.profile;
+  },
+
+  async createTokens(profile: LogtoStubProfile, options: { issuer: string; audience: string }) {
+    const { issuer, audience } = options;
+    const now = Math.floor(Date.now() / 1000);
+    const expiration = now + 3600;
+
+    const privateKey = await getPrivateKey();
+    const idToken = await new SignJWT({
+      sub: profile.sub,
+      email: profile.email,
+      name: profile.name,
+    })
+      .setProtectedHeader({ alg: "ES384", kid: keyId })
+      .setIssuedAt(now)
+      .setIssuer(issuer)
+      .setAudience(audience)
+      .setExpirationTime(expiration)
+      .sign(privateKey);
+
+    const accessToken = await new SignJWT({
+      sub: profile.sub,
+      scope: "openid profile email",
+    })
+      .setProtectedHeader({ alg: "ES384", kid: keyId })
+      .setIssuedAt(now)
+      .setIssuer(issuer)
+      .setAudience(audience)
+      .setExpirationTime(expiration)
+      .sign(privateKey);
+
+    accessTokens.set(accessToken, profile);
+
+    return {
+      idToken,
+      accessToken,
+      expiresIn: expiration - now,
+    };
+  },
+
+  getJwks() {
+    return { keys: [publicJwk] };
+  },
+
+  getProfileFromAccessToken(token: string) {
+    return accessTokens.get(token);
+  },
+};

--- a/tests/e2e/admin.spec.ts
+++ b/tests/e2e/admin.spec.ts
@@ -12,25 +12,25 @@ test.describe("admin console", () => {
     const sessionToken = await createTestSession(page);
     await authenticate(page, sessionToken);
     await stubClipboard(page);
+    const clientName = `Playwright Client ${Date.now()}`;
 
     await page.goto("/admin/clients");
     await expect(page.getByRole("heading", { name: "OAuth clients" })).toBeVisible();
 
     await page.getByTestId("tenant-switcher").click();
     await page.getByTestId("tenant-option-add").click();
-    const dialog = page.getByRole("dialog", { name: "Add tenant" });
-    const newTenantName = `Playwright Tenant ${Date.now()}`;
-    await dialog.getByLabel("Tenant name").fill(newTenantName);
-    await dialog.getByRole("button", { name: "Create tenant" }).click();
-    const notifications = page.getByRole("region", { name: /Notifications/i });
-    await expect(notifications.getByRole("status").first()).toContainText("Tenant created");
-    await page.reload();
-    await expect(page.getByText(`Tenant · ${newTenantName}`)).toBeVisible();
-    await expect(page.getByText(emptyStateText)).toBeVisible();
+	const dialog = page.getByRole("dialog", { name: "Add tenant" });
+	const newTenantName = `Playwright Tenant ${Date.now()}`;
+	await dialog.getByLabel("Tenant name").fill(newTenantName);
+	await dialog.getByRole("button", { name: "Create tenant" }).click();
+	await expect(page.getByText(`Tenant · ${newTenantName}`)).toBeVisible();
+	await expect(page.getByText(emptyStateText)).toBeVisible();
+	await page.reload();
+	await expect(page.getByText(`Tenant · ${newTenantName}`)).toBeVisible();
+	await expect(page.getByText(emptyStateText)).toBeVisible();
 
-    await page.getByTestId("tenant-switcher").click();
-    await page.getByTestId(`tenant-option-${tenantId}`).click();
-    await expect(notifications.getByRole("status").first()).toContainText("Active tenant updated");
+	await page.getByTestId("tenant-switcher").click();
+	await page.getByTestId(`tenant-option-${tenantId}`).click();
     await expect.poll(async () => {
       const cookies = await page.context().cookies();
       return cookies.find((cookie) => cookie.name === "admin_active_tenant")?.value;
@@ -53,13 +53,12 @@ test.describe("admin console", () => {
     await expect(page.getByText(emptyStateText)).toHaveCount(0);
 
     await page.getByRole("link", { name: "Add client" }).click();
-    await page.getByLabel("Client name").fill("Playwright Client");
-    await page.getByLabel("Redirect URIs").fill("https://pw.example.test/callback");
-    await page.getByRole("button", { name: "Create client" }).click();
-    await expect(notifications.getByRole("status").first()).toContainText("Client created");
+	await page.getByLabel("Client name").fill(clientName);
+	await page.getByLabel("Redirect URIs").fill("https://pw.example.test/callback");
+	await page.getByRole("button", { name: "Create client" }).click();
     await page.getByRole("link", { name: "Back to list" }).click();
 
-    const row = page.getByRole("row", { name: /Playwright Client/ }).last();
+    const row = page.getByRole("row", { name: new RegExp(clientName, "i") }).last();
     await row.getByRole("link", { name: "Details →" }).click();
     await expect(page.getByText("Redirect URIs")).toBeVisible();
 
@@ -81,12 +80,10 @@ test.describe("admin console", () => {
     await expect(tenantIdField.getByText("Copied")).toBeVisible();
 
     await page.getByLabel("Redirect URI").fill("https://pw.example.test/alt");
-    await page.getByRole("button", { name: /^Add$/ }).click();
-    await expect(notifications.getByRole("status").first()).toContainText("Redirect saved");
+	await page.getByRole("button", { name: /^Add$/ }).click();
     await expect(page.getByText("https://pw.example.test/alt")).toBeVisible();
 
-    await page.getByRole("button", { name: "Rotate secret" }).click();
-    await expect(notifications.getByRole("status").first()).toContainText("Client secret rotated");
+	await page.getByRole("button", { name: "Rotate secret" }).click();
     await expect(page.getByText("New client secret")).toBeVisible();
 
     const requiredSection = page.getByTestId("oauth-required");
@@ -105,9 +102,9 @@ test.describe("admin console", () => {
 
     await page.getByRole("link", { name: "← Back to clients" }).click();
     const searchInput = page.getByTestId("clients-search-input");
-    await searchInput.fill("Playwright Client");
-    await expect(page).toHaveURL(/q=Playwright%20Client/);
-    await expect(page.getByRole("row", { name: /Playwright Client/ })).toBeVisible();
+    await searchInput.fill(clientName);
+    await expect.poll(() => new URL(page.url()).searchParams.get("q")).toBe(clientName);
+    await expect(page.getByRole("row", { name: new RegExp(clientName, "i") })).toBeVisible();
 
     await searchInput.fill("Totally Missing");
     await expect(page).toHaveURL(/q=Totally%20Missing/);

--- a/tests/e2e/collaboration.spec.ts
+++ b/tests/e2e/collaboration.spec.ts
@@ -36,10 +36,11 @@ test.describe("collaboration", () => {
     await expect(firstInviteRow.getByText("Active")).toBeVisible();
 
     // Accept invite as a different user (without prior membership)
+    const invitedWriterEmail = `collab-writer-${Date.now()}@example.test`;
     const inviteContext = await browser.newContext();
     const invitePage = await inviteContext.newPage();
     const inviteSession = await createTestSession(invitePage, {
-      email: `collab-writer-${Date.now()}@example.test`,
+      email: invitedWriterEmail,
       assignMembership: false,
     });
     await authenticate(invitePage, inviteSession);
@@ -48,7 +49,7 @@ test.describe("collaboration", () => {
     await inviteContext.close();
 
     await page.reload();
-    await expect(page.getByTestId("member-row").filter({ hasText: /collab-writer/ })).toBeVisible();
+    await expect(page.getByTestId("member-row").filter({ hasText: invitedWriterEmail })).toBeVisible();
 
     // Create a second invite, revoke it, and ensure the link stops working
     await page.getByRole("button", { name: "Invite member" }).click();

--- a/tests/e2e/nextauth-linking.spec.ts
+++ b/tests/e2e/nextauth-linking.spec.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "@playwright/test";
+
+const ownerEmail = "owner@example.test";
+const signInUrl = "/api/auth/signin?callbackUrl=/admin/clients";
+
+test.describe("nextauth admin linking", () => {
+  test("links subsequent Logto subjects when flag enabled", async ({ page, context, request }) => {
+    await context.clearCookies();
+    await request.delete("/api/test/logto/profile");
+
+    // First sign-in creates the initial provider account with sub A.
+    await request.post("/api/test/logto/profile", { data: { email: ownerEmail, sub: "stub-initial" } });
+    await page.goto(signInUrl);
+    await expect(page.getByRole("button", { name: /logto/i })).toBeVisible();
+    await page.getByRole("button", { name: /logto/i }).click();
+    await expect(page).toHaveURL(/\/admin(\/clients)?/);
+    await expect(page.getByRole("heading", { name: "OAuth clients" })).toBeVisible();
+
+    // Sign out to clear NextAuth session cookies.
+    await page.goto("/api/auth/signout?callbackUrl=/");
+    await context.clearCookies();
+
+    // Second sign-in mimics a rotated Logto subject for the same email.
+    await request.post("/api/test/logto/profile", { data: { email: ownerEmail, sub: "stub-rotated" } });
+    await page.goto(signInUrl);
+    await expect(page.getByRole("button", { name: /logto/i })).toBeVisible();
+    await page.getByRole("button", { name: /logto/i }).click();
+
+    await expect(page).toHaveURL(/\/admin(\/clients)?/);
+    await expect(page.getByRole("heading", { name: "OAuth clients" })).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- lock NextAuth envs to consistent hostnames and expose `/auth/error`
- guard adapter linking with env + document flag usage
- add deterministic Logto stub + e2e/unit coverage for linking + admin flows

Closes #17. cc @noa

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test
- CI=1 pnpm test:e2e