### PR TITLE
fix: polish issuer select + captions

### DIFF
--- a/src/app/admin/clients/[clientId]/client-forms.tsx
+++ b/src/app/admin/clients/[clientId]/client-forms.tsx
@@ -20,7 +20,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { useToast } from "@/components/ui/use-toast";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import type { ClientAuthStrategies } from "@/server/oidc/auth-strategy";
@@ -249,9 +249,6 @@ const SUBJECT_SOURCE_LABELS: Record<"entered" | "generated_uuid", string> = {
   generated_uuid: "Generate UUID (stable per identity)",
 };
 
-export const SUBJECT_SOURCE_HELP_TEXT =
-  "Generate UUID (stable per identity) stores a persistent UUID per tenant + strategy + identifier combination.";
-
 const EMAIL_VERIFIED_LABELS: Record<"true" | "false" | "user_choice", string> = {
   true: "Always verified",
   false: "Always unverified",
@@ -363,7 +360,6 @@ export function UpdateAuthStrategiesForm({
                       <SelectItem value="generated_uuid">Generate UUID (stable per identity)</SelectItem>
                     </SelectContent>
                   </Select>
-                  <FormDescription>{SUBJECT_SOURCE_HELP_TEXT}</FormDescription>
                   <FormMessage />
                 </FormItem>
               );
@@ -557,12 +553,13 @@ export function UpdateClientIssuerForm({
               >
                 <FormControl>
                   <SelectTrigger
+                    className="text-left"
                     id="client-issuer-select"
                     aria-label="API resource"
                     data-testid="client-issuer-trigger"
                   >
                     <SelectValue aria-hidden="true" className="sr-only" />
-                    <span className="truncate" data-testid="client-issuer-value">{selectedLabel}</span>
+                    <span className="flex-1 truncate text-left" data-testid="client-issuer-value">{selectedLabel}</span>
                   </SelectTrigger>
                 </FormControl>
                 <SelectContent>

--- a/src/app/admin/clients/__tests__/update-client-auth-strategies-form.test.tsx
+++ b/src/app/admin/clients/__tests__/update-client-auth-strategies-form.test.tsx
@@ -5,7 +5,7 @@ import userEvent from "@testing-library/user-event";
 import { vi } from "vitest";
 
 import type { ClientAuthStrategies } from "@/server/oidc/auth-strategy";
-import { SUBJECT_SOURCE_HELP_TEXT, UpdateAuthStrategiesForm } from "../[clientId]/client-forms";
+import { UpdateAuthStrategiesForm } from "../[clientId]/client-forms";
 
 const mockUpdateClientAuthStrategiesAction = vi.hoisted(() => vi.fn().mockResolvedValue({ success: "saved" }));
 
@@ -81,12 +81,10 @@ describe("UpdateClientAuthStrategiesForm", () => {
     });
   });
 
-  it("renders the stable identity label and help text", () => {
+  it("renders the stable identity option", () => {
     renderForm();
     const options = screen.getAllByRole("option", { name: "Generate UUID (stable per identity)" });
     expect(options).not.toHaveLength(0);
-    const descriptions = screen.getAllByText(SUBJECT_SOURCE_HELP_TEXT);
-    expect(descriptions).toHaveLength(2);
   });
 
   it("submits the selected subject source", async () => {

--- a/src/app/admin/clients/__tests__/update-client-issuer-form.test.tsx
+++ b/src/app/admin/clients/__tests__/update-client-issuer-form.test.tsx
@@ -62,6 +62,12 @@ describe("UpdateClientIssuerForm", () => {
     expect(screen.getByLabelText("API resource")).toHaveDisplayValue("Tenant default (Primary API)");
   });
 
+  it("left-aligns the collapsed trigger label", () => {
+    renderForm();
+    const trigger = screen.getByTestId("client-issuer-trigger");
+    expect(trigger).toHaveClass("text-left");
+  });
+
   it("updates the trigger text when a resource is selected", async () => {
     const user = userEvent.setup();
     renderForm();

--- a/src/app/admin/clients/page.tsx
+++ b/src/app/admin/clients/page.tsx
@@ -56,7 +56,6 @@ export default async function ClientsPage({ searchParams }: { searchParams: Sear
         <div className="flex w-full flex-col gap-3 sm:flex-row sm:items-center sm:justify-end lg:w-auto">
           <div className="w-full sm:max-w-xs lg:w-72">
             <ClientSearchInput initialQuery={query} />
-            <p className="mt-1 text-xs text-muted-foreground">Filters apply automatically.</p>
           </div>
           {canManageClients ? (
             <Button asChild>


### PR DESCRIPTION
## Summary
- left-align the issuer/API resource Select trigger text and assert via unit test
- drop the subject source helper caption and the clients list filter hint per spec
- update tests to reflect the simplified UI

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm test:e2e

Resolves #61