### PR TITLE
feat: control issuer select with RHF

### DIFF
--- a/src/app/admin/clients/[clientId]/client-forms.tsx
+++ b/src/app/admin/clients/[clientId]/client-forms.tsx
@@ -485,36 +485,42 @@ export function UpdateClientIssuerForm({
   canEdit: boolean;
   defaultResourceId: string;
   defaultResourceName: string;
-  currentResourceId: string;
+  currentResourceId: string | null;
   usesDefault: boolean;
   resources: IssuerOption[];
 }) {
   const router = useRouter();
-  const [selectedResourceId, setSelectedResourceId] = useState<string>(usesDefault ? "default" : currentResourceId ?? defaultResourceId);
   const [pending, startSaveTransition] = useTransition();
-  const [, startResetTransition] = useTransition();
   const { toast } = useToast();
 
-  useEffect(() => {
-    startResetTransition(() => {
-      setSelectedResourceId(usesDefault ? "default" : currentResourceId);
-    });
-  }, [currentResourceId, usesDefault, startResetTransition]);
-
+  const tenantDefaultLabel = `Tenant default (${defaultResourceName})`;
   const options: IssuerOption[] = [
-    { id: "default", label: `Use tenant default (${defaultResourceName})` },
+    { id: "default", label: tenantDefaultLabel },
     ...resources,
   ];
 
-  const handleSave = () => {
-    const parsed = issuerSchema.safeParse({ resourceId: selectedResourceId });
-    if (!parsed.success) {
-      toast({ variant: "destructive", title: "Select an API resource" });
-      return;
+  const normalizeResourceId = (resourceId: string | null | undefined) => {
+    if (!resourceId || resourceId === "default") {
+      return "default";
     }
+    return resourceId;
+  };
+
+  const form = useForm<z.infer<typeof issuerSchema>>({
+    resolver: zodResolver(issuerSchema),
+    defaultValues: { resourceId: normalizeResourceId(usesDefault ? "default" : currentResourceId ?? defaultResourceId) },
+  });
+
+  useEffect(() => {
+    form.reset({ resourceId: normalizeResourceId(usesDefault ? "default" : currentResourceId ?? defaultResourceId) });
+  }, [currentResourceId, defaultResourceId, form, usesDefault]);
+
+  const watchedResourceId = useWatch({ control: form.control, name: "resourceId" });
+  const selectedLabel = options.find((option) => option.id === watchedResourceId)?.label ?? tenantDefaultLabel;
+
+  const handleSubmit = form.handleSubmit((values) => {
     startSaveTransition(async () => {
-      const normalized = parsed.data.resourceId === "default" ? "default" : parsed.data.resourceId;
-      const result = await updateClientIssuerAction({ clientId, apiResourceId: normalized });
+      const result = await updateClientIssuerAction({ clientId, apiResourceId: values.resourceId });
       if (result.error) {
         toast({ variant: "destructive", title: "Unable to update issuer", description: result.error });
         return;
@@ -522,38 +528,60 @@ export function UpdateClientIssuerForm({
       router.refresh();
       toast({ title: "Issuer updated", description: "Client now issues tokens for the selected resource." });
     });
-  };
+  });
 
   return (
-    <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
-      <div className="flex-1 space-y-2">
-        <Label htmlFor="client-issuer-select">Issuer / API resource</Label>
-        <Select
-          value={selectedResourceId}
-          onValueChange={setSelectedResourceId}
+    <Form {...form}>
+      <form onSubmit={handleSubmit} className="flex flex-col gap-3 sm:flex-row sm:items-end">
+        <FormField
+          control={form.control}
+          name="resourceId"
+          render={({ field }) => (
+            <FormItem className="flex-1 space-y-2">
+              <FormLabel htmlFor="client-issuer-select">Issuer / API resource</FormLabel>
+              <Select
+                value={field.value}
+                onValueChange={(value) => {
+                  if (!value) {
+                    return;
+                  }
+                  const normalized = normalizeResourceId(value);
+                  field.onChange(normalized);
+                  form.setValue("resourceId", normalized, { shouldValidate: true, shouldDirty: true });
+                }}
+                disabled={!canEdit || pending}
+              >
+                <FormControl>
+                  <SelectTrigger
+                    id="client-issuer-select"
+                    aria-label="API resource"
+                    data-testid="client-issuer-trigger"
+                  >
+                    <SelectValue aria-hidden="true" className="sr-only" />
+                    <span className="truncate" data-testid="client-issuer-value">{selectedLabel}</span>
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent>
+                  {options.map((option) => (
+                    <SelectItem key={option.id} value={option.id} data-testid={`issuer-option-${option.id}`}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <Button
+          type="submit"
           disabled={!canEdit || pending}
+          className="sm:w-auto w-full"
+          data-testid="issuer-form-save"
         >
-          <SelectTrigger id="client-issuer-select" aria-label="API resource">
-            <SelectValue placeholder="Select API resource" />
-          </SelectTrigger>
-          <SelectContent>
-            {options.map((option) => (
-              <SelectItem key={option.id} value={option.id} data-testid={`issuer-option-${option.id}`}>
-                {option.label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      </div>
-      <Button
-        type="button"
-        onClick={handleSave}
-        disabled={!canEdit || pending}
-        className="sm:w-auto w-full"
-        data-testid="issuer-form-save"
-      >
-        {pending ? <Loader2 className="h-4 w-4 animate-spin" /> : "Save"}
-      </Button>
-    </div>
+          {pending ? <Loader2 className="h-4 w-4 animate-spin" /> : "Save"}
+        </Button>
+      </form>
+    </Form>
   );
 }

--- a/src/app/admin/clients/[clientId]/page.tsx
+++ b/src/app/admin/clients/[clientId]/page.tsx
@@ -50,6 +50,7 @@ export default async function ClientDetailPage({ params }: { params: PageParams 
   const defaultResourceId = activeTenant.defaultApiResourceId!;
   const clientUsesDefault = !client.apiResourceId;
   const currentResourceId = client.apiResourceId ?? defaultResourceId;
+  const storedClientResourceId = client.apiResourceId;
   const defaultResource = resources.find((resource) => resource.id === defaultResourceId);
   const currentResourceName = client.apiResource?.name ?? defaultResource?.name ?? "Default resource";
   const issuerOptions = resources
@@ -164,7 +165,7 @@ export default async function ClientDetailPage({ params }: { params: PageParams 
             canEdit={canManageClients}
             defaultResourceId={defaultResourceId}
             defaultResourceName={defaultResource?.name ?? "Default resource"}
-            currentResourceId={currentResourceId}
+            currentResourceId={storedClientResourceId}
             usesDefault={clientUsesDefault}
             resources={issuerOptions}
           />

--- a/src/app/admin/clients/__tests__/update-client-issuer-form.test.tsx
+++ b/src/app/admin/clients/__tests__/update-client-issuer-form.test.tsx
@@ -35,13 +35,14 @@ const defaultResources = [
 ];
 
 const renderForm = (props?: Partial<Parameters<typeof UpdateClientIssuerForm>[0]>) => {
+  const currentResourceProp = props && Object.prototype.hasOwnProperty.call(props, "currentResourceId") ? props.currentResourceId : undefined;
   return render(
     <UpdateClientIssuerForm
       clientId="client_123"
       canEdit
       defaultResourceId="api_res_1"
       defaultResourceName="Primary API"
-      currentResourceId={props?.currentResourceId ?? "api_res_2"}
+      currentResourceId={currentResourceProp ?? "api_res_2"}
       usesDefault={props?.usesDefault ?? false}
       resources={props?.resources ?? defaultResources}
       {...props}
@@ -56,15 +57,28 @@ describe("UpdateClientIssuerForm", () => {
     mockToast.mockClear();
   });
 
-  it("loads the tenant default when usesDefault is true", () => {
-    renderForm({ usesDefault: true });
-    expect(screen.getByLabelText("API resource")).toHaveValue("default");
+  it("maps null resource ids to the tenant default label", () => {
+    renderForm({ currentResourceId: null, usesDefault: true });
+    expect(screen.getByLabelText("API resource")).toHaveDisplayValue("Tenant default (Primary API)");
   });
 
-  it("syncs the selection when props change", async () => {
-    const { rerender } = renderForm({ currentResourceId: "api_res_2", usesDefault: false });
+  it("updates the trigger text when a resource is selected", async () => {
+    const user = userEvent.setup();
+    renderForm();
+
     const select = screen.getByLabelText("API resource");
-    expect(select).toHaveValue("api_res_2");
+    await user.selectOptions(select, "api_res_1");
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("API resource")).toHaveDisplayValue("Primary API");
+    });
+  });
+
+  it("persists the chosen resource across rerenders until props change", async () => {
+    const user = userEvent.setup();
+    const { rerender } = renderForm();
+    const select = screen.getByLabelText("API resource");
+    await user.selectOptions(select, "api_res_1");
 
     rerender(
       <UpdateClientIssuerForm
@@ -72,14 +86,28 @@ describe("UpdateClientIssuerForm", () => {
         canEdit
         defaultResourceId="api_res_1"
         defaultResourceName="Primary API"
-        currentResourceId="api_res_1"
+        currentResourceId="api_res_2"
+        usesDefault={false}
+        resources={defaultResources}
+      />,
+    );
+
+    expect(screen.getByLabelText("API resource")).toHaveDisplayValue("Primary API");
+
+    rerender(
+      <UpdateClientIssuerForm
+        clientId="client_123"
+        canEdit
+        defaultResourceId="api_res_1"
+        defaultResourceName="Primary API"
+        currentResourceId={null}
         usesDefault
         resources={defaultResources}
       />,
     );
 
     await waitFor(() => {
-      expect(screen.getByLabelText("API resource")).toHaveValue("default");
+      expect(screen.getByLabelText("API resource")).toHaveDisplayValue("Tenant default (Primary API)");
     });
   });
 

--- a/tests/e2e/admin.spec.ts
+++ b/tests/e2e/admin.spec.ts
@@ -202,13 +202,28 @@ test.describe("admin console", () => {
       .getByRole("link", { name: "Details →" })
       .click();
     await expect(page.getByText(new RegExp(`Currently issuing for ${escapeRegExp(resourceName)}`))).toBeVisible();
-
     const issuerSelect = page.getByRole("combobox", { name: "API resource" });
+    await expect(issuerSelect).toHaveText(new RegExp(`Tenant default \\(${escapeRegExp(resourceName)}\\)`));
+
     await issuerSelect.click();
-    await page.getByTestId(`issuer-option-${legacyResourceId}`).click();
+    const legacyOption = page.getByTestId(`issuer-option-${legacyResourceId}`);
+    await expect(legacyOption).toBeVisible();
+    await expect(legacyOption).toHaveText(new RegExp(escapeRegExp(legacyResourceName)));
+    await legacyOption.click();
+    await expect(issuerSelect).toHaveText(new RegExp(escapeRegExp(legacyResourceName)));
     await page.getByTestId("issuer-form-save").click();
     await expect(page.getByText(new RegExp(`Currently issuing for ${escapeRegExp(legacyResourceName)}`))).toBeVisible();
+    const issuerSelectAfterSave = page.getByRole("combobox", { name: "API resource" });
+    await expect(issuerSelectAfterSave).toHaveText(new RegExp(escapeRegExp(legacyResourceName)));
     await expect(page.getByTestId("oauth-field-issuer")).toContainText(`/r/${legacyResourceId}/oidc`);
+    await expect(page.getByTestId("oauth-field-discovery")).toContainText(`/r/${legacyResourceId}/oidc/.well-known`);
+
+    await page.reload();
+    await selectTenant(page, tenantIdUnderTest);
+    const issuerSelectAfterReload = page.getByRole("combobox", { name: "API resource" });
+    await expect(issuerSelectAfterReload).toHaveText(new RegExp(escapeRegExp(legacyResourceName)));
+    await expect(page.getByTestId("oauth-field-issuer")).toContainText(`/r/${legacyResourceId}/oidc`);
+    await expect(page.getByTestId("oauth-field-discovery")).toContainText(`/r/${legacyResourceId}/oidc/.well-known`);
 
     await page.goto("/admin/api-resources");
     await selectTenant(page, tenantIdUnderTest);


### PR DESCRIPTION
## Summary
- make UpdateClientIssuerForm controlled with RHF + tenant default labeling
- pass stored resource id to preserve selection and refresh URLs
- expand unit and admin e2e coverage for issuer trigger text + persistence

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm test:e2e

Resolves #59