### PR TITLE
Move Playwright install out of postinstall

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,8 @@ jobs:
         run: pnpm typecheck
       - name: Unit & integration tests
         run: pnpm test
+      - name: Install Playwright browsers
+        run: pnpm playwright:install
       - name: Playwright E2E
         run: pnpm test:e2e
       - name: Build

--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ managing tenants, clients, redirect URIs, and RSA signing keys.
 | `pnpm prisma:migrate` | `prisma migrate dev` for the dev database. |
 | `pnpm prisma:seed` | Seeds tenants/clients/mock users for manual testing. |
 
+Playwright browsers are installed separately via `pnpm playwright:install` (run once per workstation or after dependency
+updates). CI runs this script automatically before executing E2E specs.
+
 ## Logto dev/test configuration
 
 - `tests/fixtures/logto.dev.config.ts` contains the Logto dev tenant details provided by Rowan. These credentials are for

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "prisma:migrate": "prisma migrate dev",
     "prisma:seed": "tsx -r tsconfig-paths/register prisma/seed.ts",
     "ci": "pnpm lint && pnpm typecheck && pnpm test && pnpm build",
-    "postinstall": "playwright install --with-deps"
+    "postinstall": "pnpm prisma:generate",
+    "playwright:install": "playwright install --with-deps"
   },
   "dependencies": {
     "@hookform/resolvers": "3.9.0",


### PR DESCRIPTION
Resolves #27\n\n## Summary\n- add a dedicated playwright:install script and scope postinstall to prisma generate for Vercel\n- document the manual playwright install step for local runs\n- ensure CI runs playwright:install before executing Playwright specs\n\n## Testing\n- pnpm lint\n- pnpm typecheck\n- pnpm test\n- PLAYWRIGHT_BROWSERS_PATH=0 /tmp/heartbeat.sh /workspace/use-node.sh pnpm exec dotenv -e .env.test -o -- pnpm playwright test