### PR TITLE
feat: persist mock identity subjects

### DIFF
--- a/prisma/migrations/20260221175221_mock_identity_store/migration.sql
+++ b/prisma/migrations/20260221175221_mock_identity_store/migration.sql
@@ -1,0 +1,22 @@
+-- CreateTable
+CREATE TABLE "MockIdentity" (
+    "id" TEXT NOT NULL,
+    "tenantId" TEXT NOT NULL,
+    "strategy" "LoginStrategy" NOT NULL,
+    "identifier" TEXT NOT NULL,
+    "sub" TEXT NOT NULL,
+    "email" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "MockIdentity_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "MockIdentity_sub_key" ON "MockIdentity"("sub");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "MockIdentity_tenantId_strategy_identifier_key" ON "MockIdentity"("tenantId", "strategy", "identifier");
+
+-- AddForeignKey
+ALTER TABLE "MockIdentity" ADD CONSTRAINT "MockIdentity_tenantId_fkey" FOREIGN KEY ("tenantId") REFERENCES "Tenant"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -61,6 +61,7 @@ model Tenant {
   clients           Client[]
   keys              TenantKey[]
   mockUsers         MockUser[]
+  mockIdentities    MockIdentity[]
   authorizationCode AuthorizationCode[]
   accessTokens      AccessToken[]
   mockSessions      MockSession[]
@@ -193,6 +194,20 @@ model MockUser {
   codes         AuthorizationCode[]
   accessTokens  AccessToken[]
   @@unique([tenantId, username])
+}
+
+model MockIdentity {
+  id          String        @id @default(uuid())
+  tenant      Tenant        @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  tenantId    String
+  strategy    LoginStrategy
+  identifier  String
+  sub         String        @unique
+  email       String?
+  createdAt   DateTime      @default(now())
+  updatedAt   DateTime      @updatedAt
+
+  @@unique([tenantId, strategy, identifier])
 }
 
 model MockSession {

--- a/src/app/r/[apiResourceId]/oidc/login/submit/route.ts
+++ b/src/app/r/[apiResourceId]/oidc/login/submit/route.ts
@@ -1,5 +1,3 @@
-import { randomUUID } from "node:crypto";
-
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 
@@ -17,6 +15,7 @@ import {
 } from "@/server/oidc/auth-strategy";
 import type { ClientAuthStrategies } from "@/server/oidc/auth-strategy";
 import { getApiResourceWithTenant } from "@/server/services/api-resource-service";
+import { resolveStableSubject } from "@/server/services/mock-identity-service";
 
 const loginSchema = z.object({
   strategy: z.enum(["username", "email"]).default("username"),
@@ -95,7 +94,15 @@ export async function POST(request: NextRequest, context: ApiResourceRouteContex
         emailVerifiedOverride = data.data.email_verified_preference === "true";
       }
     }
-    const subject = selectedConfig.subSource === "entered" ? trimmedIdentifier : randomUUID();
+    const subject =
+      selectedConfig.subSource === "entered"
+        ? trimmedIdentifier
+        : await resolveStableSubject({
+            tenantId: tenant.id,
+            strategy: data.data.strategy,
+            identifier: normalizedIdentifier,
+            email: data.data.strategy === "email" ? normalizedIdentifier : undefined,
+          });
     const user = await findOrCreateMockUser(tenant.id, normalizedIdentifier, {
       displayName: trimmedIdentifier,
       email: data.data.strategy === "email" ? normalizedIdentifier : null,

--- a/src/server/services/__tests__/mock-identity-service.test.ts
+++ b/src/server/services/__tests__/mock-identity-service.test.ts
@@ -1,0 +1,51 @@
+import { randomUUID } from "crypto";
+
+import { describe, expect, it } from "vitest";
+
+import { prisma } from "@/server/db/client";
+import { findOrCreateMockIdentity } from "../mock-identity-service";
+
+describe("mock identity service", () => {
+  it("returns a stable subject for repeated identifiers", async () => {
+    const identifier = `stable-user-${randomUUID()}`;
+    const first = await findOrCreateMockIdentity({
+      tenantId: "tenant_qa",
+      strategy: "username",
+      identifier,
+    });
+    const second = await findOrCreateMockIdentity({
+      tenantId: "tenant_qa",
+      strategy: "username",
+      identifier: identifier.toUpperCase(),
+    });
+    expect(first.sub).toBe(second.sub);
+  });
+
+  it("isolates identities per tenant and strategy", async () => {
+    const tenantOne = await prisma.tenant.create({ data: { name: `Mock Identity ${randomUUID()}` } });
+    const tenantTwo = await prisma.tenant.create({ data: { name: `Mock Identity ${randomUUID()}` } });
+
+    const usernameIdentity = await findOrCreateMockIdentity({
+      tenantId: tenantOne.id,
+      strategy: "username",
+      identifier: "isolate",
+    });
+    const emailIdentity = await findOrCreateMockIdentity({
+      tenantId: tenantOne.id,
+      strategy: "email",
+      identifier: "isolate@example.test",
+      email: "isolate@example.test",
+    });
+    const otherTenantIdentity = await findOrCreateMockIdentity({
+      tenantId: tenantTwo.id,
+      strategy: "username",
+      identifier: "isolate",
+    });
+
+    expect(usernameIdentity.sub).not.toBe(emailIdentity.sub);
+    expect(usernameIdentity.sub).not.toBe(otherTenantIdentity.sub);
+
+    await prisma.tenant.delete({ where: { id: tenantOne.id } });
+    await prisma.tenant.delete({ where: { id: tenantTwo.id } });
+  });
+});

--- a/src/server/services/__tests__/tenant-service.test.ts
+++ b/src/server/services/__tests__/tenant-service.test.ts
@@ -43,6 +43,14 @@ describe("tenant service", () => {
         expiresAt: new Date(Date.now() + 60 * 60 * 1000),
       },
     });
+    await prisma.mockIdentity.create({
+      data: {
+        tenantId: tenant.id,
+        strategy: $Enums.LoginStrategy.USERNAME,
+        identifier: `identity-${randomUUID()}`,
+        sub: randomUUID(),
+      },
+    });
     await prisma.authorizationCode.create({
       data: {
         tenantId: tenant.id,
@@ -93,5 +101,6 @@ describe("tenant service", () => {
     expect(await prisma.accessToken.count({ where: { tenantId: tenant.id } })).toBe(0);
     expect(await prisma.mockUser.count({ where: { tenantId: tenant.id } })).toBe(0);
     expect(await prisma.mockSession.count({ where: { tenantId: tenant.id } })).toBe(0);
+    expect(await prisma.mockIdentity.count({ where: { tenantId: tenant.id } })).toBe(0);
   });
 });

--- a/src/server/services/mock-identity-service.ts
+++ b/src/server/services/mock-identity-service.ts
@@ -1,0 +1,49 @@
+import { randomUUID } from "node:crypto";
+
+import { prisma } from "@/server/db/client";
+import type { ClientAuthStrategy } from "@/server/oidc/auth-strategy";
+import { toPrismaLoginStrategy } from "@/server/oidc/auth-strategy";
+
+type IdentityInput = {
+  tenantId: string;
+  strategy: ClientAuthStrategy;
+  identifier: string;
+  email?: string | null;
+};
+
+const normalizeIdentifier = (identifier: string) => identifier.trim().toLowerCase();
+
+const normalizeEmail = (email?: string | null) => {
+  if (!email) {
+    return null;
+  }
+  return email.trim().toLowerCase();
+};
+
+export const findOrCreateMockIdentity = async ({ tenantId, strategy, identifier, email }: IdentityInput) => {
+  const normalizedIdentifier = normalizeIdentifier(identifier);
+  const normalizedEmail = strategy === "email" ? normalizeEmail(email ?? identifier) : normalizeEmail(email);
+  const prismaStrategy = toPrismaLoginStrategy(strategy);
+  return prisma.mockIdentity.upsert({
+    where: {
+      tenantId_strategy_identifier: {
+        tenantId,
+        strategy: prismaStrategy,
+        identifier: normalizedIdentifier,
+      },
+    },
+    update: normalizedEmail ? { email: normalizedEmail } : {},
+    create: {
+      tenantId,
+      strategy: prismaStrategy,
+      identifier: normalizedIdentifier,
+      sub: randomUUID(),
+      email: normalizedEmail,
+    },
+  });
+};
+
+export const resolveStableSubject = async (input: IdentityInput) => {
+  const identity = await findOrCreateMockIdentity(input);
+  return identity.sub;
+};

--- a/tests/e2e/auth-strategies.spec.ts
+++ b/tests/e2e/auth-strategies.spec.ts
@@ -70,6 +70,9 @@ test.describe("auth strategy persistence", () => {
     expect(usernameFlow.idToken.sub).not.toBe(username);
     expect(usernameFlow.idToken.preferred_username).toBe(username);
     expect(usernameFlow.userinfo.sub).toBe(usernameFlow.idToken.sub);
+    const usernameFlowRepeat = await runUsernameFlow({ tenantId, resourceId, clientId, username });
+    expect(usernameFlowRepeat.idToken.sub).toBe(usernameFlow.idToken.sub);
+    expect(usernameFlowRepeat.userinfo.sub).toBe(usernameFlow.userinfo.sub);
 
     const emailFlowVerified = await runEmailFlow({
       resourceId,
@@ -88,6 +91,8 @@ test.describe("auth strategy persistence", () => {
     });
     expect(emailFlowUnverified.idToken.email_verified).toBe(false);
     expect(emailFlowUnverified.userinfo.email_verified).toBe(false);
+    expect(emailFlowUnverified.idToken.sub).toBe(emailFlowVerified.idToken.sub);
+    expect(emailFlowUnverified.userinfo.sub).toBe(emailFlowVerified.userinfo.sub);
   });
 });
 


### PR DESCRIPTION
## Summary
- add MockIdentity prisma model plus service to store stable subs per tenant/strategy/identifier
- route login submissions through the identity service when generated UUIDs are requested and ensure tenant deletion cascades
- extend unit + e2e suites to cover MockIdentity lookups and stable sub behavior across username/email flows

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm test:e2e

Resolves #54.