### PR TITLE
feat: add reauth ttl and prompt controls

### DIFF
--- a/prisma/migrations/20260223193753_client_reauth_ttl/migration.sql
+++ b/prisma/migrations/20260223193753_client_reauth_ttl/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Client" ADD COLUMN     "reauthTtlSeconds" INTEGER NOT NULL DEFAULT 0;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -146,6 +146,7 @@ model Client {
   pkceRequired             Boolean                  @default(true)
   tokenEndpointAuthMethod  TokenEndpointAuthMethod  @default(client_secret_basic)
   authStrategies           Json                     @default("{\"username\":{\"enabled\":true,\"subSource\":\"entered\"},\"email\":{\"enabled\":false,\"subSource\":\"entered\",\"emailVerifiedMode\":\"false\"}}")
+  reauthTtlSeconds         Int                      @default(0)
   redirectUris             RedirectUri[]
   oauthTestSessions        OAuthTestSession[]
   authorizationCodes       AuthorizationCode[]

--- a/src/app/admin/__tests__/prepare-client-oauth-test-action.test.ts
+++ b/src/app/admin/__tests__/prepare-client-oauth-test-action.test.ts
@@ -146,4 +146,15 @@ describe("prepareClientOauthTestAction", () => {
     expect(mockSetSecretCookie).toHaveBeenCalledWith("client_internal", "new_state", "stored-secret");
     expect(result?.data?.authorizationUrl).toContain("state=new_state");
   });
+
+  it("appends prompt=login when requested", async () => {
+    const result = await prepareClientOauthTestAction({
+      clientId: "client_internal",
+      redirectUri: "https://admin.example.test/callback",
+      scopes: "openid",
+      promptLogin: true,
+    });
+
+    expect(result.data?.authorizationUrl).toContain("prompt=login");
+  });
 });

--- a/src/app/admin/actions.ts
+++ b/src/app/admin/actions.ts
@@ -19,6 +19,7 @@ import {
   updateClientName,
   updateClientApiResource,
   updateClientAuthStrategies,
+  updateClientReauthTtl,
   getConfidentialClientSecret,
 } from "@/server/services/client-service";
 import { rotateKey } from "@/server/services/key-service";
@@ -72,6 +73,7 @@ const oauthTestSchema = z.object({
   redirectUri: z.string().min(1),
   scopes: z.string().min(1),
   clientSecret: z.string().optional(),
+  promptLogin: z.boolean().optional(),
 });
 const updateClientSchema = z.object({ clientId: z.string().min(1), name: z.string().min(2) });
 const deleteRedirectSchema = z.object({ redirectId: z.string().min(1) });
@@ -109,6 +111,10 @@ const updateClientStrategiesSchema = z.object({
   clientId: z.string().min(1),
   username: strategyConfigSchema,
   email: emailStrategyConfigSchema,
+});
+const updateClientReauthSchema = z.object({
+  clientId: z.string().min(1),
+  reauthTtlSeconds: z.number().int().min(0).max(86400),
 });
 
 const requireSession = async () => {
@@ -399,6 +405,9 @@ export const prepareClientOauthTestAction = async (
     authorizeUrl.searchParams.set("code_challenge", codeChallenge);
     authorizeUrl.searchParams.set("code_challenge_method", "S256");
     authorizeUrl.searchParams.set("nonce", nonce);
+    if (parsed.promptLogin) {
+      authorizeUrl.searchParams.set("prompt", "login");
+    }
 
     return { success: "Authorization URL generated", data: { authorizationUrl: authorizeUrl.toString() } };
   } catch (error) {
@@ -422,6 +431,23 @@ export const updateClientNameAction = async (input: z.infer<typeof updateClientS
   } catch (error) {
     console.error(error);
     return { error: "Unable to update client" };
+  }
+};
+
+export const updateClientReauthTtlAction = async (input: z.infer<typeof updateClientReauthSchema>): Promise<ActionState> => {
+  try {
+    const adminId = await requireSession();
+    const parsed = updateClientReauthSchema.parse(input);
+    const client = await getClientForAdmin(parsed.clientId, adminId, ["OWNER", "WRITER"]);
+    if (!client) {
+      return { error: "Client not found" };
+    }
+    await updateClientReauthTtl(client.id, parsed.reauthTtlSeconds);
+    revalidatePath(clientPath(client.id));
+    return { success: parsed.reauthTtlSeconds > 0 ? "Re-auth TTL updated" : "Re-auth disabled" };
+  } catch (error) {
+    console.error(error);
+    return { error: "Unable to update re-auth TTL" };
   }
 };
 

--- a/src/app/admin/clients/[clientId]/client-forms.tsx
+++ b/src/app/admin/clients/[clientId]/client-forms.tsx
@@ -14,6 +14,7 @@ import {
   updateClientAuthStrategiesAction,
   updateClientIssuerAction,
   updateClientNameAction,
+  updateClientReauthTtlAction,
 } from "@/app/admin/actions";
 import { CopyField } from "@/app/admin/_components/copy-field";
 import { Button } from "@/components/ui/button";
@@ -55,6 +56,42 @@ const authStrategiesSchema = z
     message: "Enable at least one strategy",
     path: ["root"],
   });
+const MAX_REAUTH_TTL_SECONDS = 86400;
+const reauthTtlSchema = z.object({
+  reauthTtlSeconds: z.coerce
+    .number()
+    .int("Enter a whole number"),
+});
+
+const formatReauthTtlSummary = (seconds: number) => {
+  if (!seconds) {
+    return "0 seconds = always require a fresh sign-in.";
+  }
+  if (seconds < 60) {
+    return `Allows reuse for ${seconds} second${seconds === 1 ? "" : "s"}.`;
+  }
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+  if (minutes < 60 && remainingSeconds === 0) {
+    return `Allows reuse for ${minutes} minute${minutes === 1 ? "" : "s"}.`;
+  }
+  if (minutes < 60) {
+    return `Allows reuse for ${minutes} minute${minutes === 1 ? "" : "s"} ${remainingSeconds} second${remainingSeconds === 1 ? "" : "s"}.`;
+  }
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+  if (remainingMinutes === 0 && remainingSeconds === 0) {
+    return `Allows reuse for ${hours} hour${hours === 1 ? "" : "s"}.`;
+  }
+  const parts = [`${hours} hour${hours === 1 ? "" : "s"}`];
+  if (remainingMinutes) {
+    parts.push(`${remainingMinutes} minute${remainingMinutes === 1 ? "" : "s"}`);
+  }
+  if (remainingSeconds) {
+    parts.push(`${remainingSeconds} second${remainingSeconds === 1 ? "" : "s"}`);
+  }
+  return `Allows reuse for ${parts.join(" ")}.`;
+};
 
 export function UpdateClientNameForm({
   clientId,
@@ -68,6 +105,7 @@ export function UpdateClientNameForm({
   const router = useRouter();
   const form = useForm<z.infer<typeof nameSchema>>({ resolver: zodResolver(nameSchema), defaultValues: { name: initialName } });
   const [pending, startTransition] = useTransition();
+  const [manualError, setManualError] = useState<string | null>(null);
   const { toast } = useToast();
 
   useEffect(() => {
@@ -104,6 +142,92 @@ export function UpdateClientNameForm({
         />
         {canEdit ? (
           <Button type="submit" disabled={pending} className="self-end">
+            {pending ? <Loader2 className="h-4 w-4 animate-spin" /> : "Save"}
+          </Button>
+        ) : (
+          <Button type="button" variant="outline" disabled className="self-end">
+            Read-only
+          </Button>
+        )}
+      </form>
+    </Form>
+  );
+}
+
+export function UpdateClientReauthTtlForm({
+  clientId,
+  initialTtl,
+  canEdit,
+}: {
+  clientId: string;
+  initialTtl: number;
+  canEdit: boolean;
+}) {
+  const router = useRouter();
+  const { toast } = useToast();
+  const [pending, startTransition] = useTransition();
+  const form = useForm<z.infer<typeof reauthTtlSchema>>({
+    resolver: zodResolver(reauthTtlSchema),
+    defaultValues: { reauthTtlSeconds: initialTtl },
+  });
+  const ttlValue = useWatch({ control: form.control, name: "reauthTtlSeconds" }) ?? 0;
+
+  useEffect(() => {
+    form.reset({ reauthTtlSeconds: initialTtl });
+  }, [initialTtl, form]);
+
+  const onSubmit = form.handleSubmit((values) => {
+    if (values.reauthTtlSeconds < 0) {
+      form.setError("reauthTtlSeconds", { type: "manual", message: "Enter 0 or a positive number" });
+      return;
+    }
+    if (values.reauthTtlSeconds > MAX_REAUTH_TTL_SECONDS) {
+      form.setError("reauthTtlSeconds", {
+        type: "manual",
+        message: `Limit to ${MAX_REAUTH_TTL_SECONDS.toLocaleString()} seconds (24 hours)`,
+      });
+      return;
+    }
+    form.clearErrors("reauthTtlSeconds");
+    startTransition(async () => {
+      const result = await updateClientReauthTtlAction({ clientId, reauthTtlSeconds: values.reauthTtlSeconds });
+      if (result.error) {
+        toast({ variant: "destructive", title: "Unable to update", description: result.error });
+        return;
+      }
+      router.refresh();
+      toast({ title: "Re-auth TTL updated", description: result.success ?? "Saved" });
+    });
+  });
+
+  return (
+    <Form {...form}>
+      <form onSubmit={onSubmit} noValidate className="grid gap-3 sm:grid-cols-[1fr_auto]">
+        <FormField
+          control={form.control}
+          name="reauthTtlSeconds"
+          render={({ field }) => (
+            <FormItem className="space-y-1">
+              <FormLabel>Session reuse TTL (seconds)</FormLabel>
+              <FormControl>
+                <Input
+                  {...field}
+                  type="number"
+                  min={0}
+                  max={MAX_REAUTH_TTL_SECONDS}
+                  inputMode="numeric"
+                  disabled={!canEdit || pending}
+                  data-testid="reauth-ttl-input"
+                />
+              </FormControl>
+              <FormMessage />
+              <p className="text-xs text-muted-foreground">{formatReauthTtlSummary(Number(ttlValue) || 0)}</p>
+              <p className="text-xs text-muted-foreground">Max {MAX_REAUTH_TTL_SECONDS.toLocaleString()} seconds (24 hours).</p>
+            </FormItem>
+          )}
+        />
+        {canEdit ? (
+          <Button type="submit" disabled={pending} className="self-end" data-testid="reauth-ttl-save">
             {pending ? <Loader2 className="h-4 w-4 animate-spin" /> : "Save"}
           </Button>
         ) : (

--- a/src/app/admin/clients/[clientId]/page.tsx
+++ b/src/app/admin/clients/[clientId]/page.tsx
@@ -9,6 +9,7 @@ import {
   DeleteRedirectButton,
   RotateSecretForm,
   UpdateAuthStrategiesForm,
+  UpdateClientReauthTtlForm,
   UpdateClientIssuerForm,
   UpdateClientNameForm,
 } from "@/app/admin/clients/[clientId]/client-forms";
@@ -218,6 +219,20 @@ export default async function ClientDetailPage({ params }: { params: PageParams 
             canEdit={canManageClients}
             initialStrategies={authStrategies}
           />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Re-authentication</CardTitle>
+          <CardDescription>Control how long Mockauth honors a previous sign-in for this client.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <UpdateClientReauthTtlForm clientId={client.id} initialTtl={client.reauthTtlSeconds} canEdit={canManageClients} />
+          <p className="text-xs text-muted-foreground">
+            0 seconds disables silent reuse. Higher values allow the authorize endpoint to skip the login form when the
+            same admin signs in again within the TTL window.
+          </p>
         </CardContent>
       </Card>
 

--- a/src/app/admin/clients/[clientId]/test/test-oauth-configurator.tsx
+++ b/src/app/admin/clients/[clientId]/test/test-oauth-configurator.tsx
@@ -11,7 +11,7 @@ import { prepareClientOauthTestAction, addRedirectUriAction } from "@/app/admin/
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
-import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { useToast } from "@/components/ui/use-toast";
 
@@ -29,6 +29,7 @@ const schema = z.object({
       }
     }, "Enter an absolute http(s) URL"),
   clientSecret: z.string().optional(),
+  enforcePromptLogin: z.boolean().optional(),
 });
 
 type FormValues = z.infer<typeof schema>;
@@ -65,6 +66,7 @@ export function TestOAuthConfigurator({
       scopes: defaultScopes,
       redirectUri: defaultRedirectUri,
       clientSecret: defaultClientSecret ?? "",
+      enforcePromptLogin: false,
     },
   });
   const [secretCopied, setSecretCopied] = useState(false);
@@ -114,6 +116,7 @@ export function TestOAuthConfigurator({
         scopes: values.scopes,
         redirectUri: values.redirectUri,
         clientSecret: values.clientSecret?.trim() || undefined,
+        promptLogin: values.enforcePromptLogin ?? false,
       });
       if (result.error || !result.data) {
         toast({ variant: "destructive", title: "Unable to generate URL", description: result.error });
@@ -202,6 +205,32 @@ export function TestOAuthConfigurator({
                   <Input {...field} data-testid="test-oauth-redirect-input" />
                 </FormControl>
                 <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="enforcePromptLogin"
+            render={({ field }) => (
+              <FormItem>
+                <div className="flex items-start gap-3 rounded-md border border-dashed p-3">
+                  <FormControl>
+                    <input
+                      type="checkbox"
+                      className="mt-1 h-4 w-4 rounded border border-muted"
+                      checked={field.value ?? false}
+                      onChange={(event) => field.onChange(event.target.checked)}
+                      disabled={pending}
+                      data-testid="test-oauth-prompt-login"
+                    />
+                  </FormControl>
+                  <div>
+                    <FormLabel className="mb-1 block">Enforce sign-in (prompt=login)</FormLabel>
+                    <FormDescription>
+                      Always show the credential screen, even when the re-authentication cookie is valid.
+                    </FormDescription>
+                  </div>
+                </div>
               </FormItem>
             )}
           />

--- a/src/app/admin/clients/[clientId]/test/test-run-again-button.tsx
+++ b/src/app/admin/clients/[clientId]/test/test-run-again-button.tsx
@@ -27,7 +27,7 @@ export function TestRunAgainButton({ clientId, scopes, redirectUri, variant, siz
   const handleClick = () => {
     startTransition(async () => {
       try {
-        const result = await prepareClientOauthTestAction({ clientId, scopes, redirectUri });
+        const result = await prepareClientOauthTestAction({ clientId, scopes, redirectUri, promptLogin: false });
         if (result.error || !result.data) {
           toast({
             variant: "destructive",

--- a/src/app/admin/clients/__tests__/test-oauth-configurator.test.tsx
+++ b/src/app/admin/clients/__tests__/test-oauth-configurator.test.tsx
@@ -76,6 +76,7 @@ describe("TestOAuthConfigurator", () => {
         scopes: "openid profile",
         redirectUri: "https://admin.example.test/callback",
         clientSecret: "override-secret",
+        promptLogin: false,
       });
     });
 
@@ -171,6 +172,24 @@ describe("TestOAuthConfigurator", () => {
         variant: "destructive",
         title: "Unable to generate URL",
         description: "Redirect missing",
+      });
+    });
+  });
+
+  it("sends promptLogin when the toggle is enabled", async () => {
+    const user = userEvent.setup();
+    render(<TestOAuthConfigurator {...defaultProps} redirectAllowed />);
+
+    await user.click(screen.getByTestId("test-oauth-prompt-login"));
+    await user.click(screen.getByTestId("test-oauth-start"));
+
+    await waitFor(() => {
+      expect(mockPrepare).toHaveBeenCalledWith({
+        clientId: "client_123",
+        scopes: "openid profile",
+        redirectUri: "https://admin.example.test/callback",
+        clientSecret: undefined,
+        promptLogin: true,
       });
     });
   });

--- a/src/app/admin/clients/__tests__/test-run-again-button.test.tsx
+++ b/src/app/admin/clients/__tests__/test-run-again-button.test.tsx
@@ -39,6 +39,7 @@ describe("TestRunAgainButton", () => {
         clientId: "client_123",
         scopes: "openid",
         redirectUri: "https://admin.example.test/callback",
+        promptLogin: false,
       });
       expect(mockPush).toHaveBeenCalledWith("https://auth.example.test");
     });

--- a/src/app/admin/clients/__tests__/update-client-issuer-form.test.tsx
+++ b/src/app/admin/clients/__tests__/update-client-issuer-form.test.tsx
@@ -15,6 +15,7 @@ vi.mock("@/app/admin/actions", () => ({
   updateClientAuthStrategiesAction: vi.fn(),
   updateClientIssuerAction: mockUpdateClientIssuerAction,
   updateClientNameAction: vi.fn(),
+  updateClientReauthTtlAction: vi.fn(),
 }));
 
 const mockRefresh = vi.fn();

--- a/src/app/admin/clients/__tests__/update-client-reauth-form.test.tsx
+++ b/src/app/admin/clients/__tests__/update-client-reauth-form.test.tsx
@@ -1,0 +1,72 @@
+/* @vitest-environment jsdom */
+
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
+
+import { UpdateClientReauthTtlForm } from "../[clientId]/client-forms";
+
+const mockUpdateClientReauthTtlAction = vi.hoisted(() => vi.fn().mockResolvedValue({ success: "saved" }));
+
+vi.mock("@/app/admin/actions", () => ({
+  addRedirectUriAction: vi.fn(),
+  deleteRedirectUriAction: vi.fn(),
+  rotateClientSecretAction: vi.fn(),
+  updateClientAuthStrategiesAction: vi.fn(),
+  updateClientIssuerAction: vi.fn(),
+  updateClientNameAction: vi.fn(),
+  updateClientReauthTtlAction: mockUpdateClientReauthTtlAction,
+}));
+
+const mockRefresh = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: mockRefresh }),
+}));
+
+const mockToast = vi.fn();
+vi.mock("@/components/ui/use-toast", () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
+describe("UpdateClientReauthTtlForm", () => {
+  beforeEach(() => {
+    mockUpdateClientReauthTtlAction.mockClear();
+    mockRefresh.mockClear();
+    mockToast.mockClear();
+  });
+
+  it("submits the entered TTL value", async () => {
+    const user = userEvent.setup();
+    render(<UpdateClientReauthTtlForm clientId="client_1" canEdit initialTtl={0} />);
+
+    const input = screen.getByTestId("reauth-ttl-input");
+    await user.clear(input);
+    await user.type(input, "300");
+    await user.click(screen.getByTestId("reauth-ttl-save"));
+
+    await waitFor(() => {
+      expect(mockUpdateClientReauthTtlAction).toHaveBeenCalledWith({ clientId: "client_1", reauthTtlSeconds: 300 });
+      expect(mockRefresh).toHaveBeenCalled();
+    });
+  });
+
+  it("shows validation errors for out-of-range values", async () => {
+    const user = userEvent.setup();
+    render(<UpdateClientReauthTtlForm clientId="client_2" canEdit initialTtl={120} />);
+
+    const input = screen.getByTestId("reauth-ttl-input");
+    await user.clear(input);
+    await user.type(input, "-5");
+    await user.click(screen.getByTestId("reauth-ttl-save"));
+
+    expect(await screen.findByText("Enter 0 or a positive number")).toBeVisible();
+    expect(mockUpdateClientReauthTtlAction).not.toHaveBeenCalled();
+  });
+
+  it("renders a read-only state when editing is disabled", () => {
+    render(<UpdateClientReauthTtlForm clientId="client_3" canEdit={false} initialTtl={45} />);
+
+    expect(screen.getByTestId("reauth-ttl-input")).toBeDisabled();
+    expect(screen.getByText("Read-only")).toBeDisabled();
+  });
+});

--- a/src/app/r/[apiResourceId]/oidc/authorize/route.ts
+++ b/src/app/r/[apiResourceId]/oidc/authorize/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse, type NextRequest } from "next/server";
+import type { NextRequest } from "next/server";
 import { z } from "zod";
 
 import { toResponse } from "@/server/errors";
@@ -6,7 +6,7 @@ import { handleAuthorize } from "@/server/services/authorize-service";
 import { MOCK_SESSION_COOKIE } from "@/server/services/mock-session-service";
 import { resolveUrl } from "@/server/http/origin";
 import type { ApiResourceRouteContext } from "@/types/api-resource-route";
-import { buildReauthCookiePath, MOCK_REAUTH_COOKIE } from "@/server/oidc/reauth-cookie";
+import { MOCK_REAUTH_COOKIE } from "@/server/oidc/reauth-cookie";
 
 const authorizeSchema = z.object({
   client_id: z.string().min(1),
@@ -23,7 +23,6 @@ const authorizeSchema = z.object({
 export async function GET(request: NextRequest, context: ApiResourceRouteContext) {
   const normalizedUrl = resolveUrl(request);
   const origin = normalizedUrl.origin;
-  const isSecure = normalizedUrl.protocol === "https:";
   const validation = authorizeSchema.safeParse(Object.fromEntries(normalizedUrl.searchParams.entries()));
 
   if (!validation.success) {
@@ -34,7 +33,6 @@ export async function GET(request: NextRequest, context: ApiResourceRouteContext
     const { apiResourceId } = await context.params;
     const sessionToken = request.cookies.get(MOCK_SESSION_COOKIE)?.value;
     const reauthCookie = request.cookies.get(MOCK_REAUTH_COOKIE)?.value;
-    const reauthenticated = Boolean(sessionToken && reauthCookie && sessionToken === reauthCookie);
     const result = await handleAuthorize(
       {
         apiResourceId,
@@ -48,30 +46,17 @@ export async function GET(request: NextRequest, context: ApiResourceRouteContext
         codeChallengeMethod: validation.data.code_challenge_method,
         prompt: validation.data.prompt,
         sessionToken,
-        reauthenticated,
+        reauthCookie,
       },
       origin,
       normalizedUrl.toString(),
     );
 
-    const response =
-      result.type === "login"
-        ? NextResponse.redirect(new URL(result.redirectTo, origin))
-        : NextResponse.redirect(result.redirectTo);
-
-    if (reauthenticated) {
-      response.cookies.set({
-        name: MOCK_REAUTH_COOKIE,
-        value: "",
-        path: buildReauthCookiePath(apiResourceId),
-        httpOnly: true,
-        sameSite: "lax",
-        secure: isSecure,
-        maxAge: 0,
-      });
+    if (result.type === "login") {
+      return Response.redirect(new URL(result.redirectTo, origin));
     }
 
-    return response;
+    return Response.redirect(result.redirectTo);
   } catch (error) {
     return toResponse(error);
   }

--- a/src/app/r/[apiResourceId]/oidc/login/submit/route.ts
+++ b/src/app/r/[apiResourceId]/oidc/login/submit/route.ts
@@ -16,7 +16,8 @@ import {
 import type { ClientAuthStrategies } from "@/server/oidc/auth-strategy";
 import { getApiResourceWithTenant } from "@/server/services/api-resource-service";
 import { resolveStableSubject } from "@/server/services/mock-identity-service";
-import { buildReauthCookiePath, MOCK_REAUTH_COOKIE, REAUTH_COOKIE_TTL_SECONDS } from "@/server/oidc/reauth-cookie";
+import { hashOpaqueToken } from "@/server/crypto/opaque-token";
+import { buildReauthCookiePath, createReauthCookieValue, MOCK_REAUTH_COOKIE } from "@/server/oidc/reauth-cookie";
 
 const loginSchema = z.object({
   strategy: z.enum(["username", "email"]).default("username"),
@@ -113,6 +114,7 @@ export async function POST(request: NextRequest, context: ApiResourceRouteContex
       subject,
       emailVerifiedOverride,
     });
+    const reauthTtlSeconds = client.reauthTtlSeconds ?? 0;
     const fallback = new URL(`/r/${resource.id}/oidc/authorize`, currentUrl.origin);
     const redirectUrl = sanitizeReturnTo(data.data.return_to, fallback, currentUrl);
     const response = NextResponse.redirect(redirectUrl, 303);
@@ -126,14 +128,21 @@ export async function POST(request: NextRequest, context: ApiResourceRouteContex
       secure: isSecure,
       maxAge: 60 * 60 * 12,
     });
+    const reauthCookieValue = createReauthCookieValue({
+      tenantId: tenant.id,
+      apiResourceId: resource.id,
+      clientId: client.clientId,
+      sessionHash: hashOpaqueToken(token),
+      ttlSeconds: reauthTtlSeconds,
+    });
     response.cookies.set({
       name: MOCK_REAUTH_COOKIE,
-      value: token,
+      value: reauthCookieValue ?? "",
       path: buildReauthCookiePath(resource.id),
       httpOnly: true,
       sameSite: "lax",
       secure: isSecure,
-      maxAge: REAUTH_COOKIE_TTL_SECONDS,
+      maxAge: reauthCookieValue ? reauthTtlSeconds : 0,
     });
     return response;
   } catch (error) {

--- a/src/server/oidc/__tests__/oidc-flow.test.ts
+++ b/src/server/oidc/__tests__/oidc-flow.test.ts
@@ -1,10 +1,13 @@
 import { randomUUID } from "node:crypto";
+import { vi } from "vitest";
 
 import { $Enums } from "@/generated/prisma/client";
 import { decodeJwt } from "jose";
 
 import { prisma } from "@/server/db/client";
 import { computeS256Challenge } from "@/server/crypto/pkce";
+import { hashOpaqueToken } from "@/server/crypto/opaque-token";
+import { createReauthCookieValue } from "@/server/oidc/reauth-cookie";
 import { handleAuthorize } from "@/server/services/authorize-service";
 import { consumeAuthorizationCode } from "@/server/services/authorization-code-service";
 import { createSession, clearSession } from "@/server/services/mock-session-service";
@@ -12,6 +15,9 @@ import { issueTokensFromCode } from "@/server/services/token-service";
 import { getUserInfo } from "@/server/services/userinfo-service";
 
 const DEFAULT_TENANT_ID = "tenant_qa";
+const CLIENT_ID = "qa-client";
+const CLIENT_SECRET = "qa-secret";
+const DEFAULT_REAUTH_TTL_SECONDS = 600;
 
 describe("OIDC flow", () => {
   let tenantId: string;
@@ -20,6 +26,21 @@ describe("OIDC flow", () => {
   let codeVerifier: string;
   let clientInternalId: string;
   let originalStrategies: unknown;
+  let originalReauthTtlSeconds: number;
+
+  const buildReauthCookie = (token: string, ttlSeconds = DEFAULT_REAUTH_TTL_SECONDS) => {
+    const cookie = createReauthCookieValue({
+      tenantId,
+      apiResourceId,
+      clientId: CLIENT_ID,
+      sessionHash: hashOpaqueToken(token),
+      ttlSeconds,
+    });
+    if (!cookie) {
+      throw new Error("Unable to create reauth cookie");
+    }
+    return cookie;
+  };
 
   beforeAll(async () => {
     const tenant = await prisma.tenant.findFirstOrThrow({ where: { id: DEFAULT_TENANT_ID }, include: { mockUsers: true } });
@@ -31,9 +52,14 @@ describe("OIDC flow", () => {
       subject: user.username,
     });
     codeVerifier = "verifier-1234567890123456789012345678901234567890";
-    const client = await prisma.client.findFirstOrThrow({ where: { tenantId: tenant.id, clientId: "qa-client" } });
+    const client = await prisma.client.findFirstOrThrow({ where: { tenantId: tenant.id, clientId: CLIENT_ID } });
     clientInternalId = client.id;
     originalStrategies = client.authStrategies;
+    originalReauthTtlSeconds = client.reauthTtlSeconds;
+    await prisma.client.update({
+      where: { id: client.id },
+      data: { reauthTtlSeconds: DEFAULT_REAUTH_TTL_SECONDS },
+    });
   });
 
   afterAll(async () => {
@@ -41,8 +67,14 @@ describe("OIDC flow", () => {
     if (tenant) {
       await clearSession(tenant.id, sessionToken);
     }
-    if (clientInternalId && originalStrategies) {
-      await prisma.client.update({ where: { id: clientInternalId }, data: { authStrategies: originalStrategies } });
+    if (clientInternalId) {
+      await prisma.client.update({
+        where: { id: clientInternalId },
+        data: {
+          ...(originalStrategies ? { authStrategies: originalStrategies } : {}),
+          ...(typeof originalReauthTtlSeconds === "number" ? { reauthTtlSeconds: originalReauthTtlSeconds } : {}),
+        },
+      });
     }
   });
 
@@ -51,7 +83,7 @@ describe("OIDC flow", () => {
     const authorize = await handleAuthorize(
       {
         apiResourceId,
-        clientId: "qa-client",
+        clientId: CLIENT_ID,
         redirectUri: "https://client.example.test/callback",
         responseType: "code",
         scope: "openid profile email",
@@ -59,10 +91,10 @@ describe("OIDC flow", () => {
         codeChallenge: challenge,
         codeChallengeMethod: "S256",
         sessionToken,
-        reauthenticated: true,
+        reauthCookie: buildReauthCookie(sessionToken),
       },
       "https://mockauth.test",
-      `https://mockauth.test/r/${apiResourceId}/oidc/authorize?client_id=qa-client`,
+      `https://mockauth.test/r/${apiResourceId}/oidc/authorize?client_id=${CLIENT_ID}`,
     );
 
     expect(authorize.type).toBe("redirect");
@@ -76,7 +108,7 @@ describe("OIDC flow", () => {
       codeVerifier,
       redirectUri: "https://client.example.test/callback",
       origin: "https://mockauth.test",
-      clientSecret: "qa-secret",
+      clientSecret: CLIENT_SECRET,
     });
 
     expect(tokenResponse.access_token).toBeTruthy();
@@ -92,18 +124,18 @@ describe("OIDC flow", () => {
 
   it("requires an explicit login step before issuing codes", async () => {
     const challenge = computeS256Challenge(codeVerifier);
-    const returnTo = `https://mockauth.test/r/${apiResourceId}/oidc/authorize?client_id=qa-client`;
+    const returnTo = `https://mockauth.test/r/${apiResourceId}/oidc/authorize?client_id=${CLIENT_ID}`;
     const authorize = await handleAuthorize(
       {
         apiResourceId,
-        clientId: "qa-client",
+        clientId: CLIENT_ID,
         redirectUri: "https://client.example.test/callback",
         responseType: "code",
         scope: "openid profile email",
         codeChallenge: challenge,
         codeChallengeMethod: "S256",
         sessionToken,
-        reauthenticated: false,
+        reauthCookie: undefined,
       },
       "https://mockauth.test",
       returnTo,
@@ -117,20 +149,20 @@ describe("OIDC flow", () => {
   it("does not trust reauth query parameters without the cookie handshake", async () => {
     const challenge = computeS256Challenge(codeVerifier);
     const forgedReturnTo = new URL(
-      `https://mockauth.test/r/${apiResourceId}/oidc/authorize?client_id=qa-client&state=manual`,
+      `https://mockauth.test/r/${apiResourceId}/oidc/authorize?client_id=${CLIENT_ID}&state=manual`,
     );
     forgedReturnTo.searchParams.set("reauth", "1");
     const authorize = await handleAuthorize(
       {
         apiResourceId,
-        clientId: "qa-client",
+        clientId: CLIENT_ID,
         redirectUri: "https://client.example.test/callback",
         responseType: "code",
         scope: "openid profile email",
         codeChallenge: challenge,
         codeChallengeMethod: "S256",
         sessionToken,
-        reauthenticated: false,
+        reauthCookie: "forged-cookie",
       },
       "https://mockauth.test",
       forgedReturnTo.toString(),
@@ -146,7 +178,7 @@ describe("OIDC flow", () => {
     const authorize = await handleAuthorize(
       {
         apiResourceId,
-        clientId: "qa-client",
+        clientId: CLIENT_ID,
         redirectUri: "https://client.example.test/callback",
         responseType: "code",
         scope: "openid profile",
@@ -156,7 +188,7 @@ describe("OIDC flow", () => {
         prompt: "none",
       },
       "https://mockauth.test",
-      `https://mockauth.test/r/${apiResourceId}/oidc/authorize?client_id=qa-client`,
+      `https://mockauth.test/r/${apiResourceId}/oidc/authorize?client_id=${CLIENT_ID}`,
     );
 
     expect(authorize.type).toBe("redirect");
@@ -164,6 +196,83 @@ describe("OIDC flow", () => {
     expect(redirected.origin).toBe("https://client.example.test");
     expect(redirected.searchParams.get("error")).toBe("login_required");
     expect(redirected.searchParams.get("state")).toBe("prompt-none");
+  });
+
+  it("satisfies prompt=none when the reauth cookie is valid", async () => {
+    const challenge = computeS256Challenge(codeVerifier);
+    const authorize = await handleAuthorize(
+      {
+        apiResourceId,
+        clientId: CLIENT_ID,
+        redirectUri: "https://client.example.test/callback",
+        responseType: "code",
+        scope: "openid profile",
+        state: "prompt-none-success",
+        codeChallenge: challenge,
+        codeChallengeMethod: "S256",
+        prompt: "none",
+        sessionToken,
+        reauthCookie: buildReauthCookie(sessionToken),
+      },
+      "https://mockauth.test",
+      `https://mockauth.test/r/${apiResourceId}/oidc/authorize?client_id=${CLIENT_ID}`,
+    );
+
+    expect(authorize.type).toBe("redirect");
+    const redirected = new URL(authorize.redirectTo);
+    expect(redirected.searchParams.get("code")).toBeTruthy();
+    expect(redirected.searchParams.get("state")).toBe("prompt-none-success");
+  });
+
+  it("forces login when prompt=login is requested", async () => {
+    const challenge = computeS256Challenge(codeVerifier);
+    const authorize = await handleAuthorize(
+      {
+        apiResourceId,
+        clientId: CLIENT_ID,
+        redirectUri: "https://client.example.test/callback",
+        responseType: "code",
+        scope: "openid profile",
+        codeChallenge: challenge,
+        codeChallengeMethod: "S256",
+        prompt: "login",
+        sessionToken,
+        reauthCookie: buildReauthCookie(sessionToken),
+      },
+      "https://mockauth.test",
+      `https://mockauth.test/r/${apiResourceId}/oidc/authorize?client_id=${CLIENT_ID}`,
+    );
+
+    expect(authorize.type).toBe("login");
+  });
+
+  it("requires login when the cookie is expired", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2024-01-01T00:00:00.000Z"));
+      const cookie = buildReauthCookie(sessionToken, 1);
+      vi.setSystemTime(new Date("2024-01-01T00:00:02.000Z"));
+      const challenge = computeS256Challenge(codeVerifier);
+      const authorize = await handleAuthorize(
+        {
+          apiResourceId,
+          clientId: CLIENT_ID,
+          redirectUri: "https://client.example.test/callback",
+          responseType: "code",
+          scope: "openid profile",
+          codeChallenge: challenge,
+          codeChallengeMethod: "S256",
+          sessionToken,
+          reauthCookie: cookie,
+        },
+        "https://mockauth.test",
+        `https://mockauth.test/r/${apiResourceId}/oidc/authorize?client_id=${CLIENT_ID}`,
+      );
+
+      expect(authorize.type).toBe("login");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("issues email-specific claims when email strategy is enabled", async () => {
@@ -194,7 +303,7 @@ describe("OIDC flow", () => {
     const authorize = await handleAuthorize(
       {
         apiResourceId,
-        clientId: "qa-client",
+        clientId: CLIENT_ID,
         redirectUri: "https://client.example.test/callback",
         responseType: "code",
         scope: "openid profile email",
@@ -202,10 +311,10 @@ describe("OIDC flow", () => {
         codeChallenge: challenge,
         codeChallengeMethod: "S256",
         sessionToken: emailSessionToken,
-        reauthenticated: true,
+        reauthCookie: buildReauthCookie(emailSessionToken),
       },
       "https://mockauth.test",
-      `https://mockauth.test/r/${apiResourceId}/oidc/authorize?client_id=qa-client`,
+      `https://mockauth.test/r/${apiResourceId}/oidc/authorize?client_id=${CLIENT_ID}`,
     );
 
     expect(authorize.type).toBe("redirect");
@@ -216,7 +325,7 @@ describe("OIDC flow", () => {
       codeVerifier,
       redirectUri: "https://client.example.test/callback",
       origin: "https://mockauth.test",
-      clientSecret: "qa-secret",
+      clientSecret: CLIENT_SECRET,
     });
 
     const idToken = decodeJwt(tokenResponse.id_token);
@@ -258,7 +367,7 @@ describe("OIDC flow", () => {
     const authorize = await handleAuthorize(
       {
         apiResourceId,
-        clientId: "qa-client",
+        clientId: CLIENT_ID,
         redirectUri: "https://client.example.test/callback",
         responseType: "code",
         scope: "openid profile email",
@@ -266,10 +375,10 @@ describe("OIDC flow", () => {
         codeChallenge: challenge,
         codeChallengeMethod: "S256",
         sessionToken: sessionTokenOverride,
-        reauthenticated: true,
+        reauthCookie: buildReauthCookie(sessionTokenOverride),
       },
       "https://mockauth.test",
-      `https://mockauth.test/r/${apiResourceId}/oidc/authorize?client_id=qa-client`,
+      `https://mockauth.test/r/${apiResourceId}/oidc/authorize?client_id=${CLIENT_ID}`,
     );
 
     expect(authorize.type).toBe("redirect");
@@ -280,7 +389,7 @@ describe("OIDC flow", () => {
       codeVerifier,
       redirectUri: "https://client.example.test/callback",
       origin: "https://mockauth.test",
-      clientSecret: "qa-secret",
+      clientSecret: CLIENT_SECRET,
     });
 
     const idToken = decodeJwt(tokenResponse.id_token);
@@ -313,7 +422,7 @@ describe("OIDC flow", () => {
     const authorize = await handleAuthorize(
       {
         apiResourceId,
-        clientId: "qa-client",
+        clientId: CLIENT_ID,
         redirectUri: "https://client.example.test/callback",
         responseType: "code",
         scope: "openid email",
@@ -321,10 +430,10 @@ describe("OIDC flow", () => {
         codeChallenge: computeS256Challenge(codeVerifier),
         codeChallengeMethod: "S256",
         sessionToken: verifiedSession,
-        reauthenticated: true,
+        reauthCookie: buildReauthCookie(verifiedSession),
       },
       "https://mockauth.test",
-      `https://mockauth.test/r/${apiResourceId}/oidc/authorize?client_id=qa-client`,
+      `https://mockauth.test/r/${apiResourceId}/oidc/authorize?client_id=${CLIENT_ID}`,
     );
     const code = new URL(authorize.redirectTo).searchParams.get("code");
     const consumed = await consumeAuthorizationCode(code!);
@@ -333,7 +442,7 @@ describe("OIDC flow", () => {
       codeVerifier,
       redirectUri: "https://client.example.test/callback",
       origin: "https://mockauth.test",
-      clientSecret: "qa-secret",
+      clientSecret: CLIENT_SECRET,
     });
     const idToken = decodeJwt(tokens.id_token);
     expect(idToken.email_verified).toBe(true);
@@ -365,7 +474,7 @@ describe("OIDC flow", () => {
       const authorize = await handleAuthorize(
         {
           apiResourceId,
-          clientId: "qa-client",
+          clientId: CLIENT_ID,
           redirectUri: "https://client.example.test/callback",
           responseType: "code",
           scope: "openid email",
@@ -373,10 +482,10 @@ describe("OIDC flow", () => {
           codeChallenge: computeS256Challenge(codeVerifier),
           codeChallengeMethod: "S256",
           sessionToken: sessionTokenChoice,
-          reauthenticated: true,
+          reauthCookie: buildReauthCookie(sessionTokenChoice),
         },
         "https://mockauth.test",
-        `https://mockauth.test/r/${apiResourceId}/oidc/authorize?client_id=qa-client`,
+        `https://mockauth.test/r/${apiResourceId}/oidc/authorize?client_id=${CLIENT_ID}`,
       );
       const code = new URL(authorize.redirectTo).searchParams.get("code");
       const consumed = await consumeAuthorizationCode(code!);
@@ -385,7 +494,7 @@ describe("OIDC flow", () => {
         codeVerifier,
         redirectUri: "https://client.example.test/callback",
         origin: "https://mockauth.test",
-        clientSecret: "qa-secret",
+        clientSecret: CLIENT_SECRET,
       });
       await clearSession(tenantId, sessionTokenChoice);
       return decodeJwt(tokens.id_token).email_verified;

--- a/src/server/oidc/__tests__/reauth-cookie.test.ts
+++ b/src/server/oidc/__tests__/reauth-cookie.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi } from "vitest";
+
+import { createReauthCookieValue, verifyReauthCookieValue } from "../reauth-cookie";
+
+const TENANT_ID = "tenant_qa";
+const API_RESOURCE_ID = "resource_123";
+const CLIENT_ID = "qa-client";
+const SESSION_HASH = "session_hash";
+
+describe("reauth-cookie", () => {
+  it("creates and validates a signed cookie", () => {
+    const value = createReauthCookieValue({
+      tenantId: TENANT_ID,
+      apiResourceId: API_RESOURCE_ID,
+      clientId: CLIENT_ID,
+      sessionHash: SESSION_HASH,
+      ttlSeconds: 120,
+    });
+
+    expect(value).toBeTruthy();
+    const valid = verifyReauthCookieValue(value!, {
+      tenantId: TENANT_ID,
+      apiResourceId: API_RESOURCE_ID,
+      clientId: CLIENT_ID,
+      sessionHash: SESSION_HASH,
+    });
+    expect(valid).toBe(true);
+  });
+
+  it("rejects tampered cookies", () => {
+    const value = createReauthCookieValue({
+      tenantId: TENANT_ID,
+      apiResourceId: API_RESOURCE_ID,
+      clientId: CLIENT_ID,
+      sessionHash: SESSION_HASH,
+      ttlSeconds: 120,
+    });
+    expect(value).toBeTruthy();
+    const parts = value!.split(".");
+    parts[1] = Buffer.from(JSON.stringify({
+      tenantId: TENANT_ID,
+      apiResourceId: "other",
+      clientId: CLIENT_ID,
+      sessionHash: SESSION_HASH,
+      exp: Math.floor(Date.now() / 1000) + 120,
+    })).toString("base64url");
+    const modified = parts.join(".");
+    const valid = verifyReauthCookieValue(modified, {
+      tenantId: TENANT_ID,
+      apiResourceId: API_RESOURCE_ID,
+      clientId: CLIENT_ID,
+      sessionHash: SESSION_HASH,
+    });
+    expect(valid).toBe(false);
+  });
+
+  it("rejects expired cookies", () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2024-01-01T00:00:00Z"));
+      const value = createReauthCookieValue({
+        tenantId: TENANT_ID,
+        apiResourceId: API_RESOURCE_ID,
+        clientId: CLIENT_ID,
+        sessionHash: SESSION_HASH,
+        ttlSeconds: 1,
+      });
+      vi.setSystemTime(new Date("2024-01-01T00:00:05Z"));
+      const valid = verifyReauthCookieValue(value!, {
+        tenantId: TENANT_ID,
+        apiResourceId: API_RESOURCE_ID,
+        clientId: CLIENT_ID,
+        sessionHash: SESSION_HASH,
+      });
+      expect(valid).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/server/oidc/reauth-cookie.ts
+++ b/src/server/oidc/reauth-cookie.ts
@@ -1,4 +1,80 @@
-export const MOCK_REAUTH_COOKIE = "mockauth_reauth_ok" as const;
-export const REAUTH_COOKIE_TTL_SECONDS = 60;
+import { createHmac, timingSafeEqual } from "node:crypto";
 
+import { env } from "@/server/env";
+
+export const MOCK_REAUTH_COOKIE = "mockauth_reauth_ok" as const;
 export const buildReauthCookiePath = (apiResourceId: string) => `/r/${apiResourceId}/oidc`;
+
+const VERSION = "v1" as const;
+
+type ReauthClaims = {
+  tenantId: string;
+  apiResourceId: string;
+  clientId: string;
+  sessionHash: string;
+  exp: number;
+};
+
+const encodePayload = (payload: ReauthClaims) => Buffer.from(JSON.stringify(payload)).toString("base64url");
+const decodePayload = (encoded: string): ReauthClaims => JSON.parse(Buffer.from(encoded, "base64url").toString());
+
+const sign = (encodedPayload: string) =>
+  createHmac("sha256", env.NEXTAUTH_SECRET).update(encodedPayload).digest("base64url");
+
+export const createReauthCookieValue = (input: {
+  tenantId: string;
+  apiResourceId: string;
+  clientId: string;
+  sessionHash: string;
+  ttlSeconds: number;
+}) => {
+  if (input.ttlSeconds <= 0) {
+    return null;
+  }
+  const expiresAt = Math.floor(Date.now() / 1000) + input.ttlSeconds;
+  const payload: ReauthClaims = {
+    tenantId: input.tenantId,
+    apiResourceId: input.apiResourceId,
+    clientId: input.clientId,
+    sessionHash: input.sessionHash,
+    exp: expiresAt,
+  };
+  const encoded = encodePayload(payload);
+  const signature = sign(encoded);
+  return `${VERSION}.${encoded}.${signature}`;
+};
+
+export const verifyReauthCookieValue = (
+  value: string | undefined,
+  expected: { tenantId: string; apiResourceId: string; clientId: string; sessionHash: string },
+) => {
+  if (!value) {
+    return false;
+  }
+  const [version, encoded, providedSignature] = value.split(".");
+  if (version !== VERSION || !encoded || !providedSignature) {
+    return false;
+  }
+  const expectedSignature = sign(encoded);
+  const providedBuffer = Buffer.from(providedSignature);
+  const expectedBuffer = Buffer.from(expectedSignature);
+  if (providedBuffer.length !== expectedBuffer.length || !timingSafeEqual(providedBuffer, expectedBuffer)) {
+    return false;
+  }
+  let payload: ReauthClaims;
+  try {
+    payload = decodePayload(encoded);
+  } catch {
+    return false;
+  }
+  const now = Math.floor(Date.now() / 1000);
+  if (payload.exp <= now) {
+    return false;
+  }
+  return (
+    payload.tenantId === expected.tenantId &&
+    payload.apiResourceId === expected.apiResourceId &&
+    payload.clientId === expected.clientId &&
+    payload.sessionHash === expected.sessionHash
+  );
+};

--- a/src/server/services/authorize-service.ts
+++ b/src/server/services/authorize-service.ts
@@ -5,6 +5,8 @@ import { getSessionUser } from "@/server/services/mock-session-service";
 import { getClientForTenant } from "@/server/services/client-service";
 import { getApiResourceWithTenant } from "@/server/services/api-resource-service";
 import { fromPrismaLoginStrategy, parseClientAuthStrategies } from "@/server/oidc/auth-strategy";
+import { verifyReauthCookieValue } from "@/server/oidc/reauth-cookie";
+import { hashOpaqueToken } from "@/server/crypto/opaque-token";
 
 type AuthorizeParams = {
   apiResourceId: string;
@@ -18,7 +20,7 @@ type AuthorizeParams = {
   codeChallengeMethod: string;
   prompt?: string;
   sessionToken?: string;
-  reauthenticated?: boolean;
+  reauthCookie?: string;
 };
 
 const ensureScopes = (requested: string[], allowed: string[]) => {
@@ -50,8 +52,36 @@ export const handleAuthorize = async (params: AuthorizeParams, origin: string, r
   const redirect = resolveRedirectUri(params.redirectUri, client.redirectUris ?? []);
 
   ensureScopes(params.scope.split(" ").filter(Boolean), client.allowedScopes);
+  const strategies = parseClientAuthStrategies(client.authStrategies);
+  const session = params.sessionToken ? await getSessionUser(tenant.id, params.sessionToken) : null;
+  const strategyAllowed = session
+    ? strategies[fromPrismaLoginStrategy(session.loginStrategy)]?.enabled ?? false
+    : false;
+  const reauthTtlSeconds = client.reauthTtlSeconds ?? 0;
+  const sessionTokenHash = params.sessionToken ? hashOpaqueToken(params.sessionToken) : null;
+  const cookieValid = Boolean(
+    reauthTtlSeconds > 0 &&
+      sessionTokenHash &&
+      params.reauthCookie &&
+      verifyReauthCookieValue(params.reauthCookie, {
+        tenantId: tenant.id,
+        apiResourceId: resource.id,
+        clientId: client.clientId,
+        sessionHash: sessionTokenHash,
+      }),
+  );
+  const hasReusableLogin = Boolean(cookieValid && session && strategyAllowed);
 
-  if (params.prompt === "none") {
+  const buildLoginRedirect = () => ({
+    type: "login" as const,
+    redirectTo: `/r/${resource.id}/oidc/login?return_to=${encodeURIComponent(new URL(returnTo).toString())}`,
+  });
+
+  if (params.prompt === "login") {
+    return buildLoginRedirect();
+  }
+
+  if (params.prompt === "none" && !hasReusableLogin) {
     const redirectUrl = new URL(redirect);
     redirectUrl.searchParams.set("error", "login_required");
     if (params.state) {
@@ -60,20 +90,12 @@ export const handleAuthorize = async (params: AuthorizeParams, origin: string, r
     return { type: "redirect" as const, redirectTo: redirectUrl.toString() };
   }
 
-  const strategies = parseClientAuthStrategies(client.authStrategies);
-  const session = params.reauthenticated ? await getSessionUser(tenant.id, params.sessionToken) : null;
-  const strategyAllowed = session
-    ? strategies[fromPrismaLoginStrategy(session.loginStrategy)]?.enabled ?? false
-    : false;
-  const mustPrompt = params.prompt === "login" && !params.reauthenticated;
-  const shouldLogin = !params.reauthenticated || mustPrompt || !session || !strategyAllowed;
+  if (!hasReusableLogin) {
+    return buildLoginRedirect();
+  }
 
-  if (shouldLogin) {
-    const loginReturnUrl = new URL(returnTo);
-    return {
-      type: "login" as const,
-      redirectTo: `/r/${resource.id}/oidc/login?return_to=${encodeURIComponent(loginReturnUrl.toString())}`,
-    };
+  if (!session) {
+    throw new Error("Session is required when reusing login");
   }
 
   const code = await createAuthorizationCode({

--- a/src/server/services/client-service.ts
+++ b/src/server/services/client-service.ts
@@ -158,6 +158,10 @@ export const updateClientAuthStrategies = async (clientId: string, strategies: C
   return prisma.client.update({ where: { id: clientId }, data: { authStrategies: strategies } });
 };
 
+export const updateClientReauthTtl = async (clientId: string, reauthTtlSeconds: number) => {
+  return prisma.client.update({ where: { id: clientId }, data: { reauthTtlSeconds } });
+};
+
 export const getConfidentialClientSecret = async (clientId: string): Promise<string | null> => {
   const client = await prisma.client.findUnique({
     where: { id: clientId },

--- a/tests/e2e/test-oauth-flow.spec.ts
+++ b/tests/e2e/test-oauth-flow.spec.ts
@@ -117,6 +117,64 @@ test.describe("Client Test OAuth", () => {
     await expect(page.getByTestId("test-oauth-error")).toContainText("login_required");
   });
 
+  test("reuses the previous login within the reauth TTL window", async ({ page }) => {
+    const sessionToken = await createTestSession(page, { tenantId: QA_TENANT_ID, role: "OWNER" });
+    await authenticate(page, sessionToken);
+
+    const clientId = await openClientDetail(page, QA_TENANT_ID, QA_CLIENT_NAME);
+    await setClientReauthTtl(page, clientId, 180);
+
+    try {
+      await completeRunAndReturnToConfigurator(page, clientId);
+      const { authorizationUrl } = await startOauthTest(page, clientId, { skipOpen: true, fromConfigPage: true });
+      await page.goto(authorizationUrl);
+      await page.waitForURL(new RegExp(`/admin/clients/${clientId}/test/redirect`));
+      await expect(page.getByTestId("test-oauth-id-token")).toBeVisible();
+    } finally {
+      await setClientReauthTtl(page, clientId, 0);
+    }
+  });
+
+  test("prompt=login toggle forces a credential screen even within the TTL", async ({ page }) => {
+    const sessionToken = await createTestSession(page, { tenantId: QA_TENANT_ID, role: "OWNER" });
+    await authenticate(page, sessionToken);
+
+    const clientId = await openClientDetail(page, QA_TENANT_ID, QA_CLIENT_NAME);
+    await setClientReauthTtl(page, clientId, 300);
+
+    try {
+      await completeRunAndReturnToConfigurator(page, clientId);
+      await page.getByTestId("test-oauth-prompt-login").check();
+      const { authorizationUrl } = await startOauthTest(page, clientId, { skipOpen: true, fromConfigPage: true });
+      await page.goto(authorizationUrl);
+      await expect(page).toHaveURL(/\/r\/.*\/oidc\/login/);
+      await completeProviderLogin(page, clientId);
+      await expect(page.getByTestId("test-oauth-id-token")).toBeVisible();
+    } finally {
+      await setClientReauthTtl(page, clientId, 0);
+    }
+  });
+
+  test("prompt=none succeeds silently when the TTL cookie is valid", async ({ page }) => {
+    const sessionToken = await createTestSession(page, { tenantId: QA_TENANT_ID, role: "OWNER" });
+    await authenticate(page, sessionToken);
+
+    const clientId = await openClientDetail(page, QA_TENANT_ID, QA_CLIENT_NAME);
+    await setClientReauthTtl(page, clientId, 240);
+
+    try {
+      await completeRunAndReturnToConfigurator(page, clientId);
+      const { authorizationUrl } = await startOauthTest(page, clientId, { skipOpen: true, fromConfigPage: true });
+      const silentUrl = new URL(authorizationUrl);
+      silentUrl.searchParams.set("prompt", "none");
+      await page.goto(silentUrl.toString());
+      await page.waitForURL(new RegExp(`/admin/clients/${clientId}/test/redirect`));
+      await expect(page.getByTestId("test-oauth-id-token")).toBeVisible();
+    } finally {
+      await setClientReauthTtl(page, clientId, 0);
+    }
+  });
+
   test("surfaces authorization errors on the redirect page", async ({ page }) => {
     const sessionToken = await createTestSession(page, { tenantId: QA_TENANT_ID, role: "OWNER" });
     await authenticate(page, sessionToken);
@@ -209,6 +267,15 @@ const completeRunAndReturnToConfigurator = async (page: Page, clientId: string) 
   await expect(page.getByTestId("test-oauth-id-token")).toBeVisible();
   await page.getByRole("link", { name: "← Back to test config" }).click();
   await expect(page).toHaveURL(new RegExp(`/admin/clients/${clientId}/test`));
+};
+
+const setClientReauthTtl = async (page: Page, clientId: string, ttlSeconds: number) => {
+  await page.goto(`/admin/clients/${clientId}`);
+  const input = page.getByTestId("reauth-ttl-input");
+  await expect(input).toBeVisible();
+  await input.fill(ttlSeconds.toString());
+  await page.getByTestId("reauth-ttl-save").click();
+  await expect(input).toHaveValue(ttlSeconds.toString());
 };
 
 const openClientDetail = async (page: Page, tenantId: string, clientName: string) => {


### PR DESCRIPTION
## Summary
- add client.reauthTtlSeconds and TTL-aware authorize/login handling with signed cookie checks
- expose admin + Test OAuth controls for TTL edits and enforce prompt=login toggle
- cover new flows with unit/integration tests plus Playwright scenarios honoring TTL + prompt semantics

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test

Closes #79
