### PR TITLE
Ensure sign-in links stay relative

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,12 +73,15 @@ managing tenants, clients, redirect URIs, and RSA signing keys.
   (and other roles) ahead of time, so the first Logto sign-in must be allowed to link automatically. Toggle this with
   `ALLOW_EMAIL_LINKING=true` (enabled in `.env.development` and `.env.test`, left `false` elsewhere by default).
 - `NEXTAUTH_URL` **must** match the public tunnel URL (e.g., the Cloudflare tunnel hostname) and stay stable. If the
-  tunnel rotates, update `NEXTAUTH_URL` immediately and keep `NEXTAUTH_SECRET` unchanged to avoid forcing users to
-  re-authorize.
+  tunnel rotates, update `NEXTAUTH_URL` immediately, re-add the tunnel callback URL inside Logto (Applications → your
+  client → **Sign-in redirect URIs**), and keep `NEXTAUTH_SECRET` unchanged to avoid forcing users to re-authorize.
 - For automated tests we rely on a built-in mock Logto server that lives under
   `http://127.0.0.1:3000/api/test/logto`. Enable it via `ENABLE_TEST_ROUTES=true` and set `LOGTO_ISSUER` to the same
   URL. You can POST to `/api/test/logto/profile` with `{ email, sub, name }` to queue the next identity when simulating
   edge cases.
+- Client-side sign-in buttons should always point to the relative path
+  `/api/auth/signin/logto?callbackUrl=/admin` so they inherit the current host; reserve `NEXTAUTH_URL` for server-side
+  NextAuth configuration only.
 
 ### Breaking Change — Stage 2 (tenantId issuers)
 

--- a/src/app/auth/error/page.tsx
+++ b/src/app/auth/error/page.tsx
@@ -35,7 +35,7 @@ export default function AuthErrorPage({ searchParams }: ErrorPageProps) {
     description: "Retry the request. If the issue persists, reach out to QA for help.",
   };
 
-  const retryHref = `/api/auth/signin?callbackUrl=${encodeURIComponent(callbackUrl)}`;
+  const retryHref = `/api/auth/signin/logto?callbackUrl=${encodeURIComponent(callbackUrl)}`;
   const supportHref = `mailto:${SUPPORT_EMAIL}?subject=${encodeURIComponent(
     `Mockauth sign-in error: ${errorCode || "unknown"}`,
   )}`;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -18,8 +18,12 @@ export default function Home() {
           tokens, and exercise PKCE flows without relying on external identity systems.
         </p>
         <div className="mt-6 flex flex-wrap gap-3">
-          <Link href="/admin" className="rounded-md bg-amber-400 px-4 py-2 font-semibold text-slate-900">
-            Open admin console
+          <Link
+            href="/api/auth/signin/logto?callbackUrl=%2Fadmin"
+            className="rounded-md bg-amber-400 px-4 py-2 font-semibold text-slate-900"
+            data-testid="landing-sign-in-link"
+          >
+            Sign in to admin console
           </Link>
           <a
             href="https://github.com/agynio/mockauth"

--- a/tests/e2e/signin-link.spec.ts
+++ b/tests/e2e/signin-link.spec.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "@playwright/test";
+
+test("landing sign-in link stays on same host", async ({ page }) => {
+  await page.goto("/");
+
+  const signInLink = page.getByTestId("landing-sign-in-link");
+  await expect(signInLink).toBeVisible();
+
+  const linkHref = await signInLink.getAttribute("href");
+  expect(linkHref).toBeTruthy();
+
+  const currentHost = new URL(page.url()).host;
+  const resolvedLink = new URL(linkHref ?? "", page.url());
+  expect(resolvedLink.host).toBe(currentHost);
+
+  await Promise.all([
+    page.waitForURL("**/api/auth/signin/logto**"),
+    signInLink.click(),
+  ]);
+
+  const navigatedHost = new URL(page.url()).host;
+  expect(navigatedHost).toBe(currentHost);
+});


### PR DESCRIPTION
## Summary
- switch marketing + error-page CTAs to the relative `/api/auth/signin/logto` route so they inherit the active host
- document tunnel rotation steps (update NEXTAUTH_URL + Logto callback) and note that client links stay relative
- add a Playwright check that the landing Sign in link remains same-origin when clicked

Closes #17. cc @noa

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test
- CI=1 pnpm test:e2e