### PR TITLE
feat: configurable email verified modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,8 @@ updates). CI runs this script automatically before executing E2E specs.
   own subject-source selector (`entered` reuses the typed identifier, `generated_uuid` rotates a random UUID each
   session).
 - Username strategy returns `preferred_username` when `profile` is requested. Email strategy requires the `email` scope
-  and emits `email` + `email_verified=false`; it never exposes `preferred_username`.
+  and emits `email` + `email_verified` according to the configured mode (always true, always false, or QA-selected at
+  login). It never exposes `preferred_username`.
 - All subject decisions are stored on the session + authorization code so every token and `userinfo` response reflects
   the strategy that was used during login.
 

--- a/prisma/migrations/20260221110136_email_verified_mode/migration.sql
+++ b/prisma/migrations/20260221110136_email_verified_mode/migration.sql
@@ -1,0 +1,18 @@
+-- AlterTable
+ALTER TABLE "AuthorizationCode" ADD COLUMN     "emailVerifiedOverride" BOOLEAN;
+
+-- AlterTable
+ALTER TABLE "Client" ALTER COLUMN "authStrategies" SET DEFAULT '{"username":{"enabled":true,"subSource":"entered"},"email":{"enabled":false,"subSource":"entered","emailVerifiedMode":"false"}}';
+
+-- Backfill missing emailVerifiedMode on existing client auth strategies
+UPDATE "Client"
+SET "authStrategies" = jsonb_set(
+  COALESCE("authStrategies", '{}'::jsonb),
+  '{email,emailVerifiedMode}',
+  to_jsonb(COALESCE(("authStrategies"->'email'->>'emailVerifiedMode'), 'false')),
+  true
+)
+WHERE ("authStrategies"->'email'->>'emailVerifiedMode') IS NULL;
+
+-- AlterTable
+ALTER TABLE "MockSession" ADD COLUMN     "emailVerifiedOverride" BOOLEAN;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -142,7 +142,7 @@ model Client {
   allowedResponseTypes     String[]                 @default(["code"])
   pkceRequired             Boolean                  @default(true)
   tokenEndpointAuthMethod  TokenEndpointAuthMethod  @default(client_secret_basic)
-  authStrategies           Json                     @default("{\"username\":{\"enabled\":true,\"subSource\":\"entered\"},\"email\":{\"enabled\":false,\"subSource\":\"entered\"}}")
+  authStrategies           Json                     @default("{\"username\":{\"enabled\":true,\"subSource\":\"entered\"},\"email\":{\"enabled\":false,\"subSource\":\"entered\",\"emailVerifiedMode\":\"false\"}}")
   redirectUris             RedirectUri[]
   authorizationCodes       AuthorizationCode[]
   accessTokens             AccessToken[]
@@ -203,6 +203,7 @@ model MockSession {
   userId           String
   loginStrategy    LoginStrategy
   subject          String
+  emailVerifiedOverride Boolean?
   sessionTokenHash String   @unique
   expiresAt        DateTime
   createdAt        DateTime @default(now())
@@ -220,6 +221,7 @@ model AuthorizationCode {
   userId             String
   loginStrategy      LoginStrategy
   subject            String
+  emailVerifiedOverride Boolean?
   codeHash           String      @unique
   redirectUri        String
   scope              String

--- a/src/app/admin/actions.ts
+++ b/src/app/admin/actions.ts
@@ -85,11 +85,13 @@ const updateClientIssuerSchema = z.object({
   apiResourceId: z.union([z.literal("default"), z.string().min(1)]),
 });
 const subjectSourceSchema = z.enum(["entered", "generated_uuid"]);
+const emailVerifiedModeSchema = z.enum(["true", "false", "user_choice"]);
 const strategyConfigSchema = z.object({ enabled: z.boolean(), subSource: subjectSourceSchema });
+const emailStrategyConfigSchema = strategyConfigSchema.extend({ emailVerifiedMode: emailVerifiedModeSchema });
 const updateClientStrategiesSchema = z.object({
   clientId: z.string().min(1),
   username: strategyConfigSchema,
-  email: strategyConfigSchema,
+  email: emailStrategyConfigSchema,
 });
 
 const requireSession = async () => {

--- a/src/app/admin/clients/[clientId]/client-forms.tsx
+++ b/src/app/admin/clients/[clientId]/client-forms.tsx
@@ -47,8 +47,9 @@ const redirectSchema = z.object({
 });
 const issuerSchema = z.object({ resourceId: z.union([z.literal("default"), z.string().min(1)]) });
 const strategyConfigSchema = z.object({ enabled: z.boolean(), subSource: z.enum(["entered", "generated_uuid"]) });
+const emailStrategyConfigSchema = strategyConfigSchema.extend({ emailVerifiedMode: z.enum(["true", "false", "user_choice"]) });
 const authStrategiesSchema = z
-  .object({ username: strategyConfigSchema, email: strategyConfigSchema })
+  .object({ username: strategyConfigSchema, email: emailStrategyConfigSchema })
   .refine((value) => value.username.enabled || value.email.enabled, {
     message: "Enable at least one strategy",
     path: ["root"],
@@ -258,7 +259,7 @@ export function UpdateAuthStrategiesForm({
     resolver: zodResolver(authStrategiesSchema),
     defaultValues: initialStrategies,
   });
-  const watchedStrategies = useWatch({ control: form.control });
+  const watchedStrategies = useWatch({ control: form.control }) as z.infer<typeof authStrategiesSchema> | undefined;
 
   useEffect(() => {
     form.reset(initialStrategies);
@@ -284,66 +285,94 @@ export function UpdateAuthStrategiesForm({
         <div className="flex items-start justify-between gap-4">
           <div>
             <h4 className="text-sm font-semibold text-foreground">{strategyMetadata[key].title}</h4>
-          <p className="text-xs text-muted-foreground">{strategyMetadata[key].description}</p>
+            <p className="text-xs text-muted-foreground">{strategyMetadata[key].description}</p>
+          </div>
+          <FormField
+            control={form.control}
+            name={`${key}.enabled` as const}
+            render={({ field }) => (
+              <FormItem className="flex items-center gap-2">
+                <FormControl>
+                  <input
+                    type="checkbox"
+                    className="h-4 w-4 rounded border border-muted"
+                    checked={field.value}
+                    onChange={(event) => field.onChange(event.target.checked)}
+                    disabled={!canEdit || pending}
+                  />
+                </FormControl>
+                <FormLabel className="text-xs text-muted-foreground">Enabled</FormLabel>
+              </FormItem>
+            )}
+          />
         </div>
-        <FormField
-          control={form.control}
-          name={`${key}.enabled` as const}
-          render={({ field }) => (
-            <FormItem className="flex items-center gap-2">
-              <FormControl>
-                <input
-                  type="checkbox"
-                  className="h-4 w-4 rounded border border-muted"
-                  checked={field.value}
-                  onChange={(event) => field.onChange(event.target.checked)}
-                  disabled={!canEdit || pending}
-                />
-              </FormControl>
-              <FormLabel className="text-xs text-muted-foreground">Enabled</FormLabel>
-            </FormItem>
-          )}
-        />
-      </div>
         <div className="mt-4 grid gap-4 sm:grid-cols-2">
           <FormField
             control={form.control}
             name={`${key}.subSource` as const}
-          render={({ field }) => {
-            const subjectSourceLabel =
-              field.value === "generated_uuid"
-                ? "Generate UUID per session"
-                : field.value === "entered"
-                  ? "Use entered value"
-                  : "Select subject source";
-            return (
-              <FormItem>
-                <FormLabel>Subject source</FormLabel>
-                <Select
-                  value={field.value}
-                  defaultValue={field.value}
-                  onValueChange={field.onChange}
-                  disabled={!canEdit || pending || !isStrategyEnabled}
-                >
-                  <FormControl>
-                    <SelectTrigger data-testid={triggerTestId} aria-label={subjectSourceLabel}>
-                      <span className="truncate text-left">{subjectSourceLabel}</span>
-                    </SelectTrigger>
-                  </FormControl>
-                  <SelectContent>
-                    <SelectItem value="entered">Use entered value</SelectItem>
-                    <SelectItem value="generated_uuid">Generate UUID per session</SelectItem>
-                  </SelectContent>
-                </Select>
-                <FormMessage />
-              </FormItem>
-            );
-          }}
-        />
-      </div>
+            render={({ field }) => {
+              const subjectSourceLabel =
+                field.value === "generated_uuid"
+                  ? "Generate UUID per session"
+                  : field.value === "entered"
+                    ? "Use entered value"
+                    : "Select subject source";
+              return (
+                <FormItem>
+                  <FormLabel>Subject source</FormLabel>
+                  <Select
+                    value={field.value}
+                    defaultValue={field.value}
+                    onValueChange={field.onChange}
+                    disabled={!canEdit || pending || !isStrategyEnabled}
+                  >
+                    <FormControl>
+                      <SelectTrigger data-testid={triggerTestId} aria-label={subjectSourceLabel}>
+                        <span className="truncate text-left">{subjectSourceLabel}</span>
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectItem value="entered">Use entered value</SelectItem>
+                      <SelectItem value="generated_uuid">Generate UUID per session</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              );
+            }}
+          />
+          {key === "email" ? (
+            <FormField
+              control={form.control}
+              name={"email.emailVerifiedMode" as const}
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Email verified mode</FormLabel>
+                  <Select
+                    value={field.value}
+                    onValueChange={field.onChange}
+                    disabled={!canEdit || pending || !isStrategyEnabled}
+                  >
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select mode" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectItem value="true">Always verified</SelectItem>
+                      <SelectItem value="false">Always unverified</SelectItem>
+                      <SelectItem value="user_choice">Allow QA to choose</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          ) : null}
+        </div>
         <p className="mt-4 text-xs text-muted-foreground">
           {key === "email"
-            ? "Email strategy returns email claims gated by the email scope and marks email_verified=false."
+            ? "Email strategy returns email claims gated by the email scope and sets email_verified per the selected mode."
             : "Username strategy returns preferred_username gated by the profile scope."}
         </p>
       </div>

--- a/src/app/admin/clients/__tests__/update-client-auth-strategies-form.test.tsx
+++ b/src/app/admin/clients/__tests__/update-client-auth-strategies-form.test.tsx
@@ -117,7 +117,7 @@ vi.mock("@/components/ui/select", async () => {
 
 const defaultStrategies: ClientAuthStrategies = {
   username: { enabled: true, subSource: "entered" },
-  email: { enabled: false, subSource: "entered" },
+  email: { enabled: false, subSource: "entered", emailVerifiedMode: "false" },
 };
 
 const renderForm = (overrides?: Partial<ClientAuthStrategies>) => {
@@ -156,7 +156,7 @@ describe("UpdateClientAuthStrategiesForm", () => {
         canEdit
         initialStrategies={{
           username: { enabled: true, subSource: "generated_uuid" },
-          email: { enabled: false, subSource: "entered" },
+          email: { enabled: false, subSource: "entered", emailVerifiedMode: "false" },
         }}
       />,
     );
@@ -178,7 +178,7 @@ describe("UpdateClientAuthStrategiesForm", () => {
       expect(mockUpdateClientAuthStrategiesAction).toHaveBeenCalledWith({
         clientId: "client_123",
         username: { enabled: true, subSource: "generated_uuid" },
-        email: { enabled: false, subSource: "entered" },
+        email: { enabled: false, subSource: "entered", emailVerifiedMode: "false" },
       });
     });
   });

--- a/src/app/t/[tenantId]/r/[apiResourceId]/oidc/login/login-form.tsx
+++ b/src/app/t/[tenantId]/r/[apiResourceId]/oidc/login/login-form.tsx
@@ -2,12 +2,15 @@
 
 import { useState } from "react";
 
+import type { EmailVerifiedMode } from "@/server/oidc/auth-strategy";
+
 type StrategyOption = {
   key: "username" | "email";
   title: string;
   description: string;
   placeholder: string;
   subSource: string;
+  emailVerifiedMode?: EmailVerifiedMode;
 };
 
 type LoginFormProps = {
@@ -19,6 +22,7 @@ type LoginFormProps = {
 
 export function LoginForm({ tenantId, apiResourceId, returnTo, strategies }: LoginFormProps) {
   const [selectedStrategy, setSelectedStrategy] = useState<"username" | "email">(strategies[0]?.key ?? "username");
+  const [emailVerifiedPreference, setEmailVerifiedPreference] = useState<"true" | "false">("true");
 
   return (
     <form method="POST" action={`/t/${tenantId}/r/${apiResourceId}/oidc/login/submit`} className="space-y-4">
@@ -74,6 +78,38 @@ export function LoginForm({ tenantId, apiResourceId, returnTo, strategies }: Log
               className="w-full rounded-lg border border-slate-700 bg-slate-950/40 px-3 py-2 text-base focus:outline-none focus:ring-2 focus:ring-amber-400 disabled:cursor-not-allowed disabled:opacity-70"
               placeholder={option.placeholder}
             />
+            {option.key === "email" && option.emailVerifiedMode === "user_choice" ? (
+              <fieldset className="space-y-2" disabled={!isActive}>
+                <legend className="text-xs font-semibold uppercase text-slate-400">Email verified flag</legend>
+                <div className="grid gap-2 sm:grid-cols-2">
+                  <label className="flex items-center gap-2 text-xs text-slate-200">
+                    <input
+                      type="radio"
+                      name="email_verified_preference"
+                      value="true"
+                      checked={emailVerifiedPreference === "true"}
+                      onChange={() => setEmailVerifiedPreference("true")}
+                      disabled={!isActive}
+                      className="h-4 w-4"
+                    />
+                    Verified
+                  </label>
+                  <label className="flex items-center gap-2 text-xs text-slate-200">
+                    <input
+                      type="radio"
+                      name="email_verified_preference"
+                      value="false"
+                      checked={emailVerifiedPreference === "false"}
+                      onChange={() => setEmailVerifiedPreference("false")}
+                      disabled={!isActive}
+                      className="h-4 w-4"
+                    />
+                    Unverified
+                  </label>
+                </div>
+                <p className="text-[0.7rem] text-slate-400">Choose how the email_verified claim should appear for this login.</p>
+              </fieldset>
+            ) : null}
           </label>
         );
       })}

--- a/src/app/t/[tenantId]/r/[apiResourceId]/oidc/login/page.tsx
+++ b/src/app/t/[tenantId]/r/[apiResourceId]/oidc/login/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 
 import { LoginForm } from "@/app/t/[tenantId]/r/[apiResourceId]/oidc/login/login-form";
 import { DEFAULT_CLIENT_AUTH_STRATEGIES, parseClientAuthStrategies } from "@/server/oidc/auth-strategy";
+import type { ClientAuthStrategies } from "@/server/oidc/auth-strategy";
 import { getClientForTenant } from "@/server/services/client-service";
 import { getActiveTenantById } from "@/server/services/tenant-service";
 
@@ -28,7 +29,10 @@ export default async function TenantLoginPage({ params, searchParams }: LoginPag
     strategyConfig = DEFAULT_CLIENT_AUTH_STRATEGIES;
   }
 
-  const enabledStrategies = (Object.entries(strategyConfig) as ["username" | "email", (typeof strategyConfig)["username"]][])
+  const enabledStrategies = (Object.entries(strategyConfig) as [
+    keyof ClientAuthStrategies,
+    ClientAuthStrategies[keyof ClientAuthStrategies],
+  ][])
     .filter(([, cfg]) => cfg.enabled)
     .map(([key, cfg]) => ({
       key,
@@ -39,16 +43,20 @@ export default async function TenantLoginPage({ params, searchParams }: LoginPag
     enabledStrategies.push({ key: "username", cfg: DEFAULT_CLIENT_AUTH_STRATEGIES.username });
   }
 
-  const strategies = enabledStrategies.map(({ key, cfg }) => ({
-    key,
-    title: key === "username" ? "Username" : "Email",
-    description:
-      key === "username"
-        ? "Enter any username to simulate an end-user."
-        : "Enter any email to simulate an email-based login.",
-    placeholder: key === "username" ? "qa-user" : "qa-user@example.test",
-    subSource: cfg.subSource,
-  }));
+  const strategies = enabledStrategies.map(({ key, cfg }) => {
+    const isEmail = key === "email";
+    const emailConfig = isEmail ? (cfg as ClientAuthStrategies["email"]) : null;
+    return {
+      key,
+      title: isEmail ? "Email" : "Username",
+      description: isEmail
+        ? "Enter any email to simulate an email-based login."
+        : "Enter any username to simulate an end-user.",
+      placeholder: isEmail ? "qa-user@example.test" : "qa-user",
+      subSource: cfg.subSource,
+      emailVerifiedMode: emailConfig?.emailVerifiedMode,
+    };
+  });
   const strategySummary = strategies.map((strategy) => strategy.title.toLowerCase()).join(" or ");
 
   return (

--- a/src/app/t/[tenantId]/r/[apiResourceId]/oidc/login/submit/route.ts
+++ b/src/app/t/[tenantId]/r/[apiResourceId]/oidc/login/submit/route.ts
@@ -16,12 +16,14 @@ import {
   parseClientAuthStrategies,
   toPrismaLoginStrategy,
 } from "@/server/oidc/auth-strategy";
+import type { ClientAuthStrategies } from "@/server/oidc/auth-strategy";
 
 const loginSchema = z.object({
   strategy: z.enum(["username", "email"]).default("username"),
   username: z.string().optional(),
   email: z.string().email().optional(),
   return_to: z.string().optional(),
+  email_verified_preference: z.enum(["true", "false"]).optional(),
 });
 
 const sanitizeReturnTo = (value: string | undefined, fallback: URL, currentUrl: URL) => {
@@ -50,6 +52,7 @@ export async function POST(request: NextRequest, context: TenantResourceRouteCon
     username: form.get("username")?.toString(),
     email: form.get("email")?.toString(),
     return_to: form.get("return_to")?.toString(),
+    email_verified_preference: form.get("email_verified_preference")?.toString(),
   });
 
   if (!data.success) {
@@ -82,6 +85,16 @@ export async function POST(request: NextRequest, context: TenantResourceRouteCon
 
     const normalizedIdentifier =
       data.data.strategy === "email" ? trimmedIdentifier.toLowerCase() : trimmedIdentifier;
+    let emailVerifiedOverride: boolean | undefined;
+    if (data.data.strategy === "email") {
+      const emailConfig = selectedConfig as ClientAuthStrategies["email"];
+      if (emailConfig.emailVerifiedMode === "user_choice") {
+        if (!data.data.email_verified_preference) {
+          return Response.json({ error: "missing_email_verified_choice" }, { status: 400 });
+        }
+        emailVerifiedOverride = data.data.email_verified_preference === "true";
+      }
+    }
     const subject = selectedConfig.subSource === "entered" ? trimmedIdentifier : randomUUID();
     const user = await findOrCreateMockUser(tenant.id, normalizedIdentifier, {
       displayName: trimmedIdentifier,
@@ -90,6 +103,7 @@ export async function POST(request: NextRequest, context: TenantResourceRouteCon
     const token = await createSession(tenant.id, user.id, {
       strategy: toPrismaLoginStrategy(data.data.strategy),
       subject,
+      emailVerifiedOverride,
     });
     const fallback = new URL(`/t/${tenant.id}/r/${apiResourceId}/oidc/authorize`, currentUrl.origin);
     const redirectUrl = sanitizeReturnTo(data.data.return_to, fallback, currentUrl);

--- a/src/server/oidc/__tests__/oidc-flow.test.ts
+++ b/src/server/oidc/__tests__/oidc-flow.test.ts
@@ -229,4 +229,108 @@ describe("OIDC flow", () => {
     expect(userinfo.sub).toBe(subject);
     await clearSession(tenantId, sessionTokenOverride);
   });
+
+  it("issues email_verified=true when configured", async () => {
+    await prisma.client.update({
+      where: { id: clientInternalId },
+      data: {
+        authStrategies: {
+          username: { enabled: false, subSource: "entered" },
+          email: { enabled: true, subSource: "entered", emailVerifiedMode: "true" },
+        },
+      },
+    });
+    const user = await prisma.mockUser.upsert({
+      where: { tenantId_username: { tenantId, username: "email-verified" } },
+      update: { email: "email-verified@example.test", displayName: "Email Verified" },
+      create: { tenantId, username: "email-verified", email: "email-verified@example.test", displayName: "Email Verified" },
+    });
+    const verifiedSession = await createSession(tenantId, user.id, {
+      strategy: $Enums.LoginStrategy.EMAIL,
+      subject: "email-verified@example.test",
+    });
+    const authorize = await handleAuthorize(
+      {
+        tenantId,
+        apiResourceId,
+        clientId: "qa-client",
+        redirectUri: "https://client.example.test/callback",
+        responseType: "code",
+        scope: "openid email",
+        state: "email-verified",
+        codeChallenge: computeS256Challenge(codeVerifier),
+        codeChallengeMethod: "S256",
+        sessionToken: verifiedSession,
+      },
+      "https://mockauth.test",
+      `https://mockauth.test/t/${DEFAULT_TENANT_ID}/r/${apiResourceId}/oidc/authorize?client_id=qa-client`,
+    );
+    const code = new URL(authorize.redirectTo).searchParams.get("code");
+    const consumed = await consumeAuthorizationCode(code!);
+    const tokens = await issueTokensFromCode({
+      code: consumed,
+      codeVerifier,
+      redirectUri: "https://client.example.test/callback",
+      origin: "https://mockauth.test",
+      clientSecret: "qa-secret",
+    });
+    const idToken = decodeJwt(tokens.id_token);
+    expect(idToken.email_verified).toBe(true);
+    await clearSession(tenantId, verifiedSession);
+  });
+
+  it("respects user choice for email_verified", async () => {
+    await prisma.client.update({
+      where: { id: clientInternalId },
+      data: {
+        authStrategies: {
+          username: { enabled: false, subSource: "entered" },
+          email: { enabled: true, subSource: "entered", emailVerifiedMode: "user_choice" },
+        },
+      },
+    });
+    const user = await prisma.mockUser.upsert({
+      where: { tenantId_username: { tenantId, username: "email-choice" } },
+      update: { email: "email-choice@example.test", displayName: "Email Choice" },
+      create: { tenantId, username: "email-choice", email: "email-choice@example.test", displayName: "Email Choice" },
+    });
+
+    const authorizeFlow = async (override: boolean) => {
+      const sessionTokenChoice = await createSession(tenantId, user.id, {
+        strategy: $Enums.LoginStrategy.EMAIL,
+        subject: "email-choice@example.test",
+        emailVerifiedOverride: override,
+      });
+      const authorize = await handleAuthorize(
+        {
+          tenantId,
+          apiResourceId,
+          clientId: "qa-client",
+          redirectUri: "https://client.example.test/callback",
+          responseType: "code",
+          scope: "openid email",
+          state: override ? "choice-true" : "choice-false",
+          codeChallenge: computeS256Challenge(codeVerifier),
+          codeChallengeMethod: "S256",
+          sessionToken: sessionTokenChoice,
+        },
+        "https://mockauth.test",
+        `https://mockauth.test/t/${DEFAULT_TENANT_ID}/r/${apiResourceId}/oidc/authorize?client_id=qa-client`,
+      );
+      const code = new URL(authorize.redirectTo).searchParams.get("code");
+      const consumed = await consumeAuthorizationCode(code!);
+      const tokens = await issueTokensFromCode({
+        code: consumed,
+        codeVerifier,
+        redirectUri: "https://client.example.test/callback",
+        origin: "https://mockauth.test",
+        clientSecret: "qa-secret",
+      });
+      await clearSession(tenantId, sessionTokenChoice);
+      return decodeJwt(tokens.id_token).email_verified;
+    };
+
+    await expect(authorizeFlow(true)).resolves.toBe(true);
+    await expect(authorizeFlow(false)).resolves.toBe(false);
+  });
 });

--- a/src/server/oidc/auth-strategy.ts
+++ b/src/server/oidc/auth-strategy.ts
@@ -2,32 +2,58 @@ import { $Enums } from "@/generated/prisma/client";
 
 export type ClientAuthStrategy = "username" | "email";
 export type SubjectSource = "entered" | "generated_uuid";
+export const SUBJECT_SOURCE_OPTIONS: SubjectSource[] = ["entered", "generated_uuid"];
 
-export type StrategyConfig = {
+export const EMAIL_VERIFIED_MODES = ["true", "false", "user_choice"] as const;
+export type EmailVerifiedMode = (typeof EMAIL_VERIFIED_MODES)[number];
+
+type StrategyConfigBase = {
   enabled: boolean;
   subSource: SubjectSource;
 };
 
-export type ClientAuthStrategies = Record<ClientAuthStrategy, StrategyConfig>;
+export type UsernameStrategyConfig = StrategyConfigBase;
+export type EmailStrategyConfig = StrategyConfigBase & { emailVerifiedMode: EmailVerifiedMode };
 
-export const SUBJECT_SOURCE_OPTIONS: SubjectSource[] = ["entered", "generated_uuid"];
+export type ClientAuthStrategies = {
+  username: UsernameStrategyConfig;
+  email: EmailStrategyConfig;
+};
 
 export const DEFAULT_CLIENT_AUTH_STRATEGIES: ClientAuthStrategies = {
   username: { enabled: true, subSource: "entered" },
-  email: { enabled: false, subSource: "entered" },
+  email: { enabled: false, subSource: "entered", emailVerifiedMode: "false" },
 };
 
 const isSubjectSource = (value: unknown): value is SubjectSource => SUBJECT_SOURCE_OPTIONS.includes(value as SubjectSource);
+const isEmailVerifiedMode = (value: unknown): value is EmailVerifiedMode =>
+  EMAIL_VERIFIED_MODES.includes(value as EmailVerifiedMode);
 
-const normalizeConfig = (value: unknown, fallback: StrategyConfig): StrategyConfig => {
+const normalizeConfigBase = (value: unknown, fallback: StrategyConfigBase): StrategyConfigBase => {
   if (!value || typeof value !== "object") {
     return fallback;
   }
-  const candidate = value as Partial<StrategyConfig>;
+  const candidate = value as Partial<StrategyConfigBase>;
   return {
     enabled: typeof candidate.enabled === "boolean" ? candidate.enabled : fallback.enabled,
     subSource: isSubjectSource(candidate.subSource) ? candidate.subSource : fallback.subSource,
   };
+};
+
+const normalizeUsernameConfig = (
+  value: unknown,
+  fallback: UsernameStrategyConfig,
+): UsernameStrategyConfig => ({
+  ...normalizeConfigBase(value, fallback),
+});
+
+const normalizeEmailConfig = (value: unknown, fallback: EmailStrategyConfig): EmailStrategyConfig => {
+  const base = normalizeConfigBase(value, fallback);
+  const candidate = value && typeof value === "object" ? (value as Partial<EmailStrategyConfig>) : {};
+  const emailVerifiedMode = isEmailVerifiedMode(candidate.emailVerifiedMode)
+    ? candidate.emailVerifiedMode
+    : fallback.emailVerifiedMode;
+  return { ...base, emailVerifiedMode };
 };
 
 export const parseClientAuthStrategies = (value: unknown): ClientAuthStrategies => {
@@ -36,8 +62,8 @@ export const parseClientAuthStrategies = (value: unknown): ClientAuthStrategies 
   }
   const candidate = value as Partial<ClientAuthStrategies>;
   return {
-    username: normalizeConfig(candidate.username, DEFAULT_CLIENT_AUTH_STRATEGIES.username),
-    email: normalizeConfig(candidate.email, DEFAULT_CLIENT_AUTH_STRATEGIES.email),
+    username: normalizeUsernameConfig(candidate.username, DEFAULT_CLIENT_AUTH_STRATEGIES.username),
+    email: normalizeEmailConfig(candidate.email, DEFAULT_CLIENT_AUTH_STRATEGIES.email),
   };
 };
 

--- a/src/server/oidc/claims.ts
+++ b/src/server/oidc/claims.ts
@@ -1,7 +1,12 @@
 import type { MockUser } from "@/generated/prisma/client";
 import type { ClientAuthStrategy } from "@/server/oidc/auth-strategy";
 
-export const claimsForScopes = (user: MockUser, scopes: string[], strategy: ClientAuthStrategy) => {
+export const claimsForScopes = (
+  user: MockUser,
+  scopes: string[],
+  strategy: ClientAuthStrategy,
+  options?: { emailVerified?: boolean },
+) => {
   const claims: Record<string, unknown> = {};
   if (scopes.includes("profile")) {
     claims.name = user.displayName ?? user.username;
@@ -12,7 +17,7 @@ export const claimsForScopes = (user: MockUser, scopes: string[], strategy: Clie
 
   if (strategy === "email" && scopes.includes("email") && user.email) {
     claims.email = user.email;
-    claims.email_verified = false;
+    claims.email_verified = options?.emailVerified ?? false;
   }
 
   return claims;

--- a/src/server/services/authorization-code-service.ts
+++ b/src/server/services/authorization-code-service.ts
@@ -15,6 +15,7 @@ export const createAuthorizationCode = async (params: {
   userId: string;
   loginStrategy: $Enums.LoginStrategy;
   subject: string;
+  emailVerifiedOverride?: boolean;
   redirectUri: string;
   scope: string;
   nonce?: string;
@@ -31,6 +32,7 @@ export const createAuthorizationCode = async (params: {
       userId: params.userId,
       loginStrategy: params.loginStrategy,
       subject: params.subject,
+      emailVerifiedOverride: params.emailVerifiedOverride ?? null,
       redirectUri: params.redirectUri,
       scope: params.scope,
       nonce: params.nonce,

--- a/src/server/services/authorize-service.ts
+++ b/src/server/services/authorize-service.ts
@@ -74,6 +74,7 @@ export const handleAuthorize = async (params: AuthorizeParams, origin: string, r
     userId: session.userId,
     loginStrategy: session.loginStrategy,
     subject: session.subject,
+    emailVerifiedOverride: session.emailVerifiedOverride ?? undefined,
     redirectUri: redirect,
     scope: params.scope,
     nonce: params.nonce,

--- a/src/server/services/mock-session-service.ts
+++ b/src/server/services/mock-session-service.ts
@@ -11,7 +11,7 @@ export const MOCK_SESSION_COOKIE = "mockauth_enduser_session";
 export const createSession = async (
   tenantId: string,
   userId: string,
-  data: { strategy: $Enums.LoginStrategy; subject: string },
+  data: { strategy: $Enums.LoginStrategy; subject: string; emailVerifiedOverride?: boolean },
 ) => {
   const token = generateOpaqueToken();
   await prisma.mockSession.create({
@@ -20,6 +20,7 @@ export const createSession = async (
       userId,
       loginStrategy: data.strategy,
       subject: data.subject,
+      emailVerifiedOverride: data.emailVerifiedOverride ?? null,
       sessionTokenHash: hashOpaqueToken(token),
       expiresAt: addHours(new Date(), SESSION_TTL_HOURS),
     },

--- a/src/server/services/token-service.ts
+++ b/src/server/services/token-service.ts
@@ -12,7 +12,7 @@ import { claimsForScopes } from "@/server/oidc/claims";
 import { issuerForResource } from "@/server/oidc/issuer";
 import { resolveRedirectUri } from "@/server/oidc/redirect-uri";
 import { getActiveKey } from "@/server/services/key-service";
-import { fromPrismaLoginStrategy } from "@/server/oidc/auth-strategy";
+import { fromPrismaLoginStrategy, parseClientAuthStrategies } from "@/server/oidc/auth-strategy";
 
 const ID_TOKEN_TTL_SECONDS = 600;
 const ACCESS_TOKEN_TTL_SECONDS = 3600;
@@ -74,8 +74,15 @@ export const issueTokensFromCode = async (params: {
   const issuer = issuerForResource(origin, code.tenantId, code.apiResourceId);
   const scopes = code.scope.split(" ").filter(Boolean);
   const strategy = fromPrismaLoginStrategy(code.loginStrategy);
+  const strategies = parseClientAuthStrategies(code.client.authStrategies);
+  const emailVerifiedClaim =
+    strategy === "email"
+      ? strategies.email.emailVerifiedMode === "user_choice"
+        ? Boolean(code.emailVerifiedOverride)
+        : strategies.email.emailVerifiedMode === "true"
+      : undefined;
   const idToken = await new SignJWT({
-    ...claimsForScopes(code.user, scopes, strategy),
+    ...claimsForScopes(code.user, scopes, strategy, { emailVerified: emailVerifiedClaim }),
     sub: code.subject,
     aud: code.client.clientId,
     iss: issuer,
@@ -89,7 +96,7 @@ export const issueTokensFromCode = async (params: {
 
   const jti = randomUUID();
   const accessToken = await new SignJWT({
-    ...claimsForScopes(code.user, scopes, strategy),
+    ...claimsForScopes(code.user, scopes, strategy, { emailVerified: emailVerifiedClaim }),
     sub: code.subject,
     aud: code.client.clientId,
     iss: issuer,

--- a/tests/e2e/oidc.spec.ts
+++ b/tests/e2e/oidc.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, type APIRequestContext } from "@playwright/test";
+import { decodeJwt } from "jose";
 import {
   allowInsecureRequests,
   authorizationCodeGrant,
@@ -181,6 +182,63 @@ test("requires login when session strategy disallows client", async ({ request }
   expect(authorizeUsernameClient.headers.get("location")).toContain("/login");
 });
 
+test("email strategy mode false returns unverified claims", async ({ request }) => {
+  const { tenantId, resourceId } = await seedTenantClients(request);
+  const [clientId] = await createClients(request, tenantId);
+  await setClientStrategies(request, tenantId, clientId, {
+    username: { enabled: false, subSource: "entered" },
+    email: { enabled: true, subSource: "entered", emailVerifiedMode: "false" },
+  });
+  const idToken = await runEmailFlow({
+    tenantId,
+    resourceId,
+    clientId,
+    email: "mode-false@example.test",
+  });
+  expect(idToken.email_verified).toBe(false);
+});
+
+test("email strategy mode true returns verified claims", async ({ request }) => {
+  const { tenantId, resourceId } = await seedTenantClients(request);
+  const [clientId] = await createClients(request, tenantId);
+  await setClientStrategies(request, tenantId, clientId, {
+    username: { enabled: false, subSource: "entered" },
+    email: { enabled: true, subSource: "entered", emailVerifiedMode: "true" },
+  });
+  const idToken = await runEmailFlow({
+    tenantId,
+    resourceId,
+    clientId,
+    email: "mode-true@example.test",
+  });
+  expect(idToken.email_verified).toBe(true);
+});
+
+test("email strategy user choice honors selection", async ({ request }) => {
+  const { tenantId, resourceId } = await seedTenantClients(request);
+  const [clientId] = await createClients(request, tenantId);
+  await setClientStrategies(request, tenantId, clientId, {
+    username: { enabled: false, subSource: "entered" },
+    email: { enabled: true, subSource: "entered", emailVerifiedMode: "user_choice" },
+  });
+  const verifiedToken = await runEmailFlow({
+    tenantId,
+    resourceId,
+    clientId,
+    email: "choice@example.test",
+    emailVerifiedPreference: "true",
+  });
+  expect(verifiedToken.email_verified).toBe(true);
+  const unverifiedToken = await runEmailFlow({
+    tenantId,
+    resourceId,
+    clientId,
+    email: "choice@example.test",
+    emailVerifiedPreference: "false",
+  });
+  expect(unverifiedToken.email_verified).toBe(false);
+});
+
 const withSessionCookies = (jar: ReturnType<typeof cookieJar>) => {
   const header = jar.header();
   return header ? { cookie: header } : undefined;
@@ -216,7 +274,7 @@ const setClientStrategies = async (
   clientId: string,
   strategies: {
     username: { enabled: boolean; subSource: "entered" | "generated_uuid" };
-    email: { enabled: boolean; subSource: "entered" | "generated_uuid" };
+    email: { enabled: boolean; subSource: "entered" | "generated_uuid"; emailVerifiedMode?: "true" | "false" | "user_choice" };
   },
 ) => {
   const response = await request.post("/api/test/client-auth-strategies", {
@@ -247,4 +305,74 @@ const buildAuthorizeUrl = (
   url.searchParams.set("code_challenge", codeChallenge);
   url.searchParams.set("code_challenge_method", "S256");
   return url.toString();
+};
+
+const runEmailFlow = async ({
+  tenantId,
+  resourceId,
+  clientId,
+  email,
+  emailVerifiedPreference,
+}: {
+  tenantId: string;
+  resourceId: string;
+  clientId: string;
+  email: string;
+  emailVerifiedPreference?: "true" | "false";
+}) => {
+  const jar = cookieJar();
+  const codeVerifier = randomPKCECodeVerifier();
+  const codeChallenge = await calculatePKCECodeChallenge(codeVerifier);
+  const state = randomState();
+  const nonce = randomNonce();
+  const authorizeUrl = buildAuthorizeUrl(tenantId, resourceId, clientId, codeChallenge, state, nonce);
+  const authorizeResponse = await fetch(authorizeUrl, { redirect: "manual", headers: withSessionCookies(jar) });
+  jar.addFrom(authorizeResponse);
+  expect(authorizeResponse.status).toBe(302);
+  const loginLocation = authorizeResponse.headers.get("location");
+  expect(loginLocation).toBeTruthy();
+  const loginUrl = new URL(loginLocation!, "http://127.0.0.1:3000");
+  loginUrl.pathname = loginUrl.pathname.replace(/\/oidc\/login$/, "/oidc/login/submit");
+  const headers: Record<string, string> = { "content-type": "application/x-www-form-urlencoded" };
+  const cookieHeader = jar.header();
+  if (cookieHeader) {
+    headers.cookie = cookieHeader;
+  }
+  const loginBody = new URLSearchParams({ strategy: "email", email, return_to: authorizeUrl });
+  if (emailVerifiedPreference) {
+    loginBody.set("email_verified_preference", emailVerifiedPreference);
+  }
+  const loginResponse = await fetch(loginUrl, {
+    method: "POST",
+    redirect: "manual",
+    headers,
+    body: loginBody.toString(),
+  });
+  jar.addFrom(loginResponse);
+  expect(loginResponse.status).toBe(303);
+  const authorizeAfterLogin = await fetch(loginResponse.headers.get("location")!, {
+    redirect: "manual",
+    headers: withSessionCookies(jar),
+  });
+  expect(authorizeAfterLogin.status).toBe(302);
+  const finalLocation = authorizeAfterLogin.headers.get("location");
+  expect(finalLocation).toContain("code=");
+  const callbackUrl = new URL(finalLocation!);
+  const code = callbackUrl.searchParams.get("code");
+  expect(code).toBeTruthy();
+  const tokenResponse = await fetch(`http://127.0.0.1:3000/t/${tenantId}/r/${resourceId}/oidc/token`, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "authorization_code",
+      code: code!,
+      redirect_uri: redirectUri,
+      code_verifier: codeVerifier,
+      client_id: clientId,
+    }).toString(),
+  });
+  expect(tokenResponse.ok).toBeTruthy();
+  const payload = (await tokenResponse.json()) as { id_token: string };
+  expect(payload.id_token).toBeTruthy();
+  return decodeJwt(payload.id_token);
 };


### PR DESCRIPTION
## Summary
- add Email verified mode to client auth strategy config with admin UI controls and login toggle for QA
- persist per-login email_verified overrides through sessions, authorization codes, and token issuance/userinfo responses
- cover parsing/unit logic plus Playwright flows for each mode (true, false, user choice)
- rebased onto main (575c01e) on 2026-03-09 and revalidated admin client forms + OIDC flow specs

## Testing
- ✅ 2026-03-09 pnpm lint
- ✅ 2026-03-09 pnpm typecheck
- ✅ 2026-03-09 pnpm test
- ✅ 2026-03-09 pnpm test:e2e

Resolves #44