### PR TITLE
feat: rename subject source label

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,8 +127,8 @@ updates). CI runs this script automatically before executing E2E specs.
 ### Per-client auth strategies
 
 - Username and email sign-in flows are configured per client. Both are enabled/disabled independently and expose their
-  own subject-source selector (`entered` reuses the typed identifier, `generated_uuid` rotates a random UUID each
-  session).
+  own subject-source selector (`entered` reuses the typed identifier, `generated_uuid` ("Generate UUID (stable per identity)")
+  stores a persistent UUID per tenant + strategy + identifier).
 - Username strategy returns `preferred_username` when `profile` is requested. Email strategy requires the `email` scope
   and emits `email` + `email_verified` according to the configured mode (always true, always false, or QA-selected at
   login). It never exposes `preferred_username`.

--- a/src/app/admin/clients/[clientId]/client-forms.tsx
+++ b/src/app/admin/clients/[clientId]/client-forms.tsx
@@ -20,7 +20,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { useToast } from "@/components/ui/use-toast";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import type { ClientAuthStrategies } from "@/server/oidc/auth-strategy";
@@ -246,8 +246,11 @@ const strategyMetadata: Record<keyof ClientAuthStrategies, { title: string; desc
 
 const SUBJECT_SOURCE_LABELS: Record<"entered" | "generated_uuid", string> = {
   entered: "Use entered value",
-  generated_uuid: "Generate UUID per session",
+  generated_uuid: "Generate UUID (stable per identity)",
 };
+
+export const SUBJECT_SOURCE_HELP_TEXT =
+  "Generate UUID (stable per identity) stores a persistent UUID per tenant + strategy + identifier combination.";
 
 const EMAIL_VERIFIED_LABELS: Record<"true" | "false" | "user_choice", string> = {
   true: "Always verified",
@@ -357,9 +360,10 @@ export function UpdateAuthStrategiesForm({
                     </FormControl>
                     <SelectContent>
                       <SelectItem value="entered">Use entered value</SelectItem>
-                      <SelectItem value="generated_uuid">Generate UUID per session</SelectItem>
+                      <SelectItem value="generated_uuid">Generate UUID (stable per identity)</SelectItem>
                     </SelectContent>
                   </Select>
+                  <FormDescription>{SUBJECT_SOURCE_HELP_TEXT}</FormDescription>
                   <FormMessage />
                 </FormItem>
               );

--- a/src/app/admin/clients/__tests__/update-client-auth-strategies-form.test.tsx
+++ b/src/app/admin/clients/__tests__/update-client-auth-strategies-form.test.tsx
@@ -5,7 +5,7 @@ import userEvent from "@testing-library/user-event";
 import { vi } from "vitest";
 
 import type { ClientAuthStrategies } from "@/server/oidc/auth-strategy";
-import { UpdateAuthStrategiesForm } from "../[clientId]/client-forms";
+import { SUBJECT_SOURCE_HELP_TEXT, UpdateAuthStrategiesForm } from "../[clientId]/client-forms";
 
 const mockUpdateClientAuthStrategiesAction = vi.hoisted(() => vi.fn().mockResolvedValue({ success: "saved" }));
 
@@ -77,8 +77,16 @@ describe("UpdateClientAuthStrategiesForm", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByTestId("strategy-username-subsource")).toHaveTextContent("Generate UUID per session");
+      expect(screen.getByTestId("strategy-username-subsource")).toHaveTextContent("Generate UUID (stable per identity)");
     });
+  });
+
+  it("renders the stable identity label and help text", () => {
+    renderForm();
+    const options = screen.getAllByRole("option", { name: "Generate UUID (stable per identity)" });
+    expect(options).not.toHaveLength(0);
+    const descriptions = screen.getAllByText(SUBJECT_SOURCE_HELP_TEXT);
+    expect(descriptions).toHaveLength(2);
   });
 
   it("submits the selected subject source", async () => {

--- a/tests/e2e/auth-strategies.spec.ts
+++ b/tests/e2e/auth-strategies.spec.ts
@@ -33,10 +33,10 @@ test.describe("auth strategy persistence", () => {
     await page.goto("/admin/clients");
     await selectTenant(page, tenantId);
     await page.getByRole("row", { name: /QA Client/i }).first().getByRole("link", { name: "Details →" }).click();
-    await updateSelect(page, page.getByTestId("strategy-username-subsource"), "Generate UUID per session");
+    await updateSelect(page, page.getByTestId("strategy-username-subsource"), "Generate UUID (stable per identity)");
     const emailToggle = page.getByTestId("strategy-email-enabled");
     await emailToggle.check();
-    await updateSelect(page, page.getByTestId("strategy-email-subsource"), "Generate UUID per session");
+    await updateSelect(page, page.getByTestId("strategy-email-subsource"), "Generate UUID (stable per identity)");
     await updateSelect(page, page.getByTestId("strategy-email-verified-mode"), "Allow QA to choose");
 
     const saveButton = page.getByRole("button", { name: "Save strategies" });
@@ -54,8 +54,8 @@ test.describe("auth strategy persistence", () => {
     );
 
     await page.reload();
-    await expect(page.getByTestId("strategy-username-subsource")).toHaveText("Generate UUID per session");
-    await expect(page.getByTestId("strategy-email-subsource")).toHaveText("Generate UUID per session");
+    await expect(page.getByTestId("strategy-username-subsource")).toHaveText("Generate UUID (stable per identity)");
+    await expect(page.getByTestId("strategy-email-subsource")).toHaveText("Generate UUID (stable per identity)");
     await expect(page.getByTestId("strategy-email-verified-mode")).toHaveText("Allow QA to choose");
     await expect(page.getByTestId("strategy-email-enabled")).toBeChecked();
 


### PR DESCRIPTION
## Summary
- rename the generated UUID subject source label to "Generate UUID (stable per identity)" and clarify README copy
- add persistent help text describing the per-tenant + strategy + identifier UUID behavior
- extend unit/E2E coverage to assert the new label/help text renders

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm test:e2e

Resolves #57.