### PR TITLE
chore: automate prisma deploys

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ signing keys.
    pnpm prisma:migrate
    pnpm prisma:seed
    ```
+   (`pnpm prisma:migrate` targets the local dev database via `prisma migrate dev`. For deploys, use
+   `pnpm db:migrate`, which wraps `prisma migrate deploy`.)
 
 ## Common Commands
 
@@ -53,6 +55,8 @@ signing keys.
 | `pnpm test` | Prepares test DB, seeds fixtures, runs Vitest suite. |
 | `pnpm test:e2e` | Rebuilds test DB and runs Playwright (uses `openid-client` to complete Auth Code + PKCE). |
 | `pnpm test:e2e:dev` | Same as above but keeps a dev server running via `start-server-and-test`. |
+| `pnpm db:generate` | Runs `prisma generate` (no migrations). Used by `postinstall` and Vercel builds. |
+| `pnpm db:migrate` | Runs `prisma migrate deploy` for production/provisioned databases. |
 | `pnpm prisma:migrate` | `prisma migrate dev` for the dev database. |
 | `pnpm prisma:seed` | Seeds tenants/clients/mock users for manual testing. |
 
@@ -125,6 +129,14 @@ For the seeded tenant `tenant_qa` (default resource `tenant_qa_default_resource`
 | UserInfo | `/t/tenant_qa/r/tenant_qa_default_resource/oidc/userinfo` |
 - Username-only login lives at `/t/<tenantId>/r/<apiResourceId>/oidc/login` and stores a tenant-scoped mock-user session cookie (separate
   from NextAuth).
+
+## Vercel deploys
+
+- `vercel.json` pins the install command to `pnpm install --frozen-lockfile` so deploys stay in lockstep with the repo.
+- The build command always runs `pnpm prisma:generate` and only executes `pnpm db:migrate` when `VERCEL_ENV=production`
+  (preview deployments stay read-only, production applies migrations before `next build`).
+- Local `postinstall` still calls `pnpm prisma:generate` and never attempts to run migrations, keeping `pnpm install`
+  safe on contributor machines.
 
 ## CI
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "test:e2e": "pnpm test:prepare && dotenv -e .env.test -o -- playwright test",
     "test:e2e:ci": "pnpm test:prepare && dotenv -e .env.test -o -- playwright test --reporter=line",
     "test:e2e:dev": "pnpm test:prepare && dotenv -e .env.test -o -- playwright test --headed",
+    "db:generate": "prisma generate",
+    "db:migrate": "prisma migrate deploy",
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev",
     "prisma:seed": "tsx -r tsconfig-paths/register prisma/seed.ts",

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "installCommand": "pnpm install --frozen-lockfile",
+  "buildCommand": "pnpm prisma:generate && if [ \"$VERCEL_ENV\" = \"production\" ]; then pnpm db:migrate; fi && pnpm build"
+}


### PR DESCRIPTION
## Summary
- add `db:generate` and `db:migrate` scripts so production deploys can run Prisma CLI without touching the dev workflow
- configure Vercel to install with a frozen lockfile and run prisma generate plus conditional deploy migrations during builds
- document the new commands plus Vercel behavior in the README (postinstall remains generate-only)

## Testing
- /workspace/use-node.sh pnpm lint
- /workspace/use-node.sh pnpm typecheck
- /workspace/use-node.sh pnpm test
- PLAYWRIGHT_BROWSERS_PATH=0 /workspace/use-node.sh pnpm test:e2e

Closes #31