### PR TITLE
feat: manage tenants in admin

### DIFF
--- a/src/app/admin/_components/sidebar.tsx
+++ b/src/app/admin/_components/sidebar.tsx
@@ -28,6 +28,7 @@ type Props = {
 
 const NAV_ITEMS = [
   { href: "/admin", label: "Overview", description: "Tenant keys and SSO stats" },
+  { href: "/admin/tenants", label: "Tenants", description: "Manage tenant access" },
   { href: "/admin/clients", label: "Clients", description: "Manage OAuth clients" },
   { href: "/admin/api-resources", label: "API resources", description: "Manage issuers per tenant" },
   { href: "/admin/members", label: "Members", description: "Collaborate with your team" },

--- a/src/app/admin/actions.ts
+++ b/src/app/admin/actions.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
+import { cookies } from "next/headers";
 import { getServerSession } from "next-auth";
 import { z } from "zod";
 
@@ -17,12 +18,18 @@ import {
   updateClientApiResource,
 } from "@/server/services/client-service";
 import { rotateKey } from "@/server/services/key-service";
-import { setAdminActiveTenantCookie } from "@/server/services/admin-tenant-context";
+import {
+  ADMIN_ACTIVE_TENANT_COOKIE,
+  clearAdminActiveTenantCookie,
+  setAdminActiveTenantCookie,
+} from "@/server/services/admin-tenant-context";
 import {
   assertTenantMembership,
   assertTenantRole,
   ensureMembershipRole,
   createTenant,
+  deleteTenant,
+  getTenantMemberships,
 } from "@/server/services/tenant-service";
 import { createInvite, removeMember, revokeInvite, updateMemberRole } from "@/server/services/membership-service";
 import {
@@ -51,6 +58,7 @@ const updateClientSchema = z.object({ clientId: z.string().min(1), name: z.strin
 const deleteRedirectSchema = z.object({ redirectId: z.string().min(1) });
 const membershipRoleSchema = z.enum(["OWNER", "WRITER", "READER"]);
 const inviteRoleSchema = z.enum(["WRITER", "READER"]);
+const deleteTenantSchema = z.object({ tenantId: z.string().min(1) });
 const updateMemberRoleSchema = z.object({
   tenantId: z.string().min(1),
   membershipId: z.string().min(1),
@@ -115,6 +123,7 @@ export const createTenantAction = async (input: z.infer<typeof tenantSchema>): P
     revalidatePath("/admin", "layout");
     revalidatePath("/admin/clients");
     revalidatePath("/admin/members");
+    revalidatePath("/admin/tenants");
     return { success: "Tenant created" };
   } catch (error) {
     console.error(error);
@@ -131,6 +140,7 @@ export const setActiveTenantAction = async (input: z.infer<typeof setTenantSchem
     revalidatePath("/admin", "layout");
     revalidatePath("/admin/clients");
     revalidatePath("/admin/members");
+    revalidatePath("/admin/tenants");
     return { success: "Active tenant updated" };
   } catch (error) {
     console.error(error);
@@ -401,5 +411,42 @@ export const revokeInviteAction = async (input: z.infer<typeof revokeInviteSchem
   } catch (error) {
     console.error(error);
     return { error: "Unable to revoke invite" };
+  }
+};
+
+export const deleteTenantAction = async (
+  input: z.infer<typeof deleteTenantSchema>,
+): Promise<ActionState<{ activeTenantId: string | null; remainingTenants: number }>> => {
+  try {
+    const adminId = await requireSession();
+    const parsed = deleteTenantSchema.parse(input);
+    await assertTenantRole(adminId, parsed.tenantId, ["OWNER"]);
+    await deleteTenant(parsed.tenantId);
+
+    const store = await cookies();
+    const activeTenantCookie = store.get(ADMIN_ACTIVE_TENANT_COOKIE)?.value ?? null;
+    const remainingMemberships = await getTenantMemberships(adminId);
+    let resultingActiveTenantId = activeTenantCookie;
+    if (activeTenantCookie === parsed.tenantId) {
+      resultingActiveTenantId = remainingMemberships[0]?.tenantId ?? null;
+      if (resultingActiveTenantId) {
+        await setAdminActiveTenantCookie(resultingActiveTenantId);
+      } else {
+        await clearAdminActiveTenantCookie();
+      }
+    }
+
+    revalidatePath("/admin", "layout");
+    revalidatePath("/admin/clients");
+    revalidatePath("/admin/api-resources");
+    revalidatePath("/admin/members");
+    revalidatePath("/admin/tenants");
+    return {
+      success: "Tenant deleted",
+      data: { activeTenantId: resultingActiveTenantId ?? null, remainingTenants: remainingMemberships.length },
+    };
+  } catch (error) {
+    console.error(error);
+    return { error: "Unable to delete tenant" };
   }
 };

--- a/src/app/admin/api/test/seed-tenants-clients/route.ts
+++ b/src/app/admin/api/test/seed-tenants-clients/route.ts
@@ -7,6 +7,10 @@ import { createClient } from "@/server/services/client-service";
 
 const ADMIN_EMAIL = "pw-admin@example.test";
 
+type SeedRequest = {
+  adminEmail?: string;
+};
+
 type SeedResponse = {
   tenantAId: string;
   tenantAResourceId: string;
@@ -18,16 +22,19 @@ type SeedResponse = {
   clientsB: { id: string; name: string; clientId: string }[];
 };
 
-export async function POST() {
+export async function POST(request: Request) {
   if (!env.ENABLE_TEST_ROUTES) {
     return NextResponse.json({ error: "Not found" }, { status: 404 });
   }
 
+  const payload = (await request.json().catch(() => ({}))) as SeedRequest;
+  const adminEmail = payload.adminEmail?.toLowerCase().trim() || ADMIN_EMAIL;
+
   const admin = await prisma.adminUser.upsert({
-    where: { email: ADMIN_EMAIL },
+    where: { email: adminEmail },
     update: {},
     create: {
-      email: ADMIN_EMAIL,
+      email: adminEmail,
       name: "Playwright Admin",
     },
   });
@@ -42,7 +49,7 @@ export async function POST() {
   const clientsA = await seedClients(tenantA.id, [`Tenant A Client ${timestamp}`, `Tenant A Extra ${timestamp}`]);
   const clientsB = await seedClients(tenantB.id, [`Tenant B Client ${timestamp}`, `Tenant B Extra ${timestamp + 1}`]);
 
-  const payload: SeedResponse = {
+  const responsePayload: SeedResponse = {
     tenantAId: tenantA.id,
     tenantAResourceId: tenantA.defaultApiResourceId!,
     tenantAName: tenantA.name,
@@ -53,7 +60,7 @@ export async function POST() {
     clientsB,
   };
 
-  return NextResponse.json(payload);
+  return NextResponse.json(responsePayload);
 }
 
 const seedClients = async (tenantId: string, names: string[]) => {

--- a/src/app/admin/api/test/tenant-state/route.ts
+++ b/src/app/admin/api/test/tenant-state/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from "next/server";
+
+import { env } from "@/server/env";
+import { prisma } from "@/server/db/client";
+
+type Body = {
+  tenantId?: string;
+};
+
+export async function POST(request: Request) {
+  if (!env.ENABLE_TEST_ROUTES) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  const payload = (await request.json().catch(() => ({}))) as Body;
+  const tenantId = payload.tenantId?.trim();
+  if (!tenantId) {
+    return NextResponse.json({ error: "tenantId required" }, { status: 400 });
+  }
+
+  const [tenant, clients, apiResources, redirectUris, keys, memberships, invites, authorizationCodes, accessTokens, mockUsers, mockSessions] = await Promise.all([
+    prisma.tenant.findUnique({ where: { id: tenantId } }),
+    prisma.client.count({ where: { tenantId } }),
+    prisma.apiResource.count({ where: { tenantId } }),
+    prisma.redirectUri.count({ where: { client: { tenantId } } }),
+    prisma.tenantKey.count({ where: { tenantId } }),
+    prisma.tenantMembership.count({ where: { tenantId } }),
+    prisma.invite.count({ where: { tenantId } }),
+    prisma.authorizationCode.count({ where: { tenantId } }),
+    prisma.accessToken.count({ where: { tenantId } }),
+    prisma.mockUser.count({ where: { tenantId } }),
+    prisma.mockSession.count({ where: { tenantId } }),
+  ]);
+
+  return NextResponse.json({
+    tenantExists: Boolean(tenant),
+    counts: {
+      clients,
+      apiResources,
+      redirectUris,
+      keys,
+      memberships,
+      invites,
+      authorizationCodes,
+      accessTokens,
+      mockUsers,
+      mockSessions,
+    },
+  });
+}

--- a/src/app/admin/tenants/page.tsx
+++ b/src/app/admin/tenants/page.tsx
@@ -1,0 +1,28 @@
+import { redirect } from "next/navigation";
+import { getServerSession } from "next-auth";
+
+import { TenantsClient } from "@/app/admin/tenants/tenants-client";
+import { authOptions } from "@/server/auth/options";
+import { getAdminTenantContext } from "@/server/services/admin-tenant-context";
+
+export const metadata = {
+  title: "Tenants · Mockauth Admin",
+};
+
+export default async function TenantsPage() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    redirect("/api/auth/signin");
+  }
+
+  const tenantContext = await getAdminTenantContext(session.user.id);
+  const tenants = tenantContext.memberships.map((membership) => ({
+    membershipId: membership.id,
+    tenantId: membership.tenantId,
+    name: membership.tenant.name,
+    role: membership.role,
+    createdAt: membership.tenant.createdAt.toISOString(),
+  }));
+
+  return <TenantsClient tenants={tenants} activeTenantId={tenantContext.activeTenant?.id ?? null} />;
+}

--- a/src/app/admin/tenants/tenants-client.tsx
+++ b/src/app/admin/tenants/tenants-client.tsx
@@ -1,0 +1,241 @@
+"use client";
+
+import { useMemo, useState, useTransition } from "react";
+import { format } from "date-fns";
+import { AlertTriangle, Check, Copy, ExternalLink, Trash2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+
+import type { MembershipRole } from "@/generated/prisma/client";
+import { deleteTenantAction, setActiveTenantAction } from "@/app/admin/actions";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { useToast } from "@/components/ui/use-toast";
+
+type TenantRecord = {
+  membershipId: string;
+  tenantId: string;
+  name: string;
+  createdAt: string;
+  role: MembershipRole;
+};
+
+type Props = {
+  tenants: TenantRecord[];
+  activeTenantId: string | null;
+};
+
+const formatDate = (value: string) => format(new Date(value), "MMM d, yyyy");
+
+export function TenantsClient({ tenants, activeTenantId }: Props) {
+  const router = useRouter();
+  const { toast } = useToast();
+  const [copiedTenantId, setCopiedTenantId] = useState<string | null>(null);
+  const [dialogTenant, setDialogTenant] = useState<TenantRecord | null>(null);
+  const [switchingTenantId, setSwitchingTenantId] = useState<string | null>(null);
+  const [isSwitching, startSwitchTransition] = useTransition();
+  const [isDeleting, startDeleteTransition] = useTransition();
+
+  const sortedTenants = useMemo(() => {
+    return [...tenants].sort((left, right) => new Date(left.createdAt).getTime() - new Date(right.createdAt).getTime());
+  }, [tenants]);
+
+  const handleCopy = async (tenantId: string) => {
+    try {
+      await navigator.clipboard.writeText(tenantId);
+      setCopiedTenantId(tenantId);
+      setTimeout(() => setCopiedTenantId((current) => (current === tenantId ? null : current)), 1500);
+      toast({ title: "Tenant ID copied" });
+    } catch (error) {
+      console.error("Failed to copy tenant ID", error);
+      toast({ variant: "destructive", title: "Copy failed", description: "Unable to copy tenant ID" });
+    }
+  };
+
+  const handleSwitch = (tenant: TenantRecord) => {
+    if (tenant.tenantId === activeTenantId || isSwitching) {
+      return;
+    }
+    setSwitchingTenantId(tenant.tenantId);
+    startSwitchTransition(async () => {
+      const result = await setActiveTenantAction({ tenantId: tenant.tenantId });
+      if (result.error) {
+        toast({ variant: "destructive", title: "Unable to open tenant", description: result.error });
+        setSwitchingTenantId(null);
+        return;
+      }
+      router.refresh();
+      toast({ title: "Tenant switched", description: `Now viewing ${tenant.name}` });
+      setSwitchingTenantId(null);
+    });
+  };
+
+  const handleDelete = () => {
+    if (!dialogTenant) {
+      return;
+    }
+    startDeleteTransition(async () => {
+      const result = await deleteTenantAction({ tenantId: dialogTenant.tenantId });
+      if (result.error) {
+        toast({ variant: "destructive", title: "Delete failed", description: result.error });
+        return;
+      }
+      toast({ title: "Tenant deleted", description: `${dialogTenant.name} has been removed.` });
+      setDialogTenant(null);
+      if ((result.data?.remainingTenants ?? 0) === 0) {
+        router.push("/admin");
+      } else {
+        router.refresh();
+      }
+    });
+  };
+
+  if (sortedTenants.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>No tenants yet</CardTitle>
+          <CardDescription>Use the tenant switcher to create your first tenant.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">
+            The sidebar switcher includes an &ldquo;Add tenant&rdquo; button once you open it. Create a tenant to unlock admin tools.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <>
+      <Card>
+        <CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <CardTitle>Tenants</CardTitle>
+            <CardDescription>View and manage every tenant linked to your account.</CardDescription>
+          </div>
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <AlertTriangle className="h-4 w-4" />
+            Deleting a tenant removes all dependent data.
+          </div>
+        </CardHeader>
+        <CardContent>
+          <Table data-testid="tenants-table">
+            <TableHeader>
+              <TableRow>
+                <TableHead>Name</TableHead>
+                <TableHead>Tenant ID</TableHead>
+                <TableHead className="hidden md:table-cell">Created</TableHead>
+                <TableHead className="text-right">Actions</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {sortedTenants.map((tenant) => {
+                const isActive = tenant.tenantId === activeTenantId;
+                const canDelete = tenant.role === "OWNER";
+                return (
+                  <TableRow key={tenant.tenantId} data-testid={`tenant-row-${tenant.tenantId}`}>
+                    <TableCell>
+                      <div className="flex flex-col gap-1">
+                        <div className="flex items-center gap-2">
+                          <span className="font-medium">{tenant.name}</span>
+                          {isActive ? <Badge variant="outline">Active</Badge> : null}
+                        </div>
+                        <p className="text-xs uppercase text-muted-foreground">{tenant.role.toLowerCase()}</p>
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex items-center gap-2">
+                        <code className="rounded-md border bg-muted/40 px-2 py-1 font-mono text-xs">{tenant.tenantId}</code>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon"
+                          aria-label={`Copy ${tenant.name} ID`}
+                          onClick={() => handleCopy(tenant.tenantId)}
+                          data-testid={`tenant-copy-${tenant.tenantId}`}
+                        >
+                          {copiedTenantId === tenant.tenantId ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+                        </Button>
+                      </div>
+                    </TableCell>
+                    <TableCell className="hidden md:table-cell text-sm text-muted-foreground" data-testid={`tenant-created-${tenant.tenantId}`}>
+                      {formatDate(tenant.createdAt)}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <div className="flex justify-end gap-2">
+                        <Button
+                          type="button"
+                          variant="secondary"
+                          size="sm"
+                          onClick={() => handleSwitch(tenant)}
+                          disabled={isActive || isSwitching || switchingTenantId === tenant.tenantId}
+                          data-testid={`tenant-open-${tenant.tenantId}`}
+                        >
+                          <ExternalLink className="mr-2 h-3.5 w-3.5" />
+                          Open
+                        </Button>
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          disabled={!canDelete}
+                          onClick={() => setDialogTenant(tenant)}
+                          data-testid={`tenant-delete-${tenant.tenantId}`}
+                          aria-disabled={!canDelete}
+                          title={canDelete ? undefined : "Only owners can delete tenants"}
+                        >
+                          <Trash2 className="mr-2 h-3.5 w-3.5" />
+                          Delete
+                        </Button>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+
+      <AlertDialog open={Boolean(dialogTenant)} onOpenChange={(open) => !open && setDialogTenant(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete {dialogTenant?.name ?? "tenant"}?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This action permanently removes the tenant and the following data:
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <ul className="list-disc space-y-1 pl-6 text-sm text-muted-foreground">
+            <li>OAuth clients and redirect URIs</li>
+            <li>API resources and signing keys</li>
+            <li>Memberships, invites, and tenant cookies</li>
+            <li>Issued authorization codes, access tokens, and mock sessions</li>
+          </ul>
+          <AlertDialogFooter>
+            <AlertDialogCancel data-testid="tenant-delete-cancel">Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDelete}
+              disabled={isDeleting}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              data-testid="tenant-delete-confirm"
+            >
+              Delete tenant
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/src/server/services/__tests__/tenant-service.test.ts
+++ b/src/server/services/__tests__/tenant-service.test.ts
@@ -1,0 +1,92 @@
+import { randomUUID } from "crypto";
+
+import { describe, expect, it } from "vitest";
+
+import { prisma } from "@/server/db/client";
+import { createClient } from "@/server/services/client-service";
+import { createTenant, deleteTenant } from "@/server/services/tenant-service";
+
+const createAdminUser = async () => {
+  return prisma.adminUser.create({
+    data: {
+      email: `tenant-test-${randomUUID()}@example.test`,
+      name: "Tenant Service Tester",
+    },
+  });
+};
+
+describe("tenant service", () => {
+  it("removes tenants and all dependent records", async () => {
+    const admin = await createAdminUser();
+    const tenant = await createTenant(admin.id, { name: `Tenant Cascade ${randomUUID()}` });
+    const { client } = await createClient(tenant.id, {
+      name: "Cascade Client",
+      clientType: "CONFIDENTIAL",
+      redirectUris: ["https://cascade.example/callback"],
+    });
+    const apiResource = await prisma.apiResource.findFirstOrThrow({ where: { tenantId: tenant.id } });
+    const mockUser = await prisma.mockUser.create({
+      data: {
+        tenantId: tenant.id,
+        username: `user-${randomUUID()}`,
+        displayName: "Cascade User",
+      },
+    });
+    await prisma.mockSession.create({
+      data: {
+        tenantId: tenant.id,
+        userId: mockUser.id,
+        sessionTokenHash: randomUUID(),
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+      },
+    });
+    await prisma.authorizationCode.create({
+      data: {
+        tenantId: tenant.id,
+        clientId: client.id,
+        apiResourceId: apiResource.id,
+        userId: mockUser.id,
+        codeHash: randomUUID(),
+        redirectUri: "https://cascade.example/callback",
+        scope: "openid",
+        codeChallenge: "challenge",
+        codeChallengeMethod: "S256",
+        expiresAt: new Date(Date.now() + 60 * 1000),
+      },
+    });
+    await prisma.accessToken.create({
+      data: {
+        tenantId: tenant.id,
+        clientId: client.id,
+        apiResourceId: apiResource.id,
+        userId: mockUser.id,
+        jti: randomUUID(),
+        scope: "openid",
+        expiresAt: new Date(Date.now() + 60 * 1000),
+      },
+    });
+    await prisma.invite.create({
+      data: {
+        tenantId: tenant.id,
+        role: "READER",
+        tokenHash: randomUUID(),
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+        createdByUserId: admin.id,
+      },
+    });
+
+    await deleteTenant(tenant.id);
+
+    expect(await prisma.tenant.findUnique({ where: { id: tenant.id } })).toBeNull();
+    expect(await prisma.client.count({ where: { tenantId: tenant.id } })).toBe(0);
+    expect(await prisma.apiResource.count({ where: { tenantId: tenant.id } })).toBe(0);
+    expect(await prisma.redirectUri.count({ where: { client: { tenantId: tenant.id } } })).toBe(0);
+    expect(await prisma.tenantKey.count({ where: { tenantId: tenant.id } })).toBe(0);
+    expect(await prisma.tenantMembership.count({ where: { tenantId: tenant.id } })).toBe(0);
+    expect(await prisma.invite.count({ where: { tenantId: tenant.id } })).toBe(0);
+    expect(await prisma.authorizationCode.count({ where: { tenantId: tenant.id } })).toBe(0);
+    expect(await prisma.accessToken.count({ where: { tenantId: tenant.id } })).toBe(0);
+    expect(await prisma.mockUser.count({ where: { tenantId: tenant.id } })).toBe(0);
+    expect(await prisma.mockSession.count({ where: { tenantId: tenant.id } })).toBe(0);
+  });
+});

--- a/src/server/services/tenant-service.ts
+++ b/src/server/services/tenant-service.ts
@@ -90,3 +90,25 @@ export const createTenant = async (adminUserId: string, data: { name: string }) 
     return tenantWithDefault;
   });
 };
+
+export const deleteTenant = async (tenantId: string) => {
+  await prisma.$transaction(async (tx) => {
+    const tenant = await tx.tenant.findUnique({ where: { id: tenantId } });
+    if (!tenant) {
+      throw new DomainError("Tenant not found", { status: 404, code: "tenant_not_found" });
+    }
+
+    await tx.tenant.update({ where: { id: tenantId }, data: { defaultApiResourceId: null } });
+    await tx.authorizationCode.deleteMany({ where: { tenantId } });
+    await tx.accessToken.deleteMany({ where: { tenantId } });
+    await tx.mockSession.deleteMany({ where: { tenantId } });
+    await tx.mockUser.deleteMany({ where: { tenantId } });
+    await tx.redirectUri.deleteMany({ where: { client: { tenantId } } });
+    await tx.client.deleteMany({ where: { tenantId } });
+    await tx.apiResource.deleteMany({ where: { tenantId } });
+    await tx.tenantKey.deleteMany({ where: { tenantId } });
+    await tx.invite.deleteMany({ where: { tenantId } });
+    await tx.tenantMembership.deleteMany({ where: { tenantId } });
+    await tx.tenant.delete({ where: { id: tenantId } });
+  });
+};

--- a/tests/e2e/tenants-switch.spec.ts
+++ b/tests/e2e/tenants-switch.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 import type { Page } from "@playwright/test";
 
-import { authenticate, createTestSession } from "./helpers/admin";
+import { authenticate, createTestSession, stubClipboard } from "./helpers/admin";
 
 type SeededClients = { id: string; name: string; clientId: string }[];
 
@@ -56,19 +56,78 @@ test.describe("tenant switching", () => {
     await expect(dialog).toBeVisible();
     await page.keyboard.press("Escape");
   });
+
+  test("tenants page opens and deletes tenants", async ({ page }) => {
+    await page.goto("/");
+    const adminEmail = `pw-tenants-${Date.now()}@example.test`;
+    const seed = await seedTenantsWithClients(page, { adminEmail });
+    const sessionToken = await createTestSession(page, {
+      assignMembership: false,
+      email: adminEmail,
+      tenantId: seed.tenantAId,
+    });
+    await authenticate(page, sessionToken);
+    await stubClipboard(page);
+
+    await page.goto("/admin/tenants");
+    const table = page.getByTestId("tenants-table");
+    await expect(table.getByTestId(`tenant-row-${seed.tenantAId}`)).toBeVisible();
+    await expect(table.getByTestId(`tenant-row-${seed.tenantBId}`)).toBeVisible();
+
+    await page.getByTestId(`tenant-copy-${seed.tenantAId}`).click();
+    await expect.poll(async () => {
+      return page.evaluate(() => (window as typeof window & { __mockClipboard?: string }).__mockClipboard ?? null);
+    }).toBe(seed.tenantAId);
+
+    await page.getByTestId(`tenant-open-${seed.tenantBId}`).click();
+    const notifications = page.getByRole("region", { name: /Notifications/i });
+    await expect(notifications.getByRole("status").first()).toContainText("Tenant switched");
+    await expectActiveTenant(page, seed.tenantBId);
+
+    await page.getByTestId(`tenant-delete-${seed.tenantBId}`).click();
+    const confirmDialog = page.getByRole("alertdialog", { name: new RegExp(`Delete ${escapeRegExp(seed.tenantBName)}`) });
+    await expect(confirmDialog).toBeVisible();
+    await confirmDialog.getByTestId("tenant-delete-confirm").click();
+
+    await expect(page.getByRole("status").first()).toContainText("Tenant deleted");
+    await expect(table.getByTestId(`tenant-row-${seed.tenantBId}`)).toHaveCount(0);
+    await expectActiveTenant(page, seed.tenantAId);
+    await expectTenantCookie(page, seed.tenantAId);
+
+    const state = await page.evaluate(async (tenantId) => {
+      const response = await fetch("/admin/api/test/tenant-state", {
+        method: "POST",
+        credentials: "include",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ tenantId }),
+      });
+      if (!response.ok) {
+        throw new Error(`Failed to read tenant state: ${response.status}`);
+      }
+      return (await response.json()) as {
+        tenantExists: boolean;
+        counts: Record<string, number>;
+      };
+    }, seed.tenantBId);
+
+    expect(state.tenantExists).toBe(false);
+    Object.values(state.counts).forEach((value) => expect(value).toBe(0));
+  });
 });
 
-const seedTenantsWithClients = async (page: Page): Promise<SeedResponse> => {
-  return page.evaluate<SeedResponse>(async () => {
+const seedTenantsWithClients = async (page: Page, options: { adminEmail?: string } = {}): Promise<SeedResponse> => {
+  return page.evaluate<SeedResponse, { adminEmail?: string }>(async (payload) => {
     const response = await fetch("/admin/api/test/seed-tenants-clients", {
       method: "POST",
       credentials: "include",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(payload ?? {}),
     });
     if (!response.ok) {
       throw new Error(`Failed to seed tenants: ${response.status}`);
     }
     return (await response.json()) as SeedResponse;
-  });
+  }, options);
 };
 
 const switchTenant = async (page: Page, tenantId: string, tenantName: string) => {


### PR DESCRIPTION
## Summary
- add a Tenants admin page with copy/open/delete controls and confirmation guardrails
- add transactional tenant deletion plus cookie handling and membership fallbacks
- cover the new flow with vitest + e2e plus expose a tenant-state test route

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test
- PLAYWRIGHT_BROWSERS_PATH=0 pnpm test:e2e

Fixes #36