### PR TITLE
fix: honor tunnel origin for logto stub

### DIFF
--- a/src/app/api/test/logto/.well-known/openid-configuration/route.ts
+++ b/src/app/api/test/logto/.well-known/openid-configuration/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 
 import { env } from "@/server/env";
+import { resolveOrigin } from "@/server/http/origin";
 
 const notFound = NextResponse.json({ error: "Not Found" }, { status: 404 });
 
@@ -9,7 +10,7 @@ export function GET(request: Request) {
     return notFound;
   }
 
-  const origin = new URL(request.url).origin;
+  const origin = resolveOrigin(request);
   const issuer = new URL("/api/test/logto", origin).toString();
 
   return NextResponse.json({

--- a/src/app/api/test/logto/token/route.ts
+++ b/src/app/api/test/logto/token/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 
 import { env } from "@/server/env";
+import { resolveOrigin } from "@/server/http/origin";
 import { logtoStub } from "@/server/test/logto-stub";
 
 const notFound = NextResponse.json({ error: "Not Found" }, { status: 404 });
@@ -40,7 +41,7 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "invalid_client" }, { status: 401 });
   }
 
-  const origin = new URL(request.url).origin;
+  const origin = resolveOrigin(request);
   const issuer = new URL("/api/test/logto", origin).toString();
   const tokens = await logtoStub.createTokens(profile, { issuer, audience: clientId });
 

--- a/src/server/http/origin.ts
+++ b/src/server/http/origin.ts
@@ -11,6 +11,26 @@ const cloneUrl = (request: RequestWithNextUrl) => {
   return new URL(request.url);
 };
 
+const maybeApplyPublicOrigin = (url: URL) => {
+  const fallback = process.env.NEXTAUTH_URL;
+  if (!fallback) {
+    return url;
+  }
+
+  const hostname = url.hostname.toLowerCase();
+  if (hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]") {
+    try {
+      const fallbackUrl = new URL(fallback);
+      url.protocol = fallbackUrl.protocol;
+      url.host = fallbackUrl.host;
+      url.port = fallbackUrl.port;
+    } catch {
+      return url;
+    }
+  }
+  return url;
+};
+
 export const resolveUrl = (request: RequestWithNextUrl) => {
   const url = cloneUrl(request);
   const headers = request.headers;
@@ -30,7 +50,7 @@ export const resolveUrl = (request: RequestWithNextUrl) => {
     }
   }
 
-  return url;
+  return maybeApplyPublicOrigin(url);
 };
 
 export const resolveOrigin = (request: RequestWithNextUrl) => {


### PR DESCRIPTION
## Summary
- ensure resolveOrigin falls back to NEXTAUTH_URL when the inbound host is localhost so tunnel requests emit the public domain
- update Logto stub discovery + token routes to use the shared origin resolver so metadata and tokens reference the tunnel host
- rebuilt the app and verified the Quick Tunnel login flow hits only https://troops-pichunter-technician-toronto.trycloudflare.com endpoints

## Testing
- pnpm lint
- pnpm test