### PR TITLE
fix: stabilize auth strategy selects

### DIFF
--- a/src/app/admin/clients/[clientId]/client-forms.tsx
+++ b/src/app/admin/clients/[clientId]/client-forms.tsx
@@ -24,6 +24,7 @@ import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import type { ClientAuthStrategies } from "@/server/oidc/auth-strategy";
+import { cn } from "@/lib/utils";
 
 const nameSchema = z.object({ name: z.string().min(2, "Name must be at least 2 characters") });
 const redirectSchema = z.object({
@@ -243,6 +244,17 @@ const strategyMetadata: Record<keyof ClientAuthStrategies, { title: string; desc
   },
 };
 
+const SUBJECT_SOURCE_LABELS: Record<"entered" | "generated_uuid", string> = {
+  entered: "Use entered value",
+  generated_uuid: "Generate UUID per session",
+};
+
+const EMAIL_VERIFIED_LABELS: Record<"true" | "false" | "user_choice", string> = {
+  true: "Always verified",
+  false: "Always unverified",
+  user_choice: "Allow QA to choose",
+};
+
 export function UpdateAuthStrategiesForm({
   clientId,
   canEdit,
@@ -311,50 +323,91 @@ export function UpdateAuthStrategiesForm({
           />
         </div>
         <div className="mt-4 grid gap-4 sm:grid-cols-2">
-         <FormField
+          <FormField
             control={form.control}
             name={`${key}.subSource` as const}
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Subject source</FormLabel>
-                <FormControl>
-                  <select
-                    className="flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+            render={({ field }) => {
+              const selectDisabled = !canEdit || pending || !isStrategyEnabled;
+              const handleChange = (nextValue: string) => {
+                if (!nextValue) {
+                  return;
+                }
+                field.onChange(nextValue);
+              };
+              return (
+                <FormItem>
+                  <FormLabel htmlFor={triggerTestId}>Subject source</FormLabel>
+                  <Select
                     value={field.value}
-                    onChange={(event) => field.onChange(event.target.value)}
-                    disabled={!canEdit || pending || !isStrategyEnabled}
-                    data-testid={triggerTestId}
+                    defaultValue={field.value}
+                    onValueChange={handleChange}
+                    disabled={selectDisabled}
                   >
-                    <option value="entered">Use entered value</option>
-                    <option value="generated_uuid">Generate UUID per session</option>
-                  </select>
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
+                    <FormControl>
+                      <SelectTrigger
+                        id={triggerTestId}
+                        data-testid={triggerTestId}
+                        aria-label={`${strategyMetadata[key].title} subject source`}
+                        disabled={selectDisabled}
+                      >
+                        <span className={cn("truncate", !field.value && "text-muted-foreground")}>
+                          {field.value ? SUBJECT_SOURCE_LABELS[field.value] : "Select subject source"}
+                        </span>
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectItem value="entered">Use entered value</SelectItem>
+                      <SelectItem value="generated_uuid">Generate UUID per session</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              );
+            }}
           />
           {key === "email" ? (
             <FormField
               control={form.control}
               name={"email.emailVerifiedMode" as const}
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Email verified mode</FormLabel>
-                  <FormControl>
-                    <select
-                      className="flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+              render={({ field }) => {
+                const selectDisabled = !canEdit || pending || !isStrategyEnabled;
+                const handleChange = (nextValue: string) => {
+                  if (!nextValue) {
+                    return;
+                  }
+                  field.onChange(nextValue);
+                };
+                return (
+                  <FormItem>
+                    <FormLabel htmlFor="strategy-email-verified-mode">Email verified mode</FormLabel>
+                    <Select
                       value={field.value}
-                      onChange={(event) => field.onChange(event.target.value)}
-                      disabled={!canEdit || pending || !isStrategyEnabled}
+                      defaultValue={field.value}
+                      onValueChange={handleChange}
+                      disabled={selectDisabled}
                     >
-                      <option value="true">Always verified</option>
-                      <option value="false">Always unverified</option>
-                      <option value="user_choice">Allow QA to choose</option>
-                    </select>
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
+                      <FormControl>
+                      <SelectTrigger
+                        id="strategy-email-verified-mode"
+                        data-testid="strategy-email-verified-mode"
+                        aria-label="Email verified mode"
+                        disabled={selectDisabled}
+                      >
+                        <span className={cn("truncate", !field.value && "text-muted-foreground")}>
+                          {field.value ? EMAIL_VERIFIED_LABELS[field.value] : "Select email verified mode"}
+                        </span>
+                      </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        <SelectItem value="true">Always verified</SelectItem>
+                        <SelectItem value="false">Always unverified</SelectItem>
+                        <SelectItem value="user_choice">Allow QA to choose</SelectItem>
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                );
+              }}
             />
           ) : null}
         </div>

--- a/src/app/admin/clients/__tests__/update-client-auth-strategies-form.test.tsx
+++ b/src/app/admin/clients/__tests__/update-client-auth-strategies-form.test.tsx
@@ -28,92 +28,7 @@ vi.mock("@/components/ui/use-toast", () => ({
   useToast: () => ({ toast: mockToast }),
 }));
 
-vi.mock("@/components/ui/select", async () => {
-  const React = await import("react");
-  type Option = { value: string; label: string };
-  const SelectContext = React.createContext<{
-    value: string;
-    onValueChange: (next: string) => void;
-    registerOption: (option: Option) => void;
-    options: Option[];
-    disabled: boolean;
-  } | null>(null);
-
-  const Select = ({ value, defaultValue, onValueChange, disabled = false, children }: any) => {
-    const [options, setOptions] = React.useState<Option[]>([]);
-    const [currentValue, setCurrentValue] = React.useState<string>(value ?? defaultValue ?? "");
-    React.useEffect(() => {
-      if (value !== undefined) {
-        setCurrentValue(value);
-      }
-    }, [value]);
-    const registerOption = (option: Option) => {
-      setOptions((prev) => {
-        const existing = prev.find((item) => item.value === option.value);
-        if (existing && existing.label === option.label) {
-          return prev;
-        }
-        const next = prev.filter((item) => item.value !== option.value);
-        return [...next, option];
-      });
-    };
-    const handleChange = (next: string) => {
-      setCurrentValue(next);
-      onValueChange?.(next);
-    };
-    return (
-      <SelectContext.Provider value={{ value: currentValue, onValueChange: handleChange, registerOption, options, disabled }}>
-        {children}
-      </SelectContext.Provider>
-    );
-  };
-
-  const SelectTrigger = ({ "data-testid": dataTestId, "aria-label": ariaLabel }: any) => {
-    const context = React.useContext(SelectContext);
-    if (!context) return null;
-    return (
-      <select
-        data-testid={dataTestId}
-        aria-label={ariaLabel}
-        value={context.value ?? ""}
-        onChange={(event) => context.onValueChange(event.target.value)}
-        disabled={context.disabled}
-      >
-        {context.options.map((option) => (
-          <option key={option.value} value={option.value}>
-            {option.label}
-          </option>
-        ))}
-      </select>
-    );
-  };
-
-  const SelectContent = ({ children }: any) => <>{children}</>;
-
-  const SelectItem = ({ value, children }: any) => {
-    const context = React.useContext(SelectContext);
-    React.useEffect(() => {
-      context?.registerOption({ value, label: String(children) });
-    }, [context, value, children]);
-    return null;
-  };
-
-  const SelectValue = ({ children }: any) => <>{children}</>;
-  const SelectGroup = ({ children }: any) => <>{children}</>;
-  const SelectLabel = ({ children }: any) => <>{children}</>;
-  const SelectSeparator = () => null;
-
-  return {
-    Select,
-    SelectTrigger,
-    SelectContent,
-    SelectItem,
-    SelectValue,
-    SelectGroup,
-    SelectLabel,
-    SelectSeparator,
-  };
-});
+vi.mock("@/components/ui/select", () => import("@/test-utils/mocks/shadcn-select"));
 
 const defaultStrategies: ClientAuthStrategies = {
   username: { enabled: true, subSource: "entered" },
@@ -179,6 +94,25 @@ describe("UpdateClientAuthStrategiesForm", () => {
         clientId: "client_123",
         username: { enabled: true, subSource: "generated_uuid" },
         email: { enabled: false, subSource: "entered", emailVerifiedMode: "false" },
+      });
+    });
+  });
+
+  it("persists email verified mode selections", async () => {
+    const user = userEvent.setup();
+    renderForm({
+      email: { enabled: true, subSource: "entered", emailVerifiedMode: "false" },
+    });
+
+    const trigger = screen.getByTestId("strategy-email-verified-mode");
+    await user.selectOptions(trigger, "user_choice");
+    await user.click(screen.getByRole("button", { name: /Save strategies/i }));
+
+    await waitFor(() => {
+      expect(mockUpdateClientAuthStrategiesAction).toHaveBeenCalledWith({
+        clientId: "client_123",
+        username: { enabled: true, subSource: "entered" },
+        email: { enabled: true, subSource: "entered", emailVerifiedMode: "user_choice" },
       });
     });
   });

--- a/src/app/admin/clients/__tests__/update-client-issuer-form.test.tsx
+++ b/src/app/admin/clients/__tests__/update-client-issuer-form.test.tsx
@@ -1,0 +1,111 @@
+/* @vitest-environment jsdom */
+
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
+
+import { UpdateClientIssuerForm } from "../[clientId]/client-forms";
+
+const mockUpdateClientIssuerAction = vi.hoisted(() => vi.fn().mockResolvedValue({ success: "saved" }));
+
+vi.mock("@/app/admin/actions", () => ({
+  addRedirectUriAction: vi.fn(),
+  deleteRedirectUriAction: vi.fn(),
+  rotateClientSecretAction: vi.fn(),
+  updateClientAuthStrategiesAction: vi.fn(),
+  updateClientIssuerAction: mockUpdateClientIssuerAction,
+  updateClientNameAction: vi.fn(),
+}));
+
+const mockRefresh = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: mockRefresh }),
+}));
+
+const mockToast = vi.fn();
+vi.mock("@/components/ui/use-toast", () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
+vi.mock("@/components/ui/select", () => import("@/test-utils/mocks/shadcn-select"));
+
+const defaultResources = [
+  { id: "api_res_1", label: "Primary API" },
+  { id: "api_res_2", label: "Payments API" },
+];
+
+const renderForm = (props?: Partial<Parameters<typeof UpdateClientIssuerForm>[0]>) => {
+  return render(
+    <UpdateClientIssuerForm
+      clientId="client_123"
+      canEdit
+      defaultResourceId="api_res_1"
+      defaultResourceName="Primary API"
+      currentResourceId={props?.currentResourceId ?? "api_res_2"}
+      usesDefault={props?.usesDefault ?? false}
+      resources={props?.resources ?? defaultResources}
+      {...props}
+    />,
+  );
+};
+
+describe("UpdateClientIssuerForm", () => {
+  beforeEach(() => {
+    mockUpdateClientIssuerAction.mockClear();
+    mockRefresh.mockClear();
+    mockToast.mockClear();
+  });
+
+  it("loads the tenant default when usesDefault is true", () => {
+    renderForm({ usesDefault: true });
+    expect(screen.getByLabelText("API resource")).toHaveValue("default");
+  });
+
+  it("syncs the selection when props change", async () => {
+    const { rerender } = renderForm({ currentResourceId: "api_res_2", usesDefault: false });
+    const select = screen.getByLabelText("API resource");
+    expect(select).toHaveValue("api_res_2");
+
+    rerender(
+      <UpdateClientIssuerForm
+        clientId="client_123"
+        canEdit
+        defaultResourceId="api_res_1"
+        defaultResourceName="Primary API"
+        currentResourceId="api_res_1"
+        usesDefault
+        resources={defaultResources}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("API resource")).toHaveValue("default");
+    });
+  });
+
+  it("submits the selected API resource", async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    const select = screen.getByLabelText("API resource");
+    await user.selectOptions(select, "api_res_1");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(mockUpdateClientIssuerAction).toHaveBeenCalledWith({ clientId: "client_123", apiResourceId: "api_res_1" });
+    });
+  });
+
+  it("sends tenant default when the default option is chosen", async () => {
+    const user = userEvent.setup();
+    renderForm({ usesDefault: false });
+
+    const select = screen.getByLabelText("API resource");
+    await user.selectOptions(select, "default");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(mockUpdateClientIssuerAction).toHaveBeenCalledWith({ clientId: "client_123", apiResourceId: "default" });
+    });
+  });
+});

--- a/src/test-utils/mocks/shadcn-select.tsx
+++ b/src/test-utils/mocks/shadcn-select.tsx
@@ -1,0 +1,81 @@
+import React from "react";
+
+type Option = { value: string; label: string };
+
+type ContextValue = {
+  value: string;
+  onValueChange: (next: string) => void;
+  registerOption: (option: Option) => void;
+  options: Option[];
+  disabled: boolean;
+};
+
+const SelectContext = React.createContext<ContextValue | null>(null);
+
+const Select = ({ value, defaultValue, onValueChange, disabled = false, children }: any) => {
+  const [options, setOptions] = React.useState<Option[]>([]);
+  const [currentValue, setCurrentValue] = React.useState<string>(value ?? defaultValue ?? "");
+  React.useEffect(() => {
+    if (value !== undefined) {
+      setCurrentValue(value);
+    }
+  }, [value]);
+  const registerOption = (option: Option) => {
+    setOptions((prev) => {
+      const existing = prev.find((item) => item.value === option.value);
+      if (existing && existing.label === option.label) {
+        return prev;
+      }
+      const next = prev.filter((item) => item.value !== option.value);
+      return [...next, option];
+    });
+  };
+  const handleChange = (next: string) => {
+    setCurrentValue(next);
+    onValueChange?.(next);
+  };
+  return (
+    <SelectContext.Provider value={{ value: currentValue, onValueChange: handleChange, registerOption, options, disabled }}>
+      {children}
+    </SelectContext.Provider>
+  );
+};
+
+const SelectTrigger = ({ id, "data-testid": dataTestId, "aria-label": ariaLabel, disabled, ...rest }: any) => {
+  const context = React.useContext(SelectContext);
+  if (!context) return null;
+  return (
+    <select
+      id={id}
+      data-testid={dataTestId}
+      aria-label={ariaLabel}
+      value={context.value ?? ""}
+      onChange={(event) => context.onValueChange(event.target.value)}
+      disabled={context.disabled || disabled}
+      {...rest}
+    >
+      {context.options.map((option) => (
+        <option key={option.value} value={option.value}>
+          {option.label}
+        </option>
+      ))}
+    </select>
+  );
+};
+
+const SelectContent = ({ children }: any) => <>{children}</>;
+
+const SelectItem = ({ value, children }: any) => {
+  const context = React.useContext(SelectContext);
+  React.useEffect(() => {
+    context?.registerOption({ value, label: String(children) });
+  }, [context, value, children]);
+  return null;
+};
+
+const SelectValue = ({ children }: any) => <>{children}</>;
+const SelectGroup = ({ children }: any) => <>{children}</>;
+const SelectLabel = ({ children }: any) => <>{children}</>;
+const SelectSeparator = () => null;
+
+export { Select, SelectTrigger, SelectContent, SelectItem, SelectValue, SelectGroup, SelectLabel, SelectSeparator };

--- a/tests/e2e/auth-strategies.spec.ts
+++ b/tests/e2e/auth-strategies.spec.ts
@@ -37,7 +37,7 @@ test.describe("auth strategy persistence", () => {
     const emailToggle = page.getByTestId("strategy-email-enabled");
     await emailToggle.check();
     await updateSelect(page, page.getByTestId("strategy-email-subsource"), "Generate UUID per session");
-    await updateSelect(page, page.getByLabel("Email verified mode"), "Allow QA to choose");
+    await updateSelect(page, page.getByTestId("strategy-email-verified-mode"), "Allow QA to choose");
 
     const saveButton = page.getByRole("button", { name: "Save strategies" });
     await expect(saveButton).toBeEnabled();
@@ -54,9 +54,9 @@ test.describe("auth strategy persistence", () => {
     );
 
     await page.reload();
-    await expect(page.getByTestId("strategy-username-subsource")).toHaveValue("generated_uuid");
-    await expect(page.getByTestId("strategy-email-subsource")).toHaveValue("generated_uuid");
-    await expect(page.getByLabel("Email verified mode")).toHaveValue("user_choice");
+    await expect(page.getByTestId("strategy-username-subsource")).toHaveText("Generate UUID per session");
+    await expect(page.getByTestId("strategy-email-subsource")).toHaveText("Generate UUID per session");
+    await expect(page.getByTestId("strategy-email-verified-mode")).toHaveText("Allow QA to choose");
     await expect(page.getByTestId("strategy-email-enabled")).toBeChecked();
 
     const latestStrategies = await getClientStrategies(page);
@@ -92,7 +92,8 @@ test.describe("auth strategy persistence", () => {
 });
 
 const updateSelect = async (page: Page, trigger: Locator, optionLabel: string) => {
-  await trigger.selectOption({ label: optionLabel });
+  await trigger.click();
+  await page.getByRole("option", { name: optionLabel }).click();
 };
 
 const selectTenant = async (page: Page, id: string) => {


### PR DESCRIPTION
## Summary
- restore the shadcn/Radix Select UX for auth strategy configuration and keep trigger text in sync
- keep client issuer select under the same mock + add dedicated unit coverage
- refresh auth strategy vitest + Playwright coverage for persistence/regressions

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm test:e2e

Resolves #53.