### PR TITLE
fix: streamline admin sidebar tenant controls

### DIFF
--- a/src/app/admin/_components/sidebar.tsx
+++ b/src/app/admin/_components/sidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Plus, LogOut } from "lucide-react";
+import { LogOut } from "lucide-react";
 import { signOut } from "next-auth/react";
 
 import { SidebarNav } from "@/app/admin/_components/sidebar-nav";
@@ -8,7 +8,6 @@ import { TenantSwitcher } from "@/app/admin/_components/tenant-controls";
 import { UserBadge } from "@/app/admin/_components/user-badge";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { Separator } from "@/components/ui/separator";
 
 type TenantSummary = {
   id: string;
@@ -38,37 +37,17 @@ export function AdminSidebar({ user, tenants, activeTenantId, onAddTenant }: Pro
   };
 
   return (
-    <div className="flex h-full flex-col bg-background">
+    <div className="flex h-full flex-col bg-background" data-testid="admin-sidebar">
       <div className="border-b px-6 py-5">
         <p className="text-xs uppercase tracking-wide text-muted-foreground">Control center</p>
         <h1 className="text-lg font-semibold text-foreground">Administration</h1>
       </div>
-      <ScrollArea className="flex-1 px-4 py-6">
-        <div className="space-y-6">
-          <section>
-            <h2 className="text-xs font-semibold uppercase text-muted-foreground">Navigation</h2>
-            <div className="mt-3">
-              <SidebarNav items={NAV_ITEMS} />
-            </div>
-          </section>
-          <Separator />
-          <section className="space-y-3">
-            <TenantSwitcher tenants={tenants} activeTenantId={activeTenantId} onAddTenant={onAddTenant} />
-            <Button
-              type="button"
-              variant="secondary"
-              className="w-full"
-              onClick={onAddTenant}
-              data-testid="add-tenant-btn"
-            >
-              <Plus className="mr-2 h-4 w-4" />
-              Create tenant
-            </Button>
-          </section>
-        </div>
+      <ScrollArea className="flex-1 px-4 py-6" data-testid="sidebar-nav-area">
+        <SidebarNav items={NAV_ITEMS} />
       </ScrollArea>
-      <div className="border-t px-4 py-5">
-        <div className="space-y-4">
+      <div className="border-t px-4 py-5 space-y-5" data-testid="sidebar-footer">
+        <TenantSwitcher tenants={tenants} activeTenantId={activeTenantId} onAddTenant={onAddTenant} />
+        <div className="space-y-4" data-testid="sidebar-user-section">
           <UserBadge user={user} />
           <Button type="button" variant="outline" className="w-full" onClick={handleLogout}>
             <LogOut className="mr-2 h-4 w-4" />

--- a/src/app/admin/_components/tenant-controls.tsx
+++ b/src/app/admin/_components/tenant-controls.tsx
@@ -77,10 +77,6 @@ export function TenantSwitcher({
 
   return (
     <div className="space-y-2">
-      <div className="flex items-center justify-between text-xs font-semibold uppercase text-muted-foreground">
-        <span>Active tenant</span>
-        {pending && <Loader2 className="h-3 w-3 animate-spin" />}
-      </div>
       <Popover open={open} onOpenChange={setOpen}>
         <PopoverTrigger asChild>
           <Button
@@ -98,7 +94,11 @@ export function TenantSwitcher({
               </span>
               {activeTenant ? <span className="text-xs text-muted-foreground">{activeTenant.id}</span> : null}
             </div>
-            <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+            {pending ? (
+              <Loader2 className="ml-2 h-4 w-4 shrink-0 animate-spin" />
+            ) : (
+              <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+            )}
           </Button>
         </PopoverTrigger>
         <PopoverContent className="w-[320px] p-0" align="start" sideOffset={8}>

--- a/src/app/admin/_components/user-badge.tsx
+++ b/src/app/admin/_components/user-badge.tsx
@@ -12,7 +12,7 @@ export function UserBadge({ user }: Props) {
   const initials = getInitials(user.name ?? user.email ?? "User");
 
   return (
-    <div className="flex items-center gap-3 rounded-xl border border-border bg-card/80 px-3 py-3">
+    <div className="flex items-center gap-3 rounded-xl border border-border bg-card/80 px-3 py-3" data-testid="sidebar-user-badge">
       <Avatar>
         {user.image ? <AvatarImage src={user.image} alt="avatar" /> : null}
         <AvatarFallback className="bg-primary/10 text-sm font-semibold text-primary">{initials}</AvatarFallback>

--- a/tests/e2e/admin.spec.ts
+++ b/tests/e2e/admin.spec.ts
@@ -17,20 +17,34 @@ test.describe("admin console", () => {
     await page.goto("/admin/clients");
     await expect(page.getByRole("heading", { name: "OAuth clients" })).toBeVisible();
 
+    const sidebar = page.getByTestId("admin-sidebar");
+    await expect(sidebar.getByText("Navigation", { exact: true })).toHaveCount(0);
+    await expect(sidebar.getByText("Active tenant", { exact: true })).toHaveCount(0);
+    await expect(page.getByTestId("add-tenant-btn")).toHaveCount(0);
+
+    const [tenantBox, userBox] = await Promise.all([
+      page.getByTestId("tenant-switcher").boundingBox(),
+      page.getByTestId("sidebar-user-badge").boundingBox(),
+    ]);
+    if (!tenantBox || !userBox) {
+      throw new Error("Sidebar layout missing");
+    }
+    expect(tenantBox.y + tenantBox.height).toBeLessThanOrEqual(userBox.y);
+
     await page.getByTestId("tenant-switcher").click();
     await page.getByTestId("tenant-option-add").click();
-	const dialog = page.getByRole("dialog", { name: "Add tenant" });
-	const newTenantName = `Playwright Tenant ${Date.now()}`;
-	await dialog.getByLabel("Tenant name").fill(newTenantName);
-	await dialog.getByRole("button", { name: "Create tenant" }).click();
-	await expect(page.getByText(`Tenant · ${newTenantName}`)).toBeVisible();
-	await expect(page.getByText(emptyStateText)).toBeVisible();
-	await page.reload();
-	await expect(page.getByText(`Tenant · ${newTenantName}`)).toBeVisible();
-	await expect(page.getByText(emptyStateText)).toBeVisible();
+    const dialog = page.getByRole("dialog", { name: "Add tenant" });
+    const newTenantName = `Playwright Tenant ${Date.now()}`;
+    await dialog.getByLabel("Tenant name").fill(newTenantName);
+    await dialog.getByRole("button", { name: "Create tenant" }).click();
+    await expect(page.getByText(`Tenant · ${newTenantName}`)).toBeVisible();
+    await expect(page.getByText(emptyStateText)).toBeVisible();
+    await page.reload();
+    await expect(page.getByText(`Tenant · ${newTenantName}`)).toBeVisible();
+    await expect(page.getByText(emptyStateText)).toBeVisible();
 
-	await page.getByTestId("tenant-switcher").click();
-	await page.getByTestId(`tenant-option-${tenantId}`).click();
+    await page.getByTestId("tenant-switcher").click();
+    await page.getByTestId(`tenant-option-${tenantId}`).click();
     await expect.poll(async () => {
       const cookies = await page.context().cookies();
       return cookies.find((cookie) => cookie.name === "admin_active_tenant")?.value;
@@ -53,9 +67,9 @@ test.describe("admin console", () => {
     await expect(page.getByText(emptyStateText)).toHaveCount(0);
 
     await page.getByRole("link", { name: "Add client" }).click();
-	await page.getByLabel("Client name").fill(clientName);
-	await page.getByLabel("Redirect URIs").fill("https://pw.example.test/callback");
-	await page.getByRole("button", { name: "Create client" }).click();
+    await page.getByLabel("Client name").fill(clientName);
+    await page.getByLabel("Redirect URIs").fill("https://pw.example.test/callback");
+    await page.getByRole("button", { name: "Create client" }).click();
     await page.getByRole("link", { name: "Back to list" }).click();
 
     const row = page.getByRole("row", { name: new RegExp(clientName, "i") }).last();
@@ -80,10 +94,10 @@ test.describe("admin console", () => {
     await expect(tenantIdField.getByText("Copied")).toBeVisible();
 
     await page.getByLabel("Redirect URI").fill("https://pw.example.test/alt");
-	await page.getByRole("button", { name: /^Add$/ }).click();
+    await page.getByRole("button", { name: /^Add$/ }).click();
     await expect(page.getByText("https://pw.example.test/alt")).toBeVisible();
 
-	await page.getByRole("button", { name: "Rotate secret" }).click();
+    await page.getByRole("button", { name: "Rotate secret" }).click();
     await expect(page.getByText("New client secret")).toBeVisible();
 
     const requiredSection = page.getByTestId("oauth-required");


### PR DESCRIPTION
## Summary
- remove the extra "Create tenant" button, keep the dropdown action, and relocate the switcher so it sits above the user card with no NAVIGATION/ACTIVE TENANT headers
- add sidebar data-test hooks plus Playwright assertions to lock the new order and ensure the legacy headers/buttons never reappear
- reuse the switcher\'s pending state inside the combobox trigger so the spinner lives inline instead of a separate label

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test
- PLAYWRIGHT_BROWSERS_PATH=0 pnpm test:e2e

Closes #6