### PR TITLE
feat: show confidential client secrets

### DIFF
--- a/prisma/migrations/20260310120000_client_secret_encrypted/migration.sql
+++ b/prisma/migrations/20260310120000_client_secret_encrypted/migration.sql
@@ -1,0 +1,2 @@
+-- Add encrypted client secret storage for confidential clients
+ALTER TABLE "Client" ADD COLUMN "clientSecretEncrypted" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -137,6 +137,7 @@ model Client {
   name                     String
   clientId                 String
   clientSecretHash         String?
+  clientSecretEncrypted    String?
   clientType               ClientType               @default(CONFIDENTIAL)
   allowedScopes            String[]                 @default(["openid", "profile", "email"])
   allowedGrantTypes        String[]                 @default(["authorization_code"])

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,4 +1,5 @@
 import { hashSecret } from "@/server/crypto/hash";
+import { encrypt } from "@/server/crypto/key-vault";
 import { prisma } from "@/server/db/client";
 import { classifyRedirect } from "@/server/oidc/redirect-uri";
 import { ensureActiveKey } from "@/server/services/key-service";
@@ -39,6 +40,7 @@ async function main() {
       name: "QA Client",
       clientId: DEFAULT_CLIENT_ID,
       clientSecretHash: await hashSecret(DEFAULT_CLIENT_SECRET),
+      clientSecretEncrypted: encrypt(DEFAULT_CLIENT_SECRET),
       tokenEndpointAuthMethod: "client_secret_post",
     },
   });

--- a/src/app/admin/clients/[clientId]/page.tsx
+++ b/src/app/admin/clients/[clientId]/page.tsx
@@ -23,6 +23,7 @@ import { listApiResources } from "@/server/services/api-resource-service";
 import { getRequestOrigin } from "@/server/utils/request-origin";
 import { buildOidcUrls } from "@/server/oidc/url-builder";
 import { parseClientAuthStrategies } from "@/server/oidc/auth-strategy";
+import { decrypt } from "@/server/crypto/key-vault";
 
 type PageParams = Promise<{ clientId: string }>;
 
@@ -58,14 +59,28 @@ export default async function ClientDetailPage({ params }: { params: PageParams 
     .filter((resource) => resource.id !== defaultResourceId)
     .map((resource) => ({ id: resource.id, label: resource.name }));
   const authStrategies = parseClientAuthStrategies(client.authStrategies);
+  const clientSecretValue = (() => {
+    if (client.clientType !== "CONFIDENTIAL" || !client.clientSecretEncrypted) {
+      return null;
+    }
+    try {
+      return decrypt(client.clientSecretEncrypted);
+    } catch (error) {
+      console.error("Unable to decrypt client secret", error);
+      return null;
+    }
+  })();
 
   const origin = await getRequestOrigin();
   const urls = buildOidcUrls(origin, currentResourceId);
   const testFlowHref = `/admin/clients/${client.id}/test`;
   type FieldDefinition = { label: string; value: string; testId?: string };
   const tenantField: FieldDefinition = { label: "Tenant ID", value: activeTenant.id, testId: "oauth-field-tenant-id" };
-  const requiredFields: FieldDefinition[] = [
-    { label: "Client ID", value: client.clientId, testId: "oauth-field-client-id" },
+  const clientIdField: FieldDefinition = { label: "Client ID", value: client.clientId, testId: "oauth-field-client-id" };
+  const secretField: FieldDefinition | null = clientSecretValue
+    ? { label: "Client secret", value: clientSecretValue, testId: "oauth-field-client-secret" }
+    : null;
+  const protocolFields: FieldDefinition[] = [
     { label: "Issuer", value: urls.issuer, testId: "oauth-field-issuer" },
     { label: "Authorization endpoint", value: urls.authorize, testId: "oauth-field-authorization" },
     { label: "Token endpoint", value: urls.token, testId: "oauth-field-token" },
@@ -75,7 +90,9 @@ export default async function ClientDetailPage({ params }: { params: PageParams 
     { label: "JWKS", value: urls.jwks, testId: "oauth-field-jwks" },
     { label: "Userinfo", value: urls.userinfo, testId: "oauth-field-userinfo" },
   ];
-  const requiredBundleItems = [tenantField, ...requiredFields].map(({ label, value }) => ({ label, value }));
+  const requiredBundleItems = [tenantField, clientIdField, ...(secretField ? [secretField] : []), ...protocolFields].map(
+    ({ label, value }) => ({ label, value }),
+  );
 
   return (
     <div className="space-y-8">
@@ -123,18 +140,26 @@ export default async function ClientDetailPage({ params }: { params: PageParams 
               </div>
               <div className="space-y-3">
                 <CopyField key={tenantField.label} label={tenantField.label} value={tenantField.value} testId={tenantField.testId} />
-                <CopyField
-                  key={requiredFields[0].label}
-                  label={requiredFields[0].label}
-                  value={requiredFields[0].value}
-                  testId={requiredFields[0].testId}
-                />
+                <CopyField key={clientIdField.label} label={clientIdField.label} value={clientIdField.value} testId={clientIdField.testId} />
                 {client.clientType === "CONFIDENTIAL" ? (
-                  <RotateSecretForm clientId={client.id} canRotate={canManageClients} />
+                  <div className="space-y-3">
+                    {secretField ? (
+                      <CopyField
+                        key={secretField.label}
+                        label={secretField.label}
+                        value={secretField.value}
+                        testId={secretField.testId}
+                        description="Treat as confidential; rotate when compromised."
+                      />
+                    ) : (
+                      <p className="text-xs text-muted-foreground">Rotate the client to generate a new secret.</p>
+                    )}
+                    <RotateSecretForm clientId={client.id} canRotate={canManageClients} />
+                  </div>
                 ) : (
                   <p className="text-xs text-muted-foreground">Public clients rely on PKCE and do not store secrets.</p>
                 )}
-                {requiredFields.slice(1).map((item) => (
+                {protocolFields.map((item) => (
                   <CopyField key={item.label} label={item.label} value={item.value} testId={item.testId} />
                 ))}
               </div>

--- a/src/server/services/__tests__/client-service.test.ts
+++ b/src/server/services/__tests__/client-service.test.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "crypto";
 
 import { prisma } from "@/server/db/client";
+import { decrypt } from "@/server/crypto/key-vault";
 import { createClient, getClientByIdForTenant, rotateClientSecret } from "@/server/services/client-service";
 import { describe, expect, it } from "vitest";
 
@@ -41,6 +42,8 @@ describe("client service", () => {
     });
     expect(stored?.redirectUris).toHaveLength(2);
     expect(stored?.clientSecretHash).toBeTruthy();
+    expect(stored?.clientSecretEncrypted).toBeTruthy();
+    expect(decrypt(stored?.clientSecretEncrypted as string)).toEqual(clientSecret);
   });
 
   it("fetches a client scoped to a tenant", async () => {
@@ -69,5 +72,7 @@ describe("client service", () => {
 
     const updated = await prisma.client.findUnique({ where: { id: client.id } });
     expect(updated?.clientSecretHash).not.toEqual(original?.clientSecretHash);
+    expect(updated?.clientSecretEncrypted).not.toEqual(original?.clientSecretEncrypted);
+    expect(decrypt(updated?.clientSecretEncrypted as string)).toEqual(nextSecret);
   });
 });

--- a/src/server/services/client-service.ts
+++ b/src/server/services/client-service.ts
@@ -3,6 +3,7 @@ import { nanoid } from "nanoid";
 import type { Prisma } from "@/generated/prisma/client";
 import { prisma } from "@/server/db/client";
 import { hashSecret } from "@/server/crypto/hash";
+import { encrypt } from "@/server/crypto/key-vault";
 import { generateOpaqueToken } from "@/server/crypto/opaque-token";
 import { DomainError } from "@/server/errors";
 import { classifyRedirect } from "@/server/oidc/redirect-uri";
@@ -29,10 +30,12 @@ export const createClient = async (
   const clientId = `client_${nanoid(16)}`;
   let clientSecret: string | null = null;
   let clientSecretHash: string | null = null;
+  let clientSecretEncrypted: string | null = null;
 
   if (data.clientType === "CONFIDENTIAL") {
     clientSecret = generateOpaqueToken(24);
     clientSecretHash = await hashSecret(clientSecret);
+    clientSecretEncrypted = encrypt(clientSecret);
   }
 
   const client = await prisma.$transaction(async (tx) => {
@@ -43,6 +46,7 @@ export const createClient = async (
         clientId,
         clientType: data.clientType,
         clientSecretHash,
+        clientSecretEncrypted,
         tokenEndpointAuthMethod: data.clientType === "PUBLIC" ? "none" : "client_secret_basic",
         authStrategies: DEFAULT_CLIENT_AUTH_STRATEGIES,
       },
@@ -132,10 +136,11 @@ export const getClientByIdForTenant = async (tenantId: string, clientInternalId:
 export const rotateClientSecret = async (clientId: string) => {
   const secret = generateOpaqueToken(24);
   const clientSecretHash = await hashSecret(secret);
+  const clientSecretEncrypted = encrypt(secret);
 
   await prisma.client.update({
     where: { id: clientId },
-    data: { clientSecretHash },
+    data: { clientSecretHash, clientSecretEncrypted },
   });
 
   return secret;

--- a/tests/e2e/admin.spec.ts
+++ b/tests/e2e/admin.spec.ts
@@ -84,7 +84,14 @@ test.describe("admin console", () => {
     const requiredLabels = await requiredSection
       .locator("[data-field-label]")
       .evaluateAll((nodes) => nodes.map((node) => node?.getAttribute("data-field-label") ?? ""));
-    expect(requiredLabels).toEqual(["Tenant ID", "Client ID", "Issuer", "Authorization endpoint", "Token endpoint"]);
+    expect(requiredLabels).toEqual([
+      "Tenant ID",
+      "Client ID",
+      "Client secret",
+      "Issuer",
+      "Authorization endpoint",
+      "Token endpoint",
+    ]);
 
     const optionalSection = page.getByTestId("oauth-optional");
     await expect(optionalSection.locator("[data-field-label]").first()).toBeVisible();


### PR DESCRIPTION
## Summary
- store encrypted client secrets so admins can retrieve them after creation
- surface a copyable secret field on confidential client detail pages and include it in bundles
- add coverage for storage, seeding, and admin experience

## Testing
- NODE_OPTIONS=--experimental-require-module pnpm lint
- NODE_OPTIONS=--experimental-require-module pnpm typecheck
- NODE_OPTIONS=--experimental-require-module pnpm test
- Playwright E2E deferred to GitHub Actions (local Chromium deps unstable)

Resolves #65