### PR TITLE
fix: truncate tenant id in collapsed sidebar

### DIFF
--- a/src/app/admin/_components/tenant-controls.tsx
+++ b/src/app/admin/_components/tenant-controls.tsx
@@ -14,6 +14,7 @@ import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "
 import { Input } from "@/components/ui/input";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { useToast } from "@/components/ui/use-toast";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 
 type TenantOption = {
@@ -75,9 +76,33 @@ export function TenantSwitcher({
     });
   };
 
+  const renderTenantId = () => {
+    if (!activeTenant) {
+      return null;
+    }
+    const truncated = activeTenant.id.slice(0, 8);
+    const idNode = (
+      <span className="font-mono text-xs text-muted-foreground" data-testid="tenant-switcher-id">
+        {truncated}
+      </span>
+    );
+    if (activeTenant.id.length <= 8) {
+      return idNode;
+    }
+    return (
+      <Tooltip delayDuration={150}>
+        <TooltipTrigger asChild>{idNode}</TooltipTrigger>
+        <TooltipContent side="top">
+          <p className="font-mono text-xs">{activeTenant.id}</p>
+        </TooltipContent>
+      </Tooltip>
+    );
+  };
+
   return (
-    <div className="space-y-2">
-      <Popover open={open} onOpenChange={setOpen}>
+    <TooltipProvider>
+      <div className="space-y-2">
+        <Popover open={open} onOpenChange={setOpen}>
         <PopoverTrigger asChild>
           <Button
             type="button"
@@ -92,7 +117,7 @@ export function TenantSwitcher({
               <span className="font-semibold">
                 {activeTenant ? activeTenant.name : tenants.length === 0 ? "No tenants" : "Select tenant"}
               </span>
-              {activeTenant ? <span className="text-xs text-muted-foreground">{activeTenant.id}</span> : null}
+              {renderTenantId()}
             </div>
             {pending ? (
               <Loader2 className="ml-2 h-4 w-4 shrink-0 animate-spin" />
@@ -168,7 +193,8 @@ export function TenantSwitcher({
           </div>
         </PopoverContent>
       </Popover>
-    </div>
+      </div>
+    </TooltipProvider>
   );
 }
 

--- a/tests/e2e/tenants-switch.spec.ts
+++ b/tests/e2e/tenants-switch.spec.ts
@@ -138,6 +138,8 @@ const switchTenant = async (page: Page, tenantId: string, tenantName: string) =>
   const notifications = page.getByRole("region", { name: /Notifications/i });
   await expect(notifications.getByRole("status").first()).toContainText("Active tenant updated");
   await expect(page.getByText(`Tenant · ${tenantName}`)).toBeVisible();
+  const truncatedId = tenantId.slice(0, 8);
+  await expect(page.locator('[data-testid="tenant-switcher-id"]:visible')).toHaveText(truncatedId);
 };
 
 const expectClientsVisible = async (page: Page, clientNames: string[]) => {


### PR DESCRIPTION
## Summary
- shorten the active tenant ID preview in the sidebar switcher to the first 8 characters and show the full value in a tooltip
- keep the dropdown listings unchanged while tagging the visible ID for tests and future hooks
- expand the tenant switching e2e helper to assert the truncated prefix so regressions are caught automatically

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm test:e2e

Resolves #45