### PR TITLE
Add rerun CTA for OAuth test

### DIFF
--- a/src/app/admin/actions.ts
+++ b/src/app/admin/actions.ts
@@ -50,6 +50,8 @@ import { resolveRedirectUri } from "@/server/oidc/redirect-uri";
 import { createOauthTestSession } from "@/server/services/oauth-test-service";
 import { setOauthTestSecretCookie } from "@/server/oauth/test-cookie";
 
+const OAUTH_TEST_SESSION_TTL_MINUTES = 15;
+
 const tenantSchema = z.object({
   name: z.string().min(2, "Tenant name must include at least two characters"),
 });
@@ -352,7 +354,7 @@ export const prepareClientOauthTestAction = async (
     const codeChallenge = computeS256Challenge(codeVerifier);
     const state = randomUUID();
     const nonce = randomBytes(16).toString("base64url");
-    const expiresAt = addMinutes(new Date(), 10);
+    const expiresAt = addMinutes(new Date(), OAUTH_TEST_SESSION_TTL_MINUTES);
 
     await createOauthTestSession({
       id: state,

--- a/src/app/admin/clients/[clientId]/test/constants.ts
+++ b/src/app/admin/clients/[clientId]/test/constants.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_TEST_SCOPES = "openid profile email";

--- a/src/app/admin/clients/[clientId]/test/page.tsx
+++ b/src/app/admin/clients/[clientId]/test/page.tsx
@@ -4,6 +4,7 @@ import { getServerSession } from "next-auth";
 
 import { CopyField } from "@/app/admin/_components/copy-field";
 import { TestOAuthConfigurator } from "@/app/admin/clients/[clientId]/test/test-oauth-configurator";
+import { DEFAULT_TEST_SCOPES } from "@/app/admin/clients/[clientId]/test/constants";
 import { authOptions } from "@/server/auth/options";
 import { getAdminTenantContext } from "@/server/services/admin-tenant-context";
 import { getClientByIdForTenant } from "@/server/services/client-service";
@@ -13,8 +14,6 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 
 type PageParams = Promise<{ clientId: string }>;
-
-const DEFAULT_SCOPES = "openid profile email";
 
 export default async function ClientTestOAuthPage({ params }: { params: PageParams }) {
   const session = await getServerSession(authOptions);
@@ -73,7 +72,7 @@ export default async function ClientTestOAuthPage({ params }: { params: PagePara
           </p>
           <TestOAuthConfigurator
             clientId={client.id}
-            defaultScopes={DEFAULT_SCOPES}
+            defaultScopes={DEFAULT_TEST_SCOPES}
             defaultRedirectUri={testRedirectUri}
             canManageRedirects={canManageRedirects}
             redirectAllowed={redirectAllowed}

--- a/src/app/admin/clients/[clientId]/test/redirect/page.tsx
+++ b/src/app/admin/clients/[clientId]/test/redirect/page.tsx
@@ -4,6 +4,8 @@ import { getServerSession } from "next-auth";
 
 import { CopyField } from "@/app/admin/_components/copy-field";
 import { TestSecretCleanup } from "@/app/admin/clients/[clientId]/test/test-secret-cleanup";
+import { TestRunAgainButton } from "@/app/admin/clients/[clientId]/test/test-run-again-button";
+import { DEFAULT_TEST_SCOPES } from "@/app/admin/clients/[clientId]/test/constants";
 import { authOptions } from "@/server/auth/options";
 import { getAdminTenantContext } from "@/server/services/admin-tenant-context";
 import { getClientByIdForTenant } from "@/server/services/client-service";
@@ -28,6 +30,8 @@ type TokenResult = {
 };
 
 type ErrorResult = { status: "error"; message: string; details?: unknown };
+
+const RERUN_HINT = 'Use "Run again" to start a new test.';
 
 const decodeJwtPayload = (token?: unknown) => {
   if (typeof token !== "string") {
@@ -84,6 +88,14 @@ export default async function ClientTestRedirectPage({ params, searchParams }: {
   const cookieSecret = state ? await readOauthTestSecretCookie(client.id, state) : null;
   const sessionRecord = state ? await consumeOauthTestSession(state) : null;
   const now = new Date();
+  let rerunScopes = DEFAULT_TEST_SCOPES;
+  let rerunRedirectUri = testRedirectUri;
+  if (sessionRecord?.scopes?.trim()) {
+    rerunScopes = sessionRecord.scopes;
+  }
+  if (sessionRecord?.redirectUri) {
+    rerunRedirectUri = sessionRecord.redirectUri;
+  }
   let result: TokenResult | ErrorResult;
 
   if (error) {
@@ -92,19 +104,19 @@ export default async function ClientTestRedirectPage({ params, searchParams }: {
       message: `${error}${error_description ? `: ${error_description}` : ""}`,
     };
   } else if (!state) {
-    result = { status: "error", message: "Missing state parameter." };
+    result = { status: "error", message: `Missing state parameter. ${RERUN_HINT}` };
   } else if (!sessionRecord) {
-    result = { status: "error", message: "Test session expired or already used." };
+    result = { status: "error", message: `Test session expired or already used. ${RERUN_HINT}` };
   } else if (sessionRecord.clientId !== client.id) {
     result = { status: "error", message: "State does not belong to this client." };
   } else if (sessionRecord.tenantId !== activeTenant.id) {
     result = { status: "error", message: "State is scoped to a different tenant." };
   } else if (sessionRecord.expiresAt < now) {
-    result = { status: "error", message: "Test session expired. Start a new test." };
+    result = { status: "error", message: `Test session expired. ${RERUN_HINT}` };
   } else if (!code) {
     result = { status: "error", message: "Authorization code missing from redirect." };
   } else if (client.tokenEndpointAuthMethod !== "none" && !cookieSecret) {
-    result = { status: "error", message: "Client secret expired. Start a new test." };
+    result = { status: "error", message: `Client secret expired. ${RERUN_HINT}` };
   } else {
     const exchange = await exchangeAuthorizationCode({
       tokenUrl: urls.token,
@@ -197,9 +209,7 @@ export default async function ClientTestRedirectPage({ params, searchParams }: {
             </div>
           ) : null}
           <div className="flex flex-wrap items-center gap-3">
-            <Button asChild>
-              <Link href={`/admin/clients/${client.id}/test`}>Start another test</Link>
-            </Button>
+            <TestRunAgainButton clientId={client.id} scopes={rerunScopes} redirectUri={rerunRedirectUri} />
             <CopyField label="Test redirect" value={testRedirectUri} />
           </div>
         </CardContent>

--- a/src/app/admin/clients/[clientId]/test/test-run-again-button.tsx
+++ b/src/app/admin/clients/[clientId]/test/test-run-again-button.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+import { prepareClientOauthTestAction } from "@/app/admin/actions";
+import { Button } from "@/components/ui/button";
+import { useToast } from "@/components/ui/use-toast";
+
+type Props = {
+  clientId: string;
+  scopes: string;
+  redirectUri: string;
+};
+
+export function TestRunAgainButton({ clientId, scopes, redirectUri }: Props) {
+  const [pending, startTransition] = useTransition();
+  const router = useRouter();
+  const { toast } = useToast();
+
+  const handleClick = () => {
+    startTransition(async () => {
+      try {
+        const result = await prepareClientOauthTestAction({ clientId, scopes, redirectUri });
+        if (result.error || !result.data) {
+          toast({
+            variant: "destructive",
+            title: "Unable to restart test",
+            description: result.error ?? "Something went wrong",
+          });
+          return;
+        }
+        router.push(result.data.authorizationUrl);
+      } catch (error) {
+        const description = error instanceof Error ? error.message : "Unknown error";
+        toast({ variant: "destructive", title: "Unable to restart test", description });
+        return;
+      }
+    });
+  };
+
+  return (
+    <Button type="button" onClick={handleClick} disabled={pending} data-testid="test-oauth-run-again">
+      {pending ? "Starting..." : "Run again"}
+    </Button>
+  );
+}

--- a/src/app/admin/clients/__tests__/test-run-again-button.test.tsx
+++ b/src/app/admin/clients/__tests__/test-run-again-button.test.tsx
@@ -1,0 +1,81 @@
+/* @vitest-environment jsdom */
+
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { TestRunAgainButton } from "../[clientId]/test/test-run-again-button";
+
+const mockPrepare = vi.hoisted(() => vi.fn().mockResolvedValue({ data: { authorizationUrl: "https://auth.example.test" } }));
+const mockToast = vi.hoisted(() => vi.fn());
+const mockPush = vi.hoisted(() => vi.fn());
+
+vi.mock("@/app/admin/actions", () => ({
+  prepareClientOauthTestAction: mockPrepare,
+}));
+
+vi.mock("@/components/ui/use-toast", () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+describe("TestRunAgainButton", () => {
+  beforeEach(() => {
+    mockPrepare.mockClear();
+    mockToast.mockClear();
+    mockPush.mockClear();
+  });
+
+  it("restarts the OAuth test using prior settings", async () => {
+    const user = userEvent.setup();
+    render(<TestRunAgainButton clientId="client_123" scopes="openid" redirectUri="https://admin.example.test/callback" />);
+
+    await user.click(screen.getByTestId("test-oauth-run-again"));
+
+    await waitFor(() => {
+      expect(mockPrepare).toHaveBeenCalledWith({
+        clientId: "client_123",
+        scopes: "openid",
+        redirectUri: "https://admin.example.test/callback",
+      });
+      expect(mockPush).toHaveBeenCalledWith("https://auth.example.test");
+    });
+  });
+
+  it("surfaces action errors via toast", async () => {
+    mockPrepare.mockResolvedValueOnce({ error: "Client missing" });
+    const user = userEvent.setup();
+    render(<TestRunAgainButton clientId="client_123" scopes="openid" redirectUri="https://admin.example.test/callback" />);
+
+    await user.click(screen.getByTestId("test-oauth-run-again"));
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith({
+        variant: "destructive",
+        title: "Unable to restart test",
+        description: "Client missing",
+      });
+      expect(mockPush).not.toHaveBeenCalled();
+    });
+  });
+
+  it("handles thrown errors", async () => {
+    mockPrepare.mockRejectedValueOnce(new Error("Network down"));
+    const user = userEvent.setup();
+    render(<TestRunAgainButton clientId="client_123" scopes="openid" redirectUri="https://admin.example.test/callback" />);
+
+    await user.click(screen.getByTestId("test-oauth-run-again"));
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith({
+        variant: "destructive",
+        title: "Unable to restart test",
+        description: "Network down",
+      });
+      expect(mockPush).not.toHaveBeenCalled();
+    });
+  });
+});
+

--- a/src/server/oauth/test-cookie.ts
+++ b/src/server/oauth/test-cookie.ts
@@ -3,7 +3,7 @@ import { cookies } from "next/headers";
 import { env } from "@/server/env";
 
 const COOKIE_PREFIX = "oauth-test-secret";
-const COOKIE_TTL_SECONDS = 60 * 10;
+const COOKIE_TTL_SECONDS = 60 * 15;
 
 export const buildTestSecretCookieName = (state: string) => `${COOKIE_PREFIX}-${state}`;
 export const buildTestSecretCookiePath = (clientId: string) => `/admin/clients/${clientId}/test/redirect`;

--- a/tests/e2e/test-oauth-flow.spec.ts
+++ b/tests/e2e/test-oauth-flow.spec.ts
@@ -12,23 +12,21 @@ test.describe("Client Test OAuth", () => {
 
     const clientId = await openClientDetail(page, QA_TENANT_ID, QA_CLIENT_NAME);
 
-    await page.getByTestId("test-oauth-link").click();
-    const warning = page.getByTestId("test-oauth-warning");
-    await expect(warning).toBeVisible();
-    await page.getByTestId("test-oauth-add-redirect").click();
-    await expect(warning).toHaveCount(0);
-
-    await expect(page.getByTestId("test-oauth-secret-info")).toContainText("stored client secret is applied automatically");
-    await page.getByTestId("test-oauth-start").click();
-
-    await page.waitForURL(/\/r\/.*\/oidc\/login/);
-    await page.getByRole("textbox", { name: /^Username/ }).fill("qa-user");
-    await page.getByRole("button", { name: "Continue" }).click();
-
-    await page.waitForURL(new RegExp(`/admin/clients/${clientId}/test/redirect`));
+    await startOauthTest(page, clientId);
     await expect(page.getByTestId("test-oauth-id-token")).toBeVisible();
     await expect(page.getByTestId("test-oauth-access-token")).toBeVisible();
     await expect(page.getByTestId("test-oauth-decoded-id")).toContainText("\"sub\"");
+
+    const firstState = (await page.getByTestId("test-oauth-state").textContent())?.trim();
+    await page.getByTestId("test-oauth-run-again").click();
+    await completeProviderLogin(page, clientId);
+
+    const secondState = (await page.getByTestId("test-oauth-state").textContent())?.trim();
+    await expect(page.getByTestId("test-oauth-id-token")).toBeVisible();
+    await expect(page.getByTestId("test-oauth-access-token")).toBeVisible();
+    expect(firstState).toBeTruthy();
+    expect(secondState).toBeTruthy();
+    expect(secondState).not.toEqual(firstState);
   });
 
   test("surfaces authorization errors on the redirect page", async ({ page }) => {
@@ -42,6 +40,29 @@ test.describe("Client Test OAuth", () => {
     );
 
     await expect(page.getByTestId("test-oauth-error")).toContainText("access_denied: Denied");
+  });
+
+  test("prompts to rerun when the session is expired", async ({ page }) => {
+    const sessionToken = await createTestSession(page, { tenantId: QA_TENANT_ID, role: "OWNER" });
+    await authenticate(page, sessionToken);
+
+    const clientId = await openClientDetail(page, QA_TENANT_ID, QA_CLIENT_NAME);
+
+    await startOauthTest(page, clientId);
+    await expect(page.getByTestId("test-oauth-id-token")).toBeVisible();
+    const expiredUrl = page.url();
+
+    await page.goto(`/admin/clients/${clientId}/test`);
+    await page.goto(expiredUrl);
+
+    const errorAlert = page.getByTestId("test-oauth-error");
+    await expect(errorAlert).toContainText("Test session expired or already used.");
+    await expect(errorAlert).toContainText("Run again");
+
+    await page.getByTestId("test-oauth-run-again").click();
+    await completeProviderLogin(page, clientId);
+
+    await expect(page.getByTestId("test-oauth-id-token")).toBeVisible();
   });
 });
 
@@ -62,4 +83,29 @@ const selectTenant = async (page: Page, tenantId: string) => {
   const option = page.getByTestId(`tenant-option-${tenantId}`);
   await expect(option).toBeVisible();
   await option.click();
+};
+
+const startOauthTest = async (page: Page, clientId: string) => {
+  await page.getByTestId("test-oauth-link").click();
+  await addTestRedirectIfNeeded(page);
+  await expect(page.getByTestId("test-oauth-secret-info")).toContainText("stored client secret is applied automatically");
+  await page.getByTestId("test-oauth-start").click();
+  await completeProviderLogin(page, clientId);
+};
+
+const addTestRedirectIfNeeded = async (page: Page) => {
+  const warning = page.getByTestId("test-oauth-warning");
+  if ((await warning.count()) === 0) {
+    return;
+  }
+  await expect(warning).toBeVisible();
+  await page.getByTestId("test-oauth-add-redirect").click();
+  await expect(warning).toHaveCount(0);
+};
+
+const completeProviderLogin = async (page: Page, clientId: string) => {
+  await page.waitForURL(/\/r\/.*\/oidc\/login/);
+  await page.getByRole("textbox", { name: /^Username/ }).fill("qa-user");
+  await page.getByRole("button", { name: "Continue" }).click();
+  await page.waitForURL(new RegExp(`/admin/clients/${clientId}/test/redirect`));
 };


### PR DESCRIPTION
## Summary
- add shared defaults and rerun CTA on OAuth test redirect
- extend test-session TTL and surface rerun guidance for expired flows
- expand Playwright coverage for reruns and session expiry

## Testing
- NODE_OPTIONS=--experimental-require-module pnpm lint
- NODE_OPTIONS=--experimental-require-module pnpm typecheck
- NODE_OPTIONS=--experimental-require-module pnpm test
- Playwright E2E deferred to GitHub Actions (Chromium still missing libglib/libdbus locally)

Closes #67