### PR TITLE
Fix: force fresh login on authorize

### DIFF
--- a/src/app/r/[apiResourceId]/oidc/authorize/route.ts
+++ b/src/app/r/[apiResourceId]/oidc/authorize/route.ts
@@ -1,4 +1,4 @@
-import type { NextRequest } from "next/server";
+import { NextResponse, type NextRequest } from "next/server";
 import { z } from "zod";
 
 import { toResponse } from "@/server/errors";
@@ -6,6 +6,7 @@ import { handleAuthorize } from "@/server/services/authorize-service";
 import { MOCK_SESSION_COOKIE } from "@/server/services/mock-session-service";
 import { resolveUrl } from "@/server/http/origin";
 import type { ApiResourceRouteContext } from "@/types/api-resource-route";
+import { buildReauthCookiePath, MOCK_REAUTH_COOKIE } from "@/server/oidc/reauth-cookie";
 
 const authorizeSchema = z.object({
   client_id: z.string().min(1),
@@ -14,7 +15,7 @@ const authorizeSchema = z.object({
   scope: z.string().min(1),
   state: z.string().optional(),
   nonce: z.string().optional(),
-  prompt: z.enum(["login"]).optional(),
+  prompt: z.enum(["login", "none"]).optional(),
   code_challenge: z.string().min(43).max(128),
   code_challenge_method: z.string().default("S256"),
 });
@@ -22,6 +23,7 @@ const authorizeSchema = z.object({
 export async function GET(request: NextRequest, context: ApiResourceRouteContext) {
   const normalizedUrl = resolveUrl(request);
   const origin = normalizedUrl.origin;
+  const isSecure = normalizedUrl.protocol === "https:";
   const validation = authorizeSchema.safeParse(Object.fromEntries(normalizedUrl.searchParams.entries()));
 
   if (!validation.success) {
@@ -31,6 +33,8 @@ export async function GET(request: NextRequest, context: ApiResourceRouteContext
   try {
     const { apiResourceId } = await context.params;
     const sessionToken = request.cookies.get(MOCK_SESSION_COOKIE)?.value;
+    const reauthCookie = request.cookies.get(MOCK_REAUTH_COOKIE)?.value;
+    const reauthenticated = Boolean(sessionToken && reauthCookie && sessionToken === reauthCookie);
     const result = await handleAuthorize(
       {
         apiResourceId,
@@ -44,16 +48,30 @@ export async function GET(request: NextRequest, context: ApiResourceRouteContext
         codeChallengeMethod: validation.data.code_challenge_method,
         prompt: validation.data.prompt,
         sessionToken,
+        reauthenticated,
       },
       origin,
       normalizedUrl.toString(),
     );
 
-    if (result.type === "login") {
-      return Response.redirect(new URL(result.redirectTo, origin));
+    const response =
+      result.type === "login"
+        ? NextResponse.redirect(new URL(result.redirectTo, origin))
+        : NextResponse.redirect(result.redirectTo);
+
+    if (reauthenticated) {
+      response.cookies.set({
+        name: MOCK_REAUTH_COOKIE,
+        value: "",
+        path: buildReauthCookiePath(apiResourceId),
+        httpOnly: true,
+        sameSite: "lax",
+        secure: isSecure,
+        maxAge: 0,
+      });
     }
 
-    return Response.redirect(result.redirectTo);
+    return response;
   } catch (error) {
     return toResponse(error);
   }

--- a/src/app/r/[apiResourceId]/oidc/login/submit/route.ts
+++ b/src/app/r/[apiResourceId]/oidc/login/submit/route.ts
@@ -16,6 +16,7 @@ import {
 import type { ClientAuthStrategies } from "@/server/oidc/auth-strategy";
 import { getApiResourceWithTenant } from "@/server/services/api-resource-service";
 import { resolveStableSubject } from "@/server/services/mock-identity-service";
+import { buildReauthCookiePath, MOCK_REAUTH_COOKIE, REAUTH_COOKIE_TTL_SECONDS } from "@/server/oidc/reauth-cookie";
 
 const loginSchema = z.object({
   strategy: z.enum(["username", "email"]).default("username"),
@@ -124,6 +125,15 @@ export async function POST(request: NextRequest, context: ApiResourceRouteContex
       sameSite: "lax",
       secure: isSecure,
       maxAge: 60 * 60 * 12,
+    });
+    response.cookies.set({
+      name: MOCK_REAUTH_COOKIE,
+      value: token,
+      path: buildReauthCookiePath(resource.id),
+      httpOnly: true,
+      sameSite: "lax",
+      secure: isSecure,
+      maxAge: REAUTH_COOKIE_TTL_SECONDS,
     });
     return response;
   } catch (error) {

--- a/src/server/oidc/__tests__/oidc-flow.test.ts
+++ b/src/server/oidc/__tests__/oidc-flow.test.ts
@@ -59,6 +59,7 @@ describe("OIDC flow", () => {
         codeChallenge: challenge,
         codeChallengeMethod: "S256",
         sessionToken,
+        reauthenticated: true,
       },
       "https://mockauth.test",
       `https://mockauth.test/r/${apiResourceId}/oidc/authorize?client_id=qa-client`,
@@ -87,6 +88,82 @@ describe("OIDC flow", () => {
     expect(idToken.sub).toBe("demo");
     expect(idToken.preferred_username).toBe("demo");
     expect(idToken.email).toBeUndefined();
+  });
+
+  it("requires an explicit login step before issuing codes", async () => {
+    const challenge = computeS256Challenge(codeVerifier);
+    const returnTo = `https://mockauth.test/r/${apiResourceId}/oidc/authorize?client_id=qa-client`;
+    const authorize = await handleAuthorize(
+      {
+        apiResourceId,
+        clientId: "qa-client",
+        redirectUri: "https://client.example.test/callback",
+        responseType: "code",
+        scope: "openid profile email",
+        codeChallenge: challenge,
+        codeChallengeMethod: "S256",
+        sessionToken,
+        reauthenticated: false,
+      },
+      "https://mockauth.test",
+      returnTo,
+    );
+
+    expect(authorize.type).toBe("login");
+    expect(authorize.redirectTo).toContain("return_to=");
+    expect(decodeURIComponent(authorize.redirectTo.split("return_to=")[1]!)).toBe(returnTo);
+  });
+
+  it("does not trust reauth query parameters without the cookie handshake", async () => {
+    const challenge = computeS256Challenge(codeVerifier);
+    const forgedReturnTo = new URL(
+      `https://mockauth.test/r/${apiResourceId}/oidc/authorize?client_id=qa-client&state=manual`,
+    );
+    forgedReturnTo.searchParams.set("reauth", "1");
+    const authorize = await handleAuthorize(
+      {
+        apiResourceId,
+        clientId: "qa-client",
+        redirectUri: "https://client.example.test/callback",
+        responseType: "code",
+        scope: "openid profile email",
+        codeChallenge: challenge,
+        codeChallengeMethod: "S256",
+        sessionToken,
+        reauthenticated: false,
+      },
+      "https://mockauth.test",
+      forgedReturnTo.toString(),
+    );
+
+    expect(authorize.type).toBe("login");
+    const decodedReturn = decodeURIComponent(authorize.redirectTo.split("return_to=")[1]!);
+    expect(decodedReturn).toBe(forgedReturnTo.toString());
+  });
+
+  it("redirects with login_required when prompt=none", async () => {
+    const challenge = computeS256Challenge(codeVerifier);
+    const authorize = await handleAuthorize(
+      {
+        apiResourceId,
+        clientId: "qa-client",
+        redirectUri: "https://client.example.test/callback",
+        responseType: "code",
+        scope: "openid profile",
+        state: "prompt-none",
+        codeChallenge: challenge,
+        codeChallengeMethod: "S256",
+        prompt: "none",
+      },
+      "https://mockauth.test",
+      `https://mockauth.test/r/${apiResourceId}/oidc/authorize?client_id=qa-client`,
+    );
+
+    expect(authorize.type).toBe("redirect");
+    const redirected = new URL(authorize.redirectTo);
+    expect(redirected.origin).toBe("https://client.example.test");
+    expect(redirected.searchParams.get("error")).toBe("login_required");
+    expect(redirected.searchParams.get("state")).toBe("prompt-none");
   });
 
   it("issues email-specific claims when email strategy is enabled", async () => {
@@ -125,6 +202,7 @@ describe("OIDC flow", () => {
         codeChallenge: challenge,
         codeChallengeMethod: "S256",
         sessionToken: emailSessionToken,
+        reauthenticated: true,
       },
       "https://mockauth.test",
       `https://mockauth.test/r/${apiResourceId}/oidc/authorize?client_id=qa-client`,
@@ -188,6 +266,7 @@ describe("OIDC flow", () => {
         codeChallenge: challenge,
         codeChallengeMethod: "S256",
         sessionToken: sessionTokenOverride,
+        reauthenticated: true,
       },
       "https://mockauth.test",
       `https://mockauth.test/r/${apiResourceId}/oidc/authorize?client_id=qa-client`,
@@ -242,6 +321,7 @@ describe("OIDC flow", () => {
         codeChallenge: computeS256Challenge(codeVerifier),
         codeChallengeMethod: "S256",
         sessionToken: verifiedSession,
+        reauthenticated: true,
       },
       "https://mockauth.test",
       `https://mockauth.test/r/${apiResourceId}/oidc/authorize?client_id=qa-client`,
@@ -293,6 +373,7 @@ describe("OIDC flow", () => {
           codeChallenge: computeS256Challenge(codeVerifier),
           codeChallengeMethod: "S256",
           sessionToken: sessionTokenChoice,
+          reauthenticated: true,
         },
         "https://mockauth.test",
         `https://mockauth.test/r/${apiResourceId}/oidc/authorize?client_id=qa-client`,

--- a/src/server/oidc/reauth-cookie.ts
+++ b/src/server/oidc/reauth-cookie.ts
@@ -1,0 +1,4 @@
+export const MOCK_REAUTH_COOKIE = "mockauth_reauth_ok" as const;
+export const REAUTH_COOKIE_TTL_SECONDS = 60;
+
+export const buildReauthCookiePath = (apiResourceId: string) => `/r/${apiResourceId}/oidc`;

--- a/src/server/services/authorize-service.ts
+++ b/src/server/services/authorize-service.ts
@@ -18,6 +18,7 @@ type AuthorizeParams = {
   codeChallengeMethod: string;
   prompt?: string;
   sessionToken?: string;
+  reauthenticated?: boolean;
 };
 
 const ensureScopes = (requested: string[], allowed: string[]) => {
@@ -50,17 +51,28 @@ export const handleAuthorize = async (params: AuthorizeParams, origin: string, r
 
   ensureScopes(params.scope.split(" ").filter(Boolean), client.allowedScopes);
 
+  if (params.prompt === "none") {
+    const redirectUrl = new URL(redirect);
+    redirectUrl.searchParams.set("error", "login_required");
+    if (params.state) {
+      redirectUrl.searchParams.set("state", params.state);
+    }
+    return { type: "redirect" as const, redirectTo: redirectUrl.toString() };
+  }
+
   const strategies = parseClientAuthStrategies(client.authStrategies);
-  const session = await getSessionUser(tenant.id, params.sessionToken);
+  const session = params.reauthenticated ? await getSessionUser(tenant.id, params.sessionToken) : null;
   const strategyAllowed = session
     ? strategies[fromPrismaLoginStrategy(session.loginStrategy)]?.enabled ?? false
-    : true;
-  const shouldLogin = params.prompt === "login" || !session || !strategyAllowed;
+    : false;
+  const mustPrompt = params.prompt === "login" && !params.reauthenticated;
+  const shouldLogin = !params.reauthenticated || mustPrompt || !session || !strategyAllowed;
 
   if (shouldLogin) {
+    const loginReturnUrl = new URL(returnTo);
     return {
       type: "login" as const,
-      redirectTo: `/r/${resource.id}/oidc/login?return_to=${encodeURIComponent(returnTo)}`,
+      redirectTo: `/r/${resource.id}/oidc/login?return_to=${encodeURIComponent(loginReturnUrl.toString())}`,
     };
   }
 

--- a/tests/e2e/test-oauth-flow.spec.ts
+++ b/tests/e2e/test-oauth-flow.spec.ts
@@ -29,6 +29,34 @@ test.describe("Client Test OAuth", () => {
     expect(secondState).not.toEqual(firstState);
   });
 
+  test("requires a new login even when a previous session exists", async ({ page }) => {
+    const sessionToken = await createTestSession(page, { tenantId: QA_TENANT_ID, role: "OWNER" });
+    await authenticate(page, sessionToken);
+
+    const clientId = await openClientDetail(page, QA_TENANT_ID, QA_CLIENT_NAME);
+
+    await completeRunAndReturnToConfigurator(page, clientId);
+
+    const { authorizationUrl } = await startOauthTest(page, clientId, { skipOpen: true, fromConfigPage: true });
+    await page.goto(authorizationUrl);
+    await expect(page).toHaveURL(/\/r\/.*\/oidc\/login/);
+  });
+
+  test("ignores manual reauth query parameters on subsequent authorizations", async ({ page }) => {
+    const sessionToken = await createTestSession(page, { tenantId: QA_TENANT_ID, role: "OWNER" });
+    await authenticate(page, sessionToken);
+
+    const clientId = await openClientDetail(page, QA_TENANT_ID, QA_CLIENT_NAME);
+
+    await completeRunAndReturnToConfigurator(page, clientId);
+
+    const { authorizationUrl } = await startOauthTest(page, clientId, { skipOpen: true, fromConfigPage: true });
+    const bypassUrl = new URL(authorizationUrl);
+    bypassUrl.searchParams.set("reauth", "1");
+    await page.goto(bypassUrl.toString());
+    await expect(page).toHaveURL(/\/r\/.*\/oidc\/login/);
+  });
+
   test("runs two Test OAuth sessions back-to-back from the configurator", async ({ page }) => {
     const sessionToken = await createTestSession(page, { tenantId: QA_TENANT_ID, role: "OWNER" });
     await authenticate(page, sessionToken);
@@ -72,6 +100,20 @@ test.describe("Client Test OAuth", () => {
     await loginNavigation;
     await completeProviderLogin(page, clientId);
     await expect(page.getByTestId("test-oauth-id-token")).toBeVisible();
+  });
+
+  test("returns login_required when prompt=none", async ({ page }) => {
+    const sessionToken = await createTestSession(page, { tenantId: QA_TENANT_ID, role: "OWNER" });
+    await authenticate(page, sessionToken);
+
+    const clientId = await openClientDetail(page, QA_TENANT_ID, QA_CLIENT_NAME);
+    const { authorizationUrl } = await startOauthTest(page, clientId, { skipOpen: true });
+    const silentUrl = new URL(authorizationUrl);
+    silentUrl.searchParams.set("prompt", "none");
+    await page.goto(silentUrl.toString());
+
+    await expect(page).toHaveURL(new RegExp(`/admin/clients/${clientId}/test/redirect`));
+    await expect(page.getByTestId("test-oauth-error")).toContainText("login_required");
   });
 
   test("surfaces authorization errors on the redirect page", async ({ page }) => {
@@ -130,6 +172,13 @@ test.describe("Client Test OAuth", () => {
     await expect(page.getByTestId("test-oauth-access-token")).toBeVisible();
   });
 });
+
+const completeRunAndReturnToConfigurator = async (page: Page, clientId: string) => {
+  await startOauthTest(page, clientId);
+  await expect(page.getByTestId("test-oauth-id-token")).toBeVisible();
+  await page.getByRole("link", { name: "← Back to test config" }).click();
+  await expect(page).toHaveURL(new RegExp(`/admin/clients/${clientId}/test`));
+};
 
 const openClientDetail = async (page: Page, tenantId: string, clientName: string) => {
   await page.goto("/admin/clients");


### PR DESCRIPTION
## Summary
- make the authorize handler ignore stale end-user sessions, requiring a fresh login hop that carries a reauth flag
- respond to `prompt=none` with `error=login_required` redirects and extend integration + Playwright coverage
- add E2E protection to ensure every authorization request still lands on the login screen even if a session already exists

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test

Closes #75