### PR TITLE
fix: add fresh-login authorize handshake

### DIFF
--- a/src/app/r/[apiResourceId]/oidc/authorize/route.ts
+++ b/src/app/r/[apiResourceId]/oidc/authorize/route.ts
@@ -1,4 +1,4 @@
-import type { NextRequest } from "next/server";
+import { NextResponse, type NextRequest } from "next/server";
 import { z } from "zod";
 
 import { toResponse } from "@/server/errors";
@@ -6,7 +6,7 @@ import { handleAuthorize } from "@/server/services/authorize-service";
 import { MOCK_SESSION_COOKIE } from "@/server/services/mock-session-service";
 import { resolveUrl } from "@/server/http/origin";
 import type { ApiResourceRouteContext } from "@/types/api-resource-route";
-import { MOCK_REAUTH_COOKIE } from "@/server/oidc/reauth-cookie";
+import { buildReauthCookiePath, MOCK_FRESH_LOGIN_COOKIE, MOCK_REAUTH_COOKIE } from "@/server/oidc/reauth-cookie";
 
 const authorizeSchema = z.object({
   client_id: z.string().min(1),
@@ -18,6 +18,7 @@ const authorizeSchema = z.object({
   prompt: z.enum(["login", "none"]).optional(),
   code_challenge: z.string().min(43).max(128),
   code_challenge_method: z.string().default("S256"),
+  fresh_login: z.string().optional(),
 });
 
 export async function GET(request: NextRequest, context: ApiResourceRouteContext) {
@@ -33,6 +34,8 @@ export async function GET(request: NextRequest, context: ApiResourceRouteContext
     const { apiResourceId } = await context.params;
     const sessionToken = request.cookies.get(MOCK_SESSION_COOKIE)?.value;
     const reauthCookie = request.cookies.get(MOCK_REAUTH_COOKIE)?.value;
+    const freshLoginCookie = request.cookies.get(MOCK_FRESH_LOGIN_COOKIE)?.value;
+    const freshLoginRequested = validation.data.fresh_login === "1";
     const result = await handleAuthorize(
       {
         apiResourceId,
@@ -47,16 +50,42 @@ export async function GET(request: NextRequest, context: ApiResourceRouteContext
         prompt: validation.data.prompt,
         sessionToken,
         reauthCookie,
+        freshLoginCookie,
+        freshLoginRequested,
       },
       origin,
       normalizedUrl.toString(),
     );
 
     if (result.type === "login") {
-      return Response.redirect(new URL(result.redirectTo, origin));
+      const response = NextResponse.redirect(new URL(result.redirectTo, origin));
+      if (result.consumeFreshLoginCookie) {
+        response.cookies.set({
+          name: MOCK_FRESH_LOGIN_COOKIE,
+          value: "",
+          path: buildReauthCookiePath(apiResourceId),
+          httpOnly: true,
+          sameSite: "lax",
+          secure: normalizedUrl.protocol === "https:",
+          maxAge: 0,
+        });
+      }
+      return response;
     }
 
-    return Response.redirect(result.redirectTo);
+    const response = NextResponse.redirect(result.redirectTo);
+    if (result.consumeFreshLoginCookie) {
+      response.cookies.set({
+        name: MOCK_FRESH_LOGIN_COOKIE,
+        value: "",
+        path: buildReauthCookiePath(apiResourceId),
+        httpOnly: true,
+        sameSite: "lax",
+        secure: normalizedUrl.protocol === "https:",
+        maxAge: 0,
+      });
+    }
+    return response;
   } catch (error) {
     return toResponse(error);
   }

--- a/src/app/r/[apiResourceId]/oidc/login/submit/route.ts
+++ b/src/app/r/[apiResourceId]/oidc/login/submit/route.ts
@@ -17,7 +17,14 @@ import type { ClientAuthStrategies } from "@/server/oidc/auth-strategy";
 import { getApiResourceWithTenant } from "@/server/services/api-resource-service";
 import { resolveStableSubject } from "@/server/services/mock-identity-service";
 import { hashOpaqueToken } from "@/server/crypto/opaque-token";
-import { buildReauthCookiePath, createReauthCookieValue, MOCK_REAUTH_COOKIE } from "@/server/oidc/reauth-cookie";
+import {
+  buildReauthCookiePath,
+  createFreshLoginCookieValue,
+  createReauthCookieValue,
+  FRESH_LOGIN_COOKIE_TTL_SECONDS,
+  MOCK_FRESH_LOGIN_COOKIE,
+  MOCK_REAUTH_COOKIE,
+} from "@/server/oidc/reauth-cookie";
 
 const loginSchema = z.object({
   strategy: z.enum(["username", "email"]).default("username"),
@@ -114,9 +121,11 @@ export async function POST(request: NextRequest, context: ApiResourceRouteContex
       subject,
       emailVerifiedOverride,
     });
+    const sessionHash = hashOpaqueToken(token);
     const reauthTtlSeconds = client.reauthTtlSeconds ?? 0;
     const fallback = new URL(`/r/${resource.id}/oidc/authorize`, currentUrl.origin);
     const redirectUrl = sanitizeReturnTo(data.data.return_to, fallback, currentUrl);
+    redirectUrl.searchParams.set("fresh_login", "1");
     const response = NextResponse.redirect(redirectUrl, 303);
     const isSecure = currentUrl.protocol === "https:";
     response.cookies.set({
@@ -132,7 +141,7 @@ export async function POST(request: NextRequest, context: ApiResourceRouteContex
       tenantId: tenant.id,
       apiResourceId: resource.id,
       clientId: client.clientId,
-      sessionHash: hashOpaqueToken(token),
+      sessionHash,
       ttlSeconds: reauthTtlSeconds,
     });
     response.cookies.set({
@@ -143,6 +152,21 @@ export async function POST(request: NextRequest, context: ApiResourceRouteContex
       sameSite: "lax",
       secure: isSecure,
       maxAge: reauthCookieValue ? reauthTtlSeconds : 0,
+    });
+    const freshLoginCookieValue = createFreshLoginCookieValue({
+      tenantId: tenant.id,
+      apiResourceId: resource.id,
+      clientId: client.clientId,
+      sessionHash,
+    });
+    response.cookies.set({
+      name: MOCK_FRESH_LOGIN_COOKIE,
+      value: freshLoginCookieValue,
+      path: buildReauthCookiePath(resource.id),
+      httpOnly: true,
+      sameSite: "lax",
+      secure: isSecure,
+      maxAge: FRESH_LOGIN_COOKIE_TTL_SECONDS,
     });
     return response;
   } catch (error) {

--- a/src/server/oidc/__tests__/oidc-flow.test.ts
+++ b/src/server/oidc/__tests__/oidc-flow.test.ts
@@ -7,7 +7,7 @@ import { decodeJwt } from "jose";
 import { prisma } from "@/server/db/client";
 import { computeS256Challenge } from "@/server/crypto/pkce";
 import { hashOpaqueToken } from "@/server/crypto/opaque-token";
-import { createReauthCookieValue } from "@/server/oidc/reauth-cookie";
+import { createFreshLoginCookieValue, createReauthCookieValue } from "@/server/oidc/reauth-cookie";
 import { handleAuthorize } from "@/server/services/authorize-service";
 import { consumeAuthorizationCode } from "@/server/services/authorization-code-service";
 import { createSession, clearSession } from "@/server/services/mock-session-service";
@@ -41,6 +41,14 @@ describe("OIDC flow", () => {
     }
     return cookie;
   };
+
+  const buildFreshLoginCookie = (token: string) =>
+    createFreshLoginCookieValue({
+      tenantId,
+      apiResourceId,
+      clientId: CLIENT_ID,
+      sessionHash: hashOpaqueToken(token),
+    });
 
   beforeAll(async () => {
     const tenant = await prisma.tenant.findFirstOrThrow({ where: { id: DEFAULT_TENANT_ID }, include: { mockUsers: true } });
@@ -171,6 +179,68 @@ describe("OIDC flow", () => {
     expect(authorize.type).toBe("login");
     const decodedReturn = decodeURIComponent(authorize.redirectTo.split("return_to=")[1]!);
     expect(decodedReturn).toBe(forgedReturnTo.toString());
+  });
+
+  it("completes authorize immediately after a fresh login even when TTL is zero", async () => {
+    await prisma.client.update({ where: { id: clientInternalId }, data: { reauthTtlSeconds: 0 } });
+    try {
+      const challenge = computeS256Challenge(codeVerifier);
+      const authorize = await handleAuthorize(
+        {
+          apiResourceId,
+          clientId: CLIENT_ID,
+          redirectUri: "https://client.example.test/callback",
+          responseType: "code",
+          scope: "openid profile",
+          state: "fresh-login",
+          codeChallenge: challenge,
+          codeChallengeMethod: "S256",
+          sessionToken,
+          reauthCookie: undefined,
+          freshLoginCookie: buildFreshLoginCookie(sessionToken),
+          freshLoginRequested: true,
+        },
+        "https://mockauth.test",
+        `https://mockauth.test/r/${apiResourceId}/oidc/authorize?client_id=${CLIENT_ID}&fresh_login=1`,
+      );
+
+      expect(authorize.type).toBe("redirect");
+      expect(authorize.consumeFreshLoginCookie).toBe(true);
+      const redirected = new URL(authorize.redirectTo);
+      expect(redirected.searchParams.get("code")).toBeTruthy();
+      expect(redirected.searchParams.get("state")).toBe("fresh-login");
+    } finally {
+      await prisma.client.update({ where: { id: clientInternalId }, data: { reauthTtlSeconds: DEFAULT_REAUTH_TTL_SECONDS } });
+    }
+  });
+
+  it("ignores forged fresh_login flags when the cookie is missing", async () => {
+    await prisma.client.update({ where: { id: clientInternalId }, data: { reauthTtlSeconds: 0 } });
+    try {
+      const challenge = computeS256Challenge(codeVerifier);
+      const forgedReturnTo = `https://mockauth.test/r/${apiResourceId}/oidc/authorize?client_id=${CLIENT_ID}&fresh_login=1`;
+      const authorize = await handleAuthorize(
+        {
+          apiResourceId,
+          clientId: CLIENT_ID,
+          redirectUri: "https://client.example.test/callback",
+          responseType: "code",
+          scope: "openid profile",
+          codeChallenge: challenge,
+          codeChallengeMethod: "S256",
+          sessionToken,
+          reauthCookie: undefined,
+          freshLoginRequested: true,
+        },
+        "https://mockauth.test",
+        forgedReturnTo,
+      );
+
+      expect(authorize.type).toBe("login");
+      expect(authorize.consumeFreshLoginCookie).toBeUndefined();
+    } finally {
+      await prisma.client.update({ where: { id: clientInternalId }, data: { reauthTtlSeconds: DEFAULT_REAUTH_TTL_SECONDS } });
+    }
   });
 
   it("redirects with login_required when prompt=none", async () => {

--- a/src/server/oidc/__tests__/reauth-cookie.test.ts
+++ b/src/server/oidc/__tests__/reauth-cookie.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect, vi } from "vitest";
 
-import { createReauthCookieValue, verifyReauthCookieValue } from "../reauth-cookie";
+import {
+  createFreshLoginCookieValue,
+  createReauthCookieValue,
+  FRESH_LOGIN_COOKIE_TTL_SECONDS,
+  verifyFreshLoginCookieValue,
+  verifyReauthCookieValue,
+} from "../reauth-cookie";
 
 const TENANT_ID = "tenant_qa";
 const API_RESOURCE_ID = "resource_123";
@@ -76,5 +82,82 @@ describe("reauth-cookie", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+describe("fresh login cookie", () => {
+  it("creates and validates a short-lived cookie", () => {
+    const value = createFreshLoginCookieValue({
+      tenantId: TENANT_ID,
+      apiResourceId: API_RESOURCE_ID,
+      clientId: CLIENT_ID,
+      sessionHash: SESSION_HASH,
+    });
+
+    expect(value).toBeTruthy();
+    const valid = verifyFreshLoginCookieValue(value, {
+      tenantId: TENANT_ID,
+      apiResourceId: API_RESOURCE_ID,
+      clientId: CLIENT_ID,
+      sessionHash: SESSION_HASH,
+    });
+    expect(valid).toBe(true);
+  });
+
+  it("rejects expired cookies", () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2024-01-01T00:00:00.000Z"));
+      const value = createFreshLoginCookieValue({
+        tenantId: TENANT_ID,
+        apiResourceId: API_RESOURCE_ID,
+        clientId: CLIENT_ID,
+        sessionHash: SESSION_HASH,
+      });
+      vi.setSystemTime(new Date("2024-01-01T00:00:10.000Z"));
+      const stillValid = verifyFreshLoginCookieValue(value, {
+        tenantId: TENANT_ID,
+        apiResourceId: API_RESOURCE_ID,
+        clientId: CLIENT_ID,
+        sessionHash: SESSION_HASH,
+      });
+      expect(stillValid).toBe(true);
+      vi.setSystemTime(new Date("2024-01-01T00:02:00.000Z"));
+      const valid = verifyFreshLoginCookieValue(value, {
+        tenantId: TENANT_ID,
+        apiResourceId: API_RESOURCE_ID,
+        clientId: CLIENT_ID,
+        sessionHash: SESSION_HASH,
+      });
+      expect(valid).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("rejects tampered cookies", () => {
+    const value = createFreshLoginCookieValue({
+      tenantId: TENANT_ID,
+      apiResourceId: API_RESOURCE_ID,
+      clientId: CLIENT_ID,
+      sessionHash: SESSION_HASH,
+    });
+    const parts = value.split(".");
+    const payload = {
+      tenantId: TENANT_ID,
+      apiResourceId: API_RESOURCE_ID,
+      clientId: CLIENT_ID,
+      sessionHash: "other",
+      exp: Math.floor(Date.now() / 1000) + FRESH_LOGIN_COOKIE_TTL_SECONDS,
+    };
+    parts[1] = Buffer.from(JSON.stringify(payload)).toString("base64url");
+    const forged = parts.join(".");
+    const valid = verifyFreshLoginCookieValue(forged, {
+      tenantId: TENANT_ID,
+      apiResourceId: API_RESOURCE_ID,
+      clientId: CLIENT_ID,
+      sessionHash: SESSION_HASH,
+    });
+    expect(valid).toBe(false);
   });
 });

--- a/src/server/oidc/reauth-cookie.ts
+++ b/src/server/oidc/reauth-cookie.ts
@@ -3,11 +3,15 @@ import { createHmac, timingSafeEqual } from "node:crypto";
 import { env } from "@/server/env";
 
 export const MOCK_REAUTH_COOKIE = "mockauth_reauth_ok" as const;
+export const MOCK_FRESH_LOGIN_COOKIE = "mockauth_fresh_login" as const;
 export const buildReauthCookiePath = (apiResourceId: string) => `/r/${apiResourceId}/oidc`;
 
-const VERSION = "v1" as const;
+const enum CookieVersion {
+  REAUTH = "reauth-v1",
+  FRESH_LOGIN = "fresh-v1",
+}
 
-type ReauthClaims = {
+type CookieClaims = {
   tenantId: string;
   apiResourceId: string;
   clientId: string;
@@ -15,53 +19,46 @@ type ReauthClaims = {
   exp: number;
 };
 
-const encodePayload = (payload: ReauthClaims) => Buffer.from(JSON.stringify(payload)).toString("base64url");
-const decodePayload = (encoded: string): ReauthClaims => JSON.parse(Buffer.from(encoded, "base64url").toString());
+const encodePayload = (payload: CookieClaims) => Buffer.from(JSON.stringify(payload)).toString("base64url");
+const decodePayload = (encoded: string): CookieClaims => JSON.parse(Buffer.from(encoded, "base64url").toString());
 
 const sign = (encodedPayload: string) =>
   createHmac("sha256", env.NEXTAUTH_SECRET).update(encodedPayload).digest("base64url");
 
-export const createReauthCookieValue = (input: {
-  tenantId: string;
-  apiResourceId: string;
-  clientId: string;
-  sessionHash: string;
-  ttlSeconds: number;
-}) => {
-  if (input.ttlSeconds <= 0) {
+const createCookieValue = (
+  version: CookieVersion,
+  payload: Omit<CookieClaims, "exp">,
+  ttlSeconds: number,
+): string | null => {
+  if (ttlSeconds <= 0) {
     return null;
   }
-  const expiresAt = Math.floor(Date.now() / 1000) + input.ttlSeconds;
-  const payload: ReauthClaims = {
-    tenantId: input.tenantId,
-    apiResourceId: input.apiResourceId,
-    clientId: input.clientId,
-    sessionHash: input.sessionHash,
-    exp: expiresAt,
-  };
-  const encoded = encodePayload(payload);
-  const signature = sign(encoded);
-  return `${VERSION}.${encoded}.${signature}`;
+  const expiresAt = Math.floor(Date.now() / 1000) + ttlSeconds;
+  const claims: CookieClaims = { ...payload, exp: expiresAt };
+  const encoded = encodePayload(claims);
+  const signature = sign(`${version}.${encoded}`);
+  return `${version}.${encoded}.${signature}`;
 };
 
-export const verifyReauthCookieValue = (
+const verifyCookieValue = (
+  version: CookieVersion,
   value: string | undefined,
   expected: { tenantId: string; apiResourceId: string; clientId: string; sessionHash: string },
 ) => {
   if (!value) {
     return false;
   }
-  const [version, encoded, providedSignature] = value.split(".");
-  if (version !== VERSION || !encoded || !providedSignature) {
+  const [providedVersion, encoded, providedSignature] = value.split(".");
+  if (providedVersion !== version || !encoded || !providedSignature) {
     return false;
   }
-  const expectedSignature = sign(encoded);
+  const expectedSignature = sign(`${version}.${encoded}`);
   const providedBuffer = Buffer.from(providedSignature);
   const expectedBuffer = Buffer.from(expectedSignature);
   if (providedBuffer.length !== expectedBuffer.length || !timingSafeEqual(providedBuffer, expectedBuffer)) {
     return false;
   }
-  let payload: ReauthClaims;
+  let payload: CookieClaims;
   try {
     payload = decodePayload(encoded);
   } catch {
@@ -78,3 +75,40 @@ export const verifyReauthCookieValue = (
     payload.sessionHash === expected.sessionHash
   );
 };
+
+export const FRESH_LOGIN_COOKIE_TTL_SECONDS = 60;
+
+export const createReauthCookieValue = (input: {
+  tenantId: string;
+  apiResourceId: string;
+  clientId: string;
+  sessionHash: string;
+  ttlSeconds: number;
+}) => {
+  return createCookieValue(CookieVersion.REAUTH, input, input.ttlSeconds);
+};
+
+export const verifyReauthCookieValue = (
+  value: string | undefined,
+  expected: { tenantId: string; apiResourceId: string; clientId: string; sessionHash: string },
+) => {
+  return verifyCookieValue(CookieVersion.REAUTH, value, expected);
+};
+
+export const createFreshLoginCookieValue = (input: {
+  tenantId: string;
+  apiResourceId: string;
+  clientId: string;
+  sessionHash: string;
+}) => {
+  const value = createCookieValue(CookieVersion.FRESH_LOGIN, input, FRESH_LOGIN_COOKIE_TTL_SECONDS);
+  if (!value) {
+    throw new Error("Failed to create fresh-login cookie value");
+  }
+  return value;
+};
+
+export const verifyFreshLoginCookieValue = (
+  value: string | undefined,
+  expected: { tenantId: string; apiResourceId: string; clientId: string; sessionHash: string },
+) => verifyCookieValue(CookieVersion.FRESH_LOGIN, value, expected);

--- a/src/server/services/authorize-service.ts
+++ b/src/server/services/authorize-service.ts
@@ -5,7 +5,7 @@ import { getSessionUser } from "@/server/services/mock-session-service";
 import { getClientForTenant } from "@/server/services/client-service";
 import { getApiResourceWithTenant } from "@/server/services/api-resource-service";
 import { fromPrismaLoginStrategy, parseClientAuthStrategies } from "@/server/oidc/auth-strategy";
-import { verifyReauthCookieValue } from "@/server/oidc/reauth-cookie";
+import { verifyFreshLoginCookieValue, verifyReauthCookieValue } from "@/server/oidc/reauth-cookie";
 import { hashOpaqueToken } from "@/server/crypto/opaque-token";
 
 type AuthorizeParams = {
@@ -21,7 +21,13 @@ type AuthorizeParams = {
   prompt?: string;
   sessionToken?: string;
   reauthCookie?: string;
+  freshLoginCookie?: string;
+  freshLoginRequested?: boolean;
 };
+
+type AuthorizeResult =
+  | { type: "login"; redirectTo: string; consumeFreshLoginCookie?: boolean }
+  | { type: "redirect"; redirectTo: string; consumeFreshLoginCookie?: boolean };
 
 const ensureScopes = (requested: string[], allowed: string[]) => {
   if (!requested.includes("openid")) {
@@ -34,7 +40,7 @@ const ensureScopes = (requested: string[], allowed: string[]) => {
   }
 };
 
-export const handleAuthorize = async (params: AuthorizeParams, origin: string, returnTo: string) => {
+export const handleAuthorize = async (params: AuthorizeParams, origin: string, returnTo: string): Promise<AuthorizeResult> => {
   if (params.responseType !== "code") {
     throw new DomainError("Only response_type=code is supported", { status: 400, code: "unsupported_response_type" });
   }
@@ -70,10 +76,24 @@ export const handleAuthorize = async (params: AuthorizeParams, origin: string, r
         sessionHash: sessionTokenHash,
       }),
   );
-  const hasReusableLogin = Boolean(cookieValid && session && strategyAllowed);
+  const freshLoginCookieValid = Boolean(
+    params.freshLoginRequested &&
+      sessionTokenHash &&
+      params.freshLoginCookie &&
+      verifyFreshLoginCookieValue(params.freshLoginCookie, {
+        tenantId: tenant.id,
+        apiResourceId: resource.id,
+        clientId: client.clientId,
+        sessionHash: sessionTokenHash,
+      }),
+  );
 
-  const buildLoginRedirect = () => ({
-    type: "login" as const,
+  const reusedViaFreshLogin = Boolean(freshLoginCookieValid && session && strategyAllowed);
+  const reusedViaReauthCookie = Boolean(cookieValid && session && strategyAllowed);
+  const hasReusableLogin = reusedViaFreshLogin || reusedViaReauthCookie;
+
+  const buildLoginRedirect = (): AuthorizeResult => ({
+    type: "login",
     redirectTo: `/r/${resource.id}/oidc/login?return_to=${encodeURIComponent(new URL(returnTo).toString())}`,
   });
 
@@ -87,7 +107,7 @@ export const handleAuthorize = async (params: AuthorizeParams, origin: string, r
     if (params.state) {
       redirectUrl.searchParams.set("state", params.state);
     }
-    return { type: "redirect" as const, redirectTo: redirectUrl.toString() };
+    return { type: "redirect" as const, redirectTo: redirectUrl.toString(), consumeFreshLoginCookie: reusedViaFreshLogin };
   }
 
   if (!hasReusableLogin) {
@@ -120,5 +140,5 @@ export const handleAuthorize = async (params: AuthorizeParams, origin: string, r
     redirectUrl.searchParams.set("state", params.state);
   }
 
-  return { type: "redirect" as const, redirectTo: redirectUrl.toString() };
+  return { type: "redirect" as const, redirectTo: redirectUrl.toString(), consumeFreshLoginCookie: reusedViaFreshLogin };
 };

--- a/tests/e2e/test-oauth-flow.spec.ts
+++ b/tests/e2e/test-oauth-flow.spec.ts
@@ -175,6 +175,25 @@ test.describe("Client Test OAuth", () => {
     }
   });
 
+  test("fresh login handshake completes authorize once when TTL is zero", async ({ page }) => {
+    const sessionToken = await createTestSession(page, { tenantId: QA_TENANT_ID, role: "OWNER" });
+    await authenticate(page, sessionToken);
+
+    const clientId = await openClientDetail(page, QA_TENANT_ID, QA_CLIENT_NAME);
+    await setClientReauthTtl(page, clientId, 0);
+
+    await startOauthTest(page, clientId);
+    await expect(page.getByTestId("test-oauth-id-token")).toBeVisible();
+    await expect(page.getByTestId("test-oauth-access-token")).toBeVisible();
+
+    await page.getByRole("link", { name: "← Back to test config" }).click();
+    await expect(page).toHaveURL(new RegExp(`/admin/clients/${clientId}/test`));
+
+    const { authorizationUrl } = await startOauthTest(page, clientId, { skipOpen: true, fromConfigPage: true });
+    await page.goto(authorizationUrl);
+    await expect(page).toHaveURL(/\/r\/.*\/oidc\/login/);
+  });
+
   test("surfaces authorization errors on the redirect page", async ({ page }) => {
     const sessionToken = await createTestSession(page, { tenantId: QA_TENANT_ID, role: "OWNER" });
     await authenticate(page, sessionToken);


### PR DESCRIPTION
## Summary
- mint an issuer/client/resource-scoped fresh-login cookie at `/oidc/login/submit`, tag redirects with `fresh_login=1`, and keep reauth cookie issuance untouched
- teach `/oidc/authorize` + `handleAuthorize` to validate the new cookie + query pair, bypass TTL=0 once, and clear the cookie after use while leaving prompt+TTL behavior unchanged
- cover the flow with unit/integration specs plus a Playwright scenario that ensures TTL=0 no longer loops but still forces another login afterwards

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test

Closes #81
