### PR TITLE
Fix Logto stub origin behind tunnel

### DIFF
--- a/src/app/api/test/logto/.well-known/openid-configuration/route.ts
+++ b/src/app/api/test/logto/.well-known/openid-configuration/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 
 import { env } from "@/server/env";
+import { resolvePublicOrigin } from "@/server/http/origin";
 
 const notFound = NextResponse.json({ error: "Not Found" }, { status: 404 });
 
@@ -9,7 +10,7 @@ export function GET(request: Request) {
     return notFound;
   }
 
-  const origin = new URL(request.url).origin;
+  const origin = resolvePublicOrigin(request);
   const issuer = new URL("/api/test/logto", origin).toString();
 
   return NextResponse.json({

--- a/src/app/api/test/logto/token/route.ts
+++ b/src/app/api/test/logto/token/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 
 import { env } from "@/server/env";
+import { resolvePublicOrigin } from "@/server/http/origin";
 import { logtoStub } from "@/server/test/logto-stub";
 
 const notFound = NextResponse.json({ error: "Not Found" }, { status: 404 });
@@ -40,7 +41,7 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "invalid_client" }, { status: 401 });
   }
 
-  const origin = new URL(request.url).origin;
+  const origin = resolvePublicOrigin(request);
   const issuer = new URL("/api/test/logto", origin).toString();
   const tokens = await logtoStub.createTokens(profile, { issuer, audience: clientId });
 

--- a/src/server/http/origin.ts
+++ b/src/server/http/origin.ts
@@ -1,5 +1,7 @@
 import type { NextRequest } from "next/server";
 
+import { env } from "@/server/env";
+
 type RequestWithNextUrl = Request | (NextRequest & { nextUrl: URL });
 
 const ensureProtocol = (protocol: string) => (protocol.endsWith(":") ? protocol : `${protocol}:`);
@@ -35,4 +37,24 @@ export const resolveUrl = (request: RequestWithNextUrl) => {
 
 export const resolveOrigin = (request: RequestWithNextUrl) => {
   return resolveUrl(request).origin;
+};
+
+const parseConfiguredOrigin = () => {
+  const target = env.NEXTAUTH_URL;
+  if (!target) {
+    return null;
+  }
+  try {
+    return new URL(target).origin;
+  } catch {
+    return null;
+  }
+};
+
+export const resolvePublicOrigin = (request: RequestWithNextUrl) => {
+  const configured = parseConfiguredOrigin();
+  if (configured) {
+    return configured;
+  }
+  return resolveOrigin(request);
 };


### PR DESCRIPTION
## Summary
- derive the public origin from NEXTAUTH_URL so the Logto stub advertises the tunnel host
- reuse the helper for token issuance so id/access tokens carry the correct issuer
- captured new Playwright evidence showing the same-origin flow through the Cloudflare tunnel

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test