### PR TITLE
Lock repo to pnpm

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-manager-strict=true

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ managing tenants, clients, redirect URIs, and RSA signing keys.
 - pnpm 10+
 - Docker (for local PostgreSQL)
 
+> **Package manager note:** Mockauth is pnpm-only. The `packageManager` field and `.npmrc` enforce pnpm 10.29.3, and the
+> checked-in `pnpm-lock.yaml` is the single source of truth. Avoid running `npm` or `yarn install` to keep dependencies
+> in sync across environments.
+
 ## Environment & Database
 
 1. Start the local Postgres containers (one for app data, one for tests):


### PR DESCRIPTION
Resolves #26\n\n## Summary\n- add .npmrc with package-manager-strict so installs use pnpm 10.29.3\n- document the pnpm-only workflow in the README prerequisites\n\n## Testing\n- pnpm lint\n- pnpm typecheck\n- pnpm test\n- PLAYWRIGHT_BROWSERS_PATH=0 /tmp/heartbeat.sh /workspace/use-node.sh pnpm exec dotenv -e .env.test -o -- pnpm playwright test