### PR TITLE
Feat: add strategy tabs to login

### DIFF
--- a/src/app/r/[apiResourceId]/oidc/login/__tests__/login-form.test.tsx
+++ b/src/app/r/[apiResourceId]/oidc/login/__tests__/login-form.test.tsx
@@ -1,0 +1,62 @@
+/* @vitest-environment jsdom */
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { LoginForm } from "../login-form";
+
+const baseProps = {
+  apiResourceId: "resource_123",
+  returnTo: "https://mockauth.test/r/resource_123/oidc/authorize?client_id=qa-client",
+};
+
+const multiStrategyConfig = [
+  {
+    key: "username" as const,
+    title: "Username",
+    description: "Enter any username",
+    placeholder: "qa-user",
+    subSource: "entered",
+  },
+  {
+    key: "email" as const,
+    title: "Email",
+    description: "Enter any email",
+    placeholder: "qa@example.test",
+    subSource: "entered",
+    emailVerifiedMode: "user_choice" as const,
+  },
+];
+
+describe("LoginForm", () => {
+  it("renders tabs and toggles the active strategy", async () => {
+    const user = userEvent.setup();
+    render(<LoginForm {...baseProps} strategies={multiStrategyConfig} />);
+
+    const strategyInput = screen.getByTestId("login-strategy-input") as HTMLInputElement;
+    expect(strategyInput.value).toBe("username");
+
+    const usernameTab = screen.getByRole("tab", { name: "Username" });
+    const emailTab = screen.getByRole("tab", { name: "Email" });
+    await user.click(emailTab);
+    expect(strategyInput.value).toBe("email");
+
+    const emailField = screen.getByTestId("login-email-input") as HTMLInputElement;
+    expect(emailField).toBeEnabled();
+    expect(screen.queryByTestId("login-username-input")).not.toBeInTheDocument();
+
+    const unverifiedOption = screen.getByLabelText("Unverified");
+    await user.click(unverifiedOption);
+    expect(unverifiedOption).toBeChecked();
+
+    await user.click(usernameTab);
+    expect(screen.getByTestId("login-username-input")).toBeEnabled();
+  });
+
+  it("omits tabs when only a single strategy is available", () => {
+    render(<LoginForm {...baseProps} strategies={[multiStrategyConfig[0]!]} />);
+
+    expect(screen.queryByTestId("login-strategy-tabs")).not.toBeInTheDocument();
+    expect(screen.getByTestId("login-username-input")).toBeEnabled();
+  });
+});

--- a/src/app/r/[apiResourceId]/oidc/login/login-form.tsx
+++ b/src/app/r/[apiResourceId]/oidc/login/login-form.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 
 import type { EmailVerifiedMode } from "@/server/oidc/auth-strategy";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 type StrategyOption = {
   key: "username" | "email";
@@ -23,95 +24,92 @@ export function LoginForm({ apiResourceId, returnTo, strategies }: LoginFormProp
   const [selectedStrategy, setSelectedStrategy] = useState<"username" | "email">(strategies[0]?.key ?? "username");
   const [emailVerifiedPreference, setEmailVerifiedPreference] = useState<"true" | "false">("true");
 
+  const renderStrategyFields = (option: StrategyOption, isActive: boolean) => {
+    const inputName = option.key === "username" ? "username" : "email";
+    const inputType = option.key === "email" ? "email" : "text";
+    return (
+      <div key={option.key} className="space-y-4">
+        <label className="space-y-2 block text-sm">
+          <span className="text-slate-200 flex items-center justify-between">
+            {option.title}
+            <span className="text-[0.7rem] uppercase text-slate-400">
+              {option.subSource === "entered" ? "Sub: entered" : "Sub: uuid"}
+            </span>
+          </span>
+          <p className="text-xs text-slate-400">{option.description}</p>
+          <input
+            type={inputType}
+            name={inputName}
+            required={isActive}
+            disabled={!isActive}
+            autoComplete="off"
+            className="w-full rounded-lg border border-slate-700 bg-slate-950/40 px-3 py-2 text-base focus:outline-none focus:ring-2 focus:ring-amber-400 disabled:cursor-not-allowed disabled:opacity-70"
+            placeholder={option.placeholder}
+            data-testid={`login-${option.key}-input`}
+          />
+        </label>
+        {option.key === "email" && option.emailVerifiedMode === "user_choice" ? (
+          <fieldset className="space-y-2" disabled={!isActive}>
+            <legend className="text-xs font-semibold uppercase text-slate-400">Email verified flag</legend>
+            <div className="grid gap-2 sm:grid-cols-2">
+              <label className="flex items-center gap-2 text-xs text-slate-200">
+                <input
+                  type="radio"
+                  name="email_verified_preference"
+                  value="true"
+                  checked={emailVerifiedPreference === "true"}
+                  onChange={() => setEmailVerifiedPreference("true")}
+                  disabled={!isActive}
+                  className="h-4 w-4"
+                />
+                Verified
+              </label>
+              <label className="flex items-center gap-2 text-xs text-slate-200">
+                <input
+                  type="radio"
+                  name="email_verified_preference"
+                  value="false"
+                  checked={emailVerifiedPreference === "false"}
+                  onChange={() => setEmailVerifiedPreference("false")}
+                  disabled={!isActive}
+                  className="h-4 w-4"
+                />
+                Unverified
+              </label>
+            </div>
+            <p className="text-[0.7rem] text-slate-400">Choose how the email_verified claim should appear for this login.</p>
+          </fieldset>
+        ) : null}
+      </div>
+    );
+  };
+
   return (
     <form method="POST" action={`/r/${apiResourceId}/oidc/login/submit`} className="space-y-4">
-      <input type="hidden" name="strategy" value={selectedStrategy} />
+      <input type="hidden" name="strategy" value={selectedStrategy} data-testid="login-strategy-input" />
       <input type="hidden" name="return_to" value={returnTo} />
       {strategies.length > 1 ? (
-        <div className="space-y-2" role="radiogroup" aria-label="Authentication strategy">
-          <p className="text-xs font-semibold uppercase text-muted-foreground">Choose a strategy</p>
-          <div className="grid gap-3 sm:grid-cols-2">
+        <Tabs
+          value={selectedStrategy}
+          onValueChange={(value) => setSelectedStrategy(value as "username" | "email")}
+          className="space-y-4"
+        >
+          <TabsList className="grid w-full grid-cols-2" data-testid="login-strategy-tabs">
             {strategies.map((option) => (
-              <label
-                key={option.key}
-                className={`cursor-pointer rounded-md border p-3 text-sm transition ${
-                  selectedStrategy === option.key ? "border-amber-400 bg-amber-50 text-slate-900" : "border-slate-800"
-                }`}
-              >
-                <div className="flex items-center gap-2">
-                  <input
-                    type="radio"
-                    name="strategy-choice"
-                    value={option.key}
-                    checked={selectedStrategy === option.key}
-                    onChange={() => setSelectedStrategy(option.key)}
-                    className="h-4 w-4"
-                  />
-                  <span className="font-semibold">{option.title}</span>
-                </div>
-                <p className="mt-1 text-xs">
-                  {option.description}
-                </p>
-              </label>
+              <TabsTrigger key={option.key} value={option.key} className="data-[state=active]:bg-amber-50 data-[state=active]:text-slate-900">
+                {option.title}
+              </TabsTrigger>
             ))}
-          </div>
-        </div>
-      ) : null}
-
-      {strategies.map((option) => {
-        const isActive = option.key === selectedStrategy;
-        const inputName = option.key === "username" ? "username" : "email";
-        const inputType = option.key === "email" ? "email" : "text";
-        return (
-          <label key={option.key} className={`space-y-2 block text-sm ${isActive ? "" : "opacity-60"}`}>
-            <span className="text-slate-200 flex items-center justify-between">
-              {option.title}
-              <span className="text-[0.7rem] uppercase text-slate-400">{option.subSource === "entered" ? "Sub: entered" : "Sub: uuid"}</span>
-            </span>
-            <input
-              type={inputType}
-              name={inputName}
-              required={isActive}
-              disabled={!isActive}
-              autoComplete="off"
-              className="w-full rounded-lg border border-slate-700 bg-slate-950/40 px-3 py-2 text-base focus:outline-none focus:ring-2 focus:ring-amber-400 disabled:cursor-not-allowed disabled:opacity-70"
-              placeholder={option.placeholder}
-            />
-            {option.key === "email" && option.emailVerifiedMode === "user_choice" ? (
-              <fieldset className="space-y-2" disabled={!isActive}>
-                <legend className="text-xs font-semibold uppercase text-slate-400">Email verified flag</legend>
-                <div className="grid gap-2 sm:grid-cols-2">
-                  <label className="flex items-center gap-2 text-xs text-slate-200">
-                    <input
-                      type="radio"
-                      name="email_verified_preference"
-                      value="true"
-                      checked={emailVerifiedPreference === "true"}
-                      onChange={() => setEmailVerifiedPreference("true")}
-                      disabled={!isActive}
-                      className="h-4 w-4"
-                    />
-                    Verified
-                  </label>
-                  <label className="flex items-center gap-2 text-xs text-slate-200">
-                    <input
-                      type="radio"
-                      name="email_verified_preference"
-                      value="false"
-                      checked={emailVerifiedPreference === "false"}
-                      onChange={() => setEmailVerifiedPreference("false")}
-                      disabled={!isActive}
-                      className="h-4 w-4"
-                    />
-                    Unverified
-                  </label>
-                </div>
-                <p className="text-[0.7rem] text-slate-400">Choose how the email_verified claim should appear for this login.</p>
-              </fieldset>
-            ) : null}
-          </label>
-        );
-      })}
+          </TabsList>
+          {strategies.map((option) => (
+            <TabsContent key={option.key} value={option.key} className="space-y-4">
+              {renderStrategyFields(option, selectedStrategy === option.key)}
+            </TabsContent>
+          ))}
+        </Tabs>
+      ) : (
+        renderStrategyFields(strategies[0]!, true)
+      )}
 
       <button
         type="submit"

--- a/tests/e2e/test-oauth-flow.spec.ts
+++ b/tests/e2e/test-oauth-flow.spec.ts
@@ -4,6 +4,7 @@ import { authenticate, createTestSession } from "./helpers/admin";
 
 const QA_TENANT_ID = "tenant_qa";
 const QA_CLIENT_NAME = "QA Client";
+const QA_CLIENT_ID = "qa-client";
 
 test.describe("Client Test OAuth", () => {
   test("runs the guided OAuth test flow", async ({ page }) => {
@@ -129,6 +130,36 @@ test.describe("Client Test OAuth", () => {
     await expect(page.getByTestId("test-oauth-id-token")).toBeVisible();
     await expect(page.getByTestId("test-oauth-access-token")).toBeVisible();
   });
+
+  test("shows tabs for multiple login strategies", async ({ page }) => {
+    const sessionToken = await createTestSession(page, { tenantId: QA_TENANT_ID, role: "OWNER" });
+    await authenticate(page, sessionToken);
+
+    await updateClientAuthStrategies(page, {
+      username: { enabled: true, subSource: "entered" },
+      email: { enabled: true, subSource: "entered", emailVerifiedMode: "user_choice" },
+    });
+
+    try {
+      const clientId = await openClientDetail(page, QA_TENANT_ID, QA_CLIENT_NAME);
+      const { authorizationUrl } = await startOauthTest(page, clientId, { skipOpen: true });
+      await page.goto(authorizationUrl);
+
+      await expect(page.getByTestId("login-strategy-tabs")).toBeVisible();
+      await page.getByRole("tab", { name: "Email" }).click();
+      await page.getByRole("textbox", { name: /^Email/ }).fill("tab-user@example.test");
+      await page.getByLabel("Unverified").click();
+      await page.getByRole("button", { name: "Continue" }).click();
+
+      await page.waitForURL(new RegExp(`/admin/clients/${clientId}/test/redirect`));
+      await expect(page.getByTestId("test-oauth-decoded-id")).toContainText("tab-user@example.test");
+    } finally {
+      await updateClientAuthStrategies(page, {
+        username: { enabled: true, subSource: "entered" },
+        email: { enabled: false, subSource: "entered", emailVerifiedMode: "false" },
+      });
+    }
+  });
 });
 
 const openClientDetail = async (page: Page, tenantId: string, clientName: string) => {
@@ -148,6 +179,18 @@ const selectTenant = async (page: Page, tenantId: string) => {
   const option = page.getByTestId(`tenant-option-${tenantId}`);
   await expect(option).toBeVisible();
   await option.click();
+};
+
+const updateClientAuthStrategies = async (
+  page: Page,
+  strategies: {
+    username: { enabled: boolean; subSource: string };
+    email: { enabled: boolean; subSource: string; emailVerifiedMode: string };
+  },
+) => {
+  await page.request.post("/api/test/client-auth-strategies", {
+    data: { tenantId: QA_TENANT_ID, clientId: QA_CLIENT_ID, strategies },
+  });
 };
 
 type StartOptions = { expectSecretField?: boolean; skipOpen?: boolean; fromConfigPage?: boolean };
@@ -191,9 +234,34 @@ const addTestRedirectIfNeeded = async (page: Page) => {
   await expect(warning).toHaveCount(0);
 };
 
-const completeProviderLogin = async (page: Page, clientId: string) => {
+type LoginOptions = {
+  strategy?: "username" | "email";
+  identifier?: string;
+  emailVerifiedPreference?: "true" | "false";
+};
+
+const completeProviderLogin = async (page: Page, clientId: string, options?: LoginOptions) => {
   await page.waitForURL(/\/r\/.*\/oidc\/login/);
-  await page.getByRole("textbox", { name: /^Username/ }).fill("qa-user");
+  const strategy = options?.strategy ?? "username";
+  await selectLoginTabIfPresent(page, strategy);
+  const identifier = options?.identifier ?? (strategy === "email" ? "qa-user@example.test" : "qa-user");
+  const labelPattern = strategy === "email" ? /^Email/ : /^Username/;
+  await page.getByRole("textbox", { name: labelPattern }).fill(identifier);
+  if (strategy === "email" && options?.emailVerifiedPreference) {
+    const radioLabel = options.emailVerifiedPreference === "true" ? "Verified" : "Unverified";
+    const radio = page.getByLabel(radioLabel, { exact: true });
+    if (await radio.count()) {
+      await radio.click();
+    }
+  }
   await page.getByRole("button", { name: "Continue" }).click();
   await page.waitForURL(new RegExp(`/admin/clients/${clientId}/test/redirect`));
+};
+
+const selectLoginTabIfPresent = async (page: Page, strategy: "username" | "email") => {
+  const tabName = strategy === "email" ? "Email" : "Username";
+  const tab = page.getByRole("tab", { name: tabName });
+  if ((await tab.count()) > 0) {
+    await tab.click();
+  }
 };


### PR DESCRIPTION
## Summary
- replace radio-based strategy selection with Radix tabs so only one set of credentials is shown at a time
- add unit coverage for the tabbed login form and extend the OAuth E2E suite with a tab-switching flow using the email strategy
- update the Playwright helpers to support choosing strategies programmatically

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test

Closes #76