### PR TITLE
feat(admin): support custom client scopes

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -13,3 +13,4 @@ MOCKAUTH_KEY_ENCRYPTION_SECRET=abcdefghijklmnopqrstuvwxyz123456
 MOCKAUTH_ALLOW_ANY_REDIRECT=false
 ENABLE_TEST_ROUTES=true
 MOCKAUTH_ALLOW_INSECURE_TEST_COOKIE=true
+PLAYWRIGHT_LD_LIBRARY_PATH=../playwright-libs/sysroot/usr/lib/x86_64-linux-gnu:../playwright-libs/sysroot/usr/lib/x86_64-linux-gnu/gbm

--- a/README.md
+++ b/README.md
@@ -137,13 +137,13 @@ updates). CI runs this script automatically before executing E2E specs.
 
 ### Per-client scopes
 
-- Mockauth currently supports three OIDC scopes: `openid`, `profile`, and `email`. `openid` is mandatory and cannot be
-  removed.
-- Every client defaults to all three scopes. The Admin UI exposes a **Scopes** card on each client so QA can toggle
-  `profile` and `email` independently; `openid` is always locked on.
-- Discovery advertises the server-wide set via `scopes_supported`. The authorize endpoint additionally enforces each
-  client's allowed scopes, returning `invalid_scope` if a request is missing `openid`, includes unsupported scopes, or
-  asks for scopes that were disabled for that client.
+- Mockauth seeds clients with the OIDC defaults `openid`, `profile`, and `email`, but you can add any custom scope that
+  matches `^[a-z0-9:_-]{1,64}$`. `openid` remains mandatory and cannot be removed.
+- The Admin UI exposes a tags-based **Scopes** card on each client. Use the suggestions for standard OIDC scopes or type
+  custom values; duplicates are ignored automatically.
+- Discovery advertises only the platform-wide OIDC defaults via `scopes_supported`. Custom scopes stay per-client and
+  opaque to discovery.
+- The authorize endpoint validates that every requested scope is allowed for the client and still requires `openid`.
 
 ### Breaking Change — Stage 2 (resource-scoped issuers)
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,29 @@
+import path from "node:path";
+
 import { defineConfig, devices } from "@playwright/test";
+
+const projectRoot = process.cwd();
+const ldLibrarySegments = (process.env.PLAYWRIGHT_LD_LIBRARY_PATH ?? "")
+  .split(":")
+  .map((segment) => segment.trim())
+  .filter(Boolean)
+  .map((segment) =>
+    path.isAbsolute(segment) ? segment : path.resolve(projectRoot, segment),
+  );
+
+const chromiumLdLibraryPath = [
+  "/usr/lib/x86_64-linux-gnu",
+  "/lib/x86_64-linux-gnu",
+  ...ldLibrarySegments,
+  path.resolve(
+    projectRoot,
+    ".playwright-browsers",
+    "chromium_headless_shell-1208",
+    "chrome-headless-shell-linux64",
+  ),
+]
+  .filter(Boolean)
+  .join(":");
 
 export default defineConfig({
   testDir: "tests/e2e",
@@ -9,6 +34,12 @@ export default defineConfig({
   use: {
     baseURL: process.env.PLAYWRIGHT_BASE_URL ?? "http://127.0.0.1:3000",
     trace: "on-first-retry",
+    launchOptions: {
+      env: {
+        ...process.env,
+        LD_LIBRARY_PATH: chromiumLdLibraryPath,
+      },
+    },
   },
   projects: [
     {
@@ -17,7 +48,9 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: "pnpm build && pnpm exec next start --hostname 127.0.0.1 --port 3000",
+    command:
+      process.env.PLAYWRIGHT_WEB_SERVER_CMD ??
+      "pnpm build && pnpm exec next start --hostname 127.0.0.1 --port 3000",
     url: "http://127.0.0.1:3000/api/health",
     reuseExistingServer: !process.env.CI,
     stdout: "pipe",

--- a/scripts/run-playwright-suite.mjs
+++ b/scripts/run-playwright-suite.mjs
@@ -2,9 +2,12 @@
 import { spawn } from 'node:child_process';
 import { readdirSync, statSync } from 'node:fs';
 import path from 'node:path';
+import dotenv from 'dotenv';
 
 const projectRoot = process.cwd();
 const testsDir = path.resolve(projectRoot, 'tests/e2e');
+
+dotenv.config({ path: path.resolve(projectRoot, '.env.test'), override: true });
 
 const args = process.argv.slice(2);
 const requestedSpecs = args.filter((arg) => !arg.startsWith('--'));
@@ -34,19 +37,23 @@ if (specsToRun.length === 0) {
 const env = {
   ...process.env,
   PLAYWRIGHT_BROWSERS_PATH: path.resolve(projectRoot, '.playwright-browsers'),
+  LD_LIBRARY_PATH: [
+    '/usr/lib/x86_64-linux-gnu',
+    '/lib/x86_64-linux-gnu',
+    path.resolve(projectRoot, '.playwright-browsers', 'chromium_headless_shell-1208', 'chrome-headless-shell-linux64'),
+    process.env.LD_LIBRARY_PATH ?? '',
+  ]
+    .filter(Boolean)
+    .join(':'),
 };
 
 const runSpec = (spec) =>
   new Promise((resolve, reject) => {
     process.stdout.write(`\n=== Running ${spec} ===\n`);
-    const child = spawn(
-      'pnpm',
-      ['exec', 'dotenv', '-e', '.env.test', '-o', '--', 'playwright', 'test', spec, '--reporter=line', '--workers=1'],
-      {
-        stdio: 'inherit',
-        env,
-      },
-    );
+    const child = spawn('pnpm', ['exec', 'playwright', 'test', spec, '--reporter=line', '--workers=1'], {
+      stdio: 'inherit',
+      env,
+    });
 
     const keepalive = setInterval(() => {
       process.stdout.write(`[keepalive] ${new Date().toISOString()} ${spec}\n`);

--- a/src/app/admin/__tests__/update-client-scopes-action.test.ts
+++ b/src/app/admin/__tests__/update-client-scopes-action.test.ts
@@ -66,9 +66,19 @@ describe("updateClientScopesAction", () => {
   it("updates scopes with canonical ordering", async () => {
     const result = await updateClientScopesAction({ clientId: "client_internal", scopes: ["email", "openid", "profile"] });
 
-    expect(result).toEqual({ success: "Scopes updated", data: { allowedScopes: ["openid", "profile", "email"] } });
-    expect(mockUpdateScopes).toHaveBeenCalledWith("client_internal", ["openid", "profile", "email"]);
+    expect(result).toEqual({ success: "Scopes updated", data: { allowedScopes: ["openid", "email", "profile"] } });
+    expect(mockUpdateScopes).toHaveBeenCalledWith("client_internal", ["openid", "email", "profile"]);
     expect(mockRevalidate).toHaveBeenCalledWith("/admin/clients/client_internal");
+  });
+
+  it("allows custom scopes that match the required pattern", async () => {
+    const result = await updateClientScopesAction({
+      clientId: "client_internal",
+      scopes: ["openid", "profile", "tenant:write"],
+    });
+
+    expect(result).toEqual({ success: "Scopes updated", data: { allowedScopes: ["openid", "profile", "tenant:write"] } });
+    expect(mockUpdateScopes).toHaveBeenCalledWith("client_internal", ["openid", "profile", "tenant:write"]);
   });
 
   it("returns an error when openid is missing", async () => {
@@ -78,10 +88,10 @@ describe("updateClientScopesAction", () => {
     expect(mockUpdateScopes).not.toHaveBeenCalled();
   });
 
-  it("returns an error for unsupported scopes", async () => {
-    const result = await updateClientScopesAction({ clientId: "client_internal", scopes: ["openid", "address"] });
+  it("returns an error for invalid scope formats", async () => {
+    const result = await updateClientScopesAction({ clientId: "client_internal", scopes: ["openid", "invalid scope"] });
 
-    expect(result).toEqual({ error: "Unsupported scopes: address" });
+    expect(result).toEqual({ error: "Scopes must match ^[a-z0-9:_-]{1,64}$: invalid scope" });
     expect(mockUpdateScopes).not.toHaveBeenCalled();
   });
 

--- a/src/app/admin/actions.ts
+++ b/src/app/admin/actions.ts
@@ -51,7 +51,7 @@ import { buildOidcUrls } from "@/server/oidc/url-builder";
 import { resolveRedirectUri } from "@/server/oidc/redirect-uri";
 import { createOauthTestSession, resetOauthTestSessionsForClient } from "@/server/services/oauth-test-service";
 import { clearOauthTestSecretCookie, setOauthTestSecretCookie } from "@/server/oauth/test-cookie";
-import { isSupportedScope, normalizeScopes, SUPPORTED_SCOPES } from "@/server/oidc/scopes";
+import { isValidScopeValue, normalizeScopes, SUPPORTED_SCOPES } from "@/server/oidc/scopes";
 
 const OAUTH_TEST_SESSION_TTL_MINUTES = 15;
 
@@ -200,11 +200,11 @@ export const createClientAction = async (
     if (!normalizedScopes.includes("openid")) {
       return { error: "Scopes must include openid" };
     }
-    const unsupported = normalizedScopes.filter((scope) => !isSupportedScope(scope));
-    if (unsupported.length > 0) {
-      return { error: `Unsupported scopes: ${unsupported.join(", ")}` };
+    const invalid = normalizedScopes.filter((scope) => !isValidScopeValue(scope));
+    if (invalid.length > 0) {
+      return { error: `Scopes must match ^[a-z0-9:_-]{1,64}$: ${invalid.join(", ")}` };
     }
-    const canonicalScopes = SUPPORTED_SCOPES.filter((scope) => normalizedScopes.includes(scope));
+    const canonicalScopes = ["openid", ...normalizedScopes.filter((scope) => scope !== "openid")];
     const { client, clientSecret } = await createClient(parsed.tenantId, {
       name: parsed.name,
       clientType: parsed.type,
@@ -510,12 +510,11 @@ export const updateClientScopesAction = async (
     if (!normalized.includes("openid")) {
       return { error: "Scopes must include openid" };
     }
-    const unsupported = normalized.filter((scope) => !isSupportedScope(scope));
-    if (unsupported.length > 0) {
-      return { error: `Unsupported scopes: ${unsupported.join(", ")}` };
+    const invalid = normalized.filter((scope) => !isValidScopeValue(scope));
+    if (invalid.length > 0) {
+      return { error: `Scopes must match ^[a-z0-9:_-]{1,64}$: ${invalid.join(", ")}` };
     }
-
-    const canonical = SUPPORTED_SCOPES.filter((scope) => normalized.includes(scope));
+    const canonical = ["openid", ...normalized.filter((scope) => scope !== "openid")];
     await updateClientAllowedScopes(client.id, canonical);
     revalidatePath(clientPath(client.id));
     return { success: "Scopes updated", data: { allowedScopes: canonical } };

--- a/src/app/admin/clients/[clientId]/client-forms.tsx
+++ b/src/app/admin/clients/[clientId]/client-forms.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useEffect, useState, useTransition } from "react";
+import { useEffect, useReducer, useState, useTransition, type FormEvent, type KeyboardEvent } from "react";
 import { useRouter } from "next/navigation";
 import { z } from "zod";
-import { Loader2, Trash2 } from "lucide-react";
+import { Loader2, Trash2, X } from "lucide-react";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm, useWatch } from "react-hook-form";
 
@@ -18,6 +18,7 @@ import {
   updateClientReauthTtlAction,
 } from "@/app/admin/actions";
 import { CopyField } from "@/app/admin/_components/copy-field";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { useToast } from "@/components/ui/use-toast";
@@ -27,6 +28,7 @@ import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import type { ClientAuthStrategies } from "@/server/oidc/auth-strategy";
 import { cn } from "@/lib/utils";
+import { isValidScopeValue, normalizeScopes } from "@/server/oidc/scopes";
 
 const nameSchema = z.object({ name: z.string().min(2, "Name must be at least 2 characters") });
 const redirectSchema = z.object({
@@ -63,26 +65,6 @@ const reauthTtlSchema = z.object({
     .number()
     .int("Enter a whole number"),
 });
-const scopeTogglesSchema = z.object({
-  profile: z.boolean(),
-  email: z.boolean(),
-});
-const optionalScopeKeys = ["profile", "email"] as const;
-type OptionalScopeKey = (typeof optionalScopeKeys)[number];
-const scopeMetadata: Record<"openid" | OptionalScopeKey, { title: string; description: string }> = {
-  openid: {
-    title: "openid",
-    description: "Core scope required for all Mockauth clients.",
-  },
-  profile: {
-    title: "profile",
-    description: "Includes profile claims like preferred_username.",
-  },
-  email: {
-    title: "email",
-    description: "Includes email and email_verified claims when enabled.",
-  },
-};
 
 const formatReauthTtlSummary = (seconds: number) => {
   if (!seconds) {
@@ -112,6 +94,44 @@ const formatReauthTtlSummary = (seconds: number) => {
     parts.push(`${remainingSeconds} second${remainingSeconds === 1 ? "" : "s"}`);
   }
   return `Allows reuse for ${parts.join(" ")}.`;
+};
+
+const ensureCanonicalScopes = (values: string[]): string[] => {
+  const normalized = normalizeScopes(values);
+  if (!normalized.includes("openid")) {
+    return ["openid", ...normalized];
+  }
+  return ["openid", ...normalized.filter((scope) => scope !== "openid")];
+};
+
+type ScopeFormState = {
+  scopes: string[];
+  input: string;
+  error: string | null;
+};
+
+type ScopeFormAction =
+  | { type: "reset"; scopes: string[] }
+  | { type: "add"; scope: string }
+  | { type: "remove"; scope: string }
+  | { type: "setInput"; value: string }
+  | { type: "setError"; value: string | null };
+
+const scopeFormReducer = (state: ScopeFormState, action: ScopeFormAction): ScopeFormState => {
+  switch (action.type) {
+    case "reset":
+      return { scopes: action.scopes, input: "", error: null };
+    case "add":
+      return { scopes: ensureCanonicalScopes([...state.scopes, action.scope]), input: "", error: null };
+    case "remove":
+      return { ...state, scopes: ensureCanonicalScopes(state.scopes.filter((value) => value !== action.scope)) };
+    case "setInput":
+      return { ...state, input: action.value };
+    case "setError":
+      return { ...state, error: action.value };
+    default:
+      return state;
+  }
 };
 
 export function UpdateClientNameForm({
@@ -388,87 +408,142 @@ export function UpdateClientScopesForm({
   const router = useRouter();
   const { toast } = useToast();
   const [pending, startTransition] = useTransition();
-  const form = useForm<z.infer<typeof scopeTogglesSchema>>({
-    resolver: zodResolver(scopeTogglesSchema),
-    defaultValues: {
-      profile: initialScopes.includes("profile"),
-      email: initialScopes.includes("email"),
-    },
-  });
+  const [state, dispatch] = useReducer(scopeFormReducer, initialScopes, (scopes: string[]): ScopeFormState => ({
+    scopes: ensureCanonicalScopes(scopes),
+    input: "",
+    error: null,
+  }));
+  const { scopes, input, error } = state;
 
   useEffect(() => {
-    form.reset({ profile: initialScopes.includes("profile"), email: initialScopes.includes("email") });
-  }, [form, initialScopes]);
+    dispatch({ type: "reset", scopes: ensureCanonicalScopes(initialScopes) });
+  }, [initialScopes]);
 
-  const handleSubmit = form.handleSubmit((values) => {
-    const scopes = ["openid", ...optionalScopeKeys.filter((key) => values[key])];
+  const addScope = (raw: string) => {
+    if (!canEdit || pending) {
+      return;
+    }
+    const candidate = raw.trim().toLowerCase();
+    if (!candidate) {
+      return;
+    }
+    if (!isValidScopeValue(candidate)) {
+      dispatch({ type: "setError", value: "Scopes must match ^[a-z0-9:_-]{1,64}$" });
+      return;
+    }
+    dispatch({ type: "add", scope: candidate });
+  };
+
+  const removeScope = (scope: string) => {
+    if (!canEdit || pending || scope === "openid") {
+      return;
+    }
+    dispatch({ type: "remove", scope });
+  };
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!scopes.includes("openid")) {
+      dispatch({ type: "setError", value: "Scopes must include openid" });
+      return;
+    }
+
     startTransition(async () => {
       const result = await updateClientScopesAction({ clientId, scopes });
       if (result.error) {
         toast({ variant: "destructive", title: "Unable to update", description: result.error });
         return;
       }
+      const nextScopes = result.data?.allowedScopes ?? scopes;
+      dispatch({ type: "reset", scopes: ensureCanonicalScopes(nextScopes) });
       router.refresh();
       toast({ title: "Scopes updated", description: result.success ?? "Saved" });
     });
-  });
+  };
 
-  const renderOptionalScope = (key: OptionalScopeKey) => (
-    <FormField
-      key={key}
-      control={form.control}
-      name={key}
-      render={({ field }) => (
-        <FormItem className="rounded-md border p-3">
-          <div className="flex items-start justify-between gap-4">
-            <div>
-              <FormLabel className="text-sm font-semibold text-foreground capitalize">{scopeMetadata[key].title}</FormLabel>
-              <p className="text-xs text-muted-foreground">{scopeMetadata[key].description}</p>
-            </div>
-            <FormControl>
-              <input
-                type="checkbox"
-                className="h-4 w-4 rounded border border-muted"
-                checked={field.value}
-                onChange={(event) => field.onChange(event.target.checked)}
-                disabled={!canEdit || pending}
-                data-testid={`scope-${key}-toggle`}
-              />
-            </FormControl>
-          </div>
-        </FormItem>
-      )}
-    />
-  );
+  const handleInputKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Enter" || event.key === ",") {
+      event.preventDefault();
+      addScope(input);
+    }
+  };
+
+  const suggestedScopes = ["profile", "email", "address", "phone", "offline_access"];
 
   return (
-    <Form {...form}>
-      <form onSubmit={handleSubmit} className="space-y-4">
-        <div className="space-y-3">
-          <div className="rounded-md border bg-muted/50 p-3">
-            <div className="flex items-start justify-between gap-4">
-              <div>
-                <p className="text-sm font-semibold text-foreground capitalize">{scopeMetadata.openid.title}</p>
-                <p className="text-xs text-muted-foreground">{scopeMetadata.openid.description}</p>
-              </div>
-              <input
-                type="checkbox"
-                className="h-4 w-4 rounded border border-muted"
-                checked
-                readOnly
-                disabled
-                data-testid="scope-openid-toggle"
-              />
-            </div>
-          </div>
-          {optionalScopeKeys.map(renderOptionalScope)}
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="space-y-3">
+        <div>
+          <p className="text-sm font-semibold text-foreground">Allowed scopes</p>
+          <p className="text-xs text-muted-foreground">
+            openid is required. Additional scopes must match the pattern {"^[a-z0-9:_-]{1,64}$"}.
+          </p>
         </div>
-        <p className="text-xs text-muted-foreground">openid is mandatory; profile and email control returned claims.</p>
-        <Button type="submit" disabled={!canEdit || pending} className="w-full sm:w-auto" data-testid="scope-save-button">
-          {pending ? <Loader2 className="h-4 w-4 animate-spin" /> : canEdit ? "Save scopes" : "Read-only"}
-        </Button>
-      </form>
-    </Form>
+        <div className="flex flex-wrap gap-2" data-testid="scope-chip-list">
+          {scopes.map((scope) => (
+            <Badge
+              key={scope}
+              variant="secondary"
+              className="flex items-center gap-1 rounded-full px-3 py-1 text-xs"
+              data-testid={`scope-chip-${scope}`}
+            >
+              {scope}
+              {scope !== "openid" && canEdit ? (
+                <button
+                  type="button"
+                  onClick={() => removeScope(scope)}
+                  className="ml-1 inline-flex h-4 w-4 items-center justify-center rounded-full text-muted-foreground hover:text-destructive"
+                  aria-label={`Remove ${scope}`}
+                  data-testid={`remove-scope-${scope}`}
+                  disabled={pending}
+                >
+                  <X className="h-3 w-3" />
+                </button>
+              ) : null}
+            </Badge>
+          ))}
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <Input
+          value={input}
+          onChange={(event) => {
+            dispatch({ type: "setInput", value: event.target.value });
+            if (error) {
+              dispatch({ type: "setError", value: null });
+            }
+          }}
+          onKeyDown={handleInputKeyDown}
+          placeholder="Add a scope and press Enter"
+          disabled={!canEdit || pending}
+          data-testid="scope-input"
+        />
+        {error ? <p className="text-xs font-medium text-destructive">{error}</p> : null}
+        <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+          {suggestedScopes
+            .filter((scope) => !scopes.includes(scope))
+            .map((scope) => (
+              <Button
+                key={scope}
+                type="button"
+                size="sm"
+                variant="outline"
+                className="h-7 px-2 text-xs"
+                onClick={() => addScope(scope)}
+                disabled={!canEdit || pending}
+                data-testid={`scope-suggestion-${scope}`}
+              >
+                {scope}
+              </Button>
+            ))}
+        </div>
+      </div>
+
+      <Button type="submit" disabled={!canEdit || pending} className="w-full sm:w-auto" data-testid="scope-save-button">
+        {pending ? <Loader2 className="h-4 w-4 animate-spin" /> : canEdit ? "Save scopes" : "Read-only"}
+      </Button>
+    </form>
   );
 }
 

--- a/src/app/admin/clients/__tests__/update-client-scopes-form.test.tsx
+++ b/src/app/admin/clients/__tests__/update-client-scopes-form.test.tsx
@@ -40,7 +40,7 @@ describe("UpdateClientScopesForm", () => {
     const user = userEvent.setup();
     render(<UpdateClientScopesForm clientId="client_1" initialScopes={["openid"]} canEdit />);
 
-    await user.click(screen.getByTestId("scope-profile-toggle"));
+    await user.click(screen.getByTestId("scope-suggestion-profile"));
     await user.click(screen.getByTestId("scope-save-button"));
 
     await waitFor(() => {
@@ -55,11 +55,11 @@ describe("UpdateClientScopesForm", () => {
     mockUpdateClientScopesAction.mockResolvedValueOnce({ error: "Unsupported scope" });
     render(<UpdateClientScopesForm clientId="client_2" initialScopes={["openid", "email"]} canEdit />);
 
-    await user.click(screen.getByTestId("scope-profile-toggle"));
+    await user.click(screen.getByTestId("scope-suggestion-profile"));
     await user.click(screen.getByTestId("scope-save-button"));
 
     await waitFor(() => {
-      expect(mockUpdateClientScopesAction).toHaveBeenCalledWith({ clientId: "client_2", scopes: ["openid", "profile", "email"] });
+      expect(mockUpdateClientScopesAction).toHaveBeenCalledWith({ clientId: "client_2", scopes: ["openid", "email", "profile"] });
     });
     expect(mockToast).toHaveBeenCalledWith({ variant: "destructive", title: "Unable to update", description: "Unsupported scope" });
     expect(mockRefresh).not.toHaveBeenCalled();
@@ -68,9 +68,10 @@ describe("UpdateClientScopesForm", () => {
   it("renders a read-only state when editing is disabled", () => {
     render(<UpdateClientScopesForm clientId="client_3" initialScopes={["openid", "profile", "email"]} canEdit={false} />);
 
-    expect(screen.getByTestId("scope-openid-toggle")).toBeDisabled();
-    expect(screen.getByTestId("scope-profile-toggle")).toBeDisabled();
+    expect(screen.getByTestId("scope-input")).toBeDisabled();
     expect(screen.getByTestId("scope-save-button")).toBeDisabled();
     expect(screen.getByTestId("scope-save-button")).toHaveTextContent("Read-only");
+    expect(screen.queryByTestId("remove-scope-profile")).not.toBeInTheDocument();
+    expect(screen.getByTestId("scope-suggestion-address")).toBeDisabled();
   });
 });

--- a/src/server/oidc/__tests__/oidc-flow.test.ts
+++ b/src/server/oidc/__tests__/oidc-flow.test.ts
@@ -187,7 +187,7 @@ describe("OIDC flow", () => {
     ).rejects.toThrowError("scope must include openid");
   });
 
-  it("rejects authorize requests with unsupported scopes", async () => {
+  it("rejects authorize requests with scopes outside the client allowlist", async () => {
     const challenge = computeS256Challenge(codeVerifier);
     await expect(
       handleAuthorize(
@@ -205,7 +205,7 @@ describe("OIDC flow", () => {
         "https://mockauth.test",
         `https://mockauth.test/r/${apiResourceId}/oidc/authorize?client_id=${CLIENT_ID}`,
       ),
-    ).rejects.toThrowError("Unsupported scopes: offline_access");
+    ).rejects.toThrowError("Client does not allow scopes: offline_access");
   });
 
   it("rejects scopes disabled for the client", async () => {

--- a/src/server/oidc/__tests__/scopes.test.ts
+++ b/src/server/oidc/__tests__/scopes.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { isSupportedScope, normalizeScopes, SUPPORTED_SCOPES } from "@/server/oidc/scopes";
+import { isSupportedScope, isValidScopeValue, normalizeScopes, SUPPORTED_SCOPES } from "@/server/oidc/scopes";
 
 describe("OIDC scopes", () => {
   it("normalizes scope values", () => {
@@ -18,5 +18,13 @@ describe("OIDC scopes", () => {
       expect(isSupportedScope(scope)).toBe(true);
     }
     expect(isSupportedScope("offline_access")).toBe(false);
+  });
+
+  it("validates scope values", () => {
+    expect(isValidScopeValue("openid")).toBe(true);
+    expect(isValidScopeValue("tenant:admin")).toBe(true);
+    expect(isValidScopeValue("invalid scope")).toBe(false);
+    expect(isValidScopeValue("UPPERCASE")).toBe(false);
+    expect(isValidScopeValue("a".repeat(65))).toBe(false);
   });
 });

--- a/src/server/oidc/scopes.ts
+++ b/src/server/oidc/scopes.ts
@@ -2,6 +2,8 @@ export const SUPPORTED_SCOPES = ["openid", "profile", "email"] as const;
 
 export type SupportedScope = (typeof SUPPORTED_SCOPES)[number];
 
+export const SCOPE_VALUE_PATTERN = /^[a-z0-9:_-]{1,64}$/;
+
 export const normalizeScopes = (scopes: string[]): string[] => {
   const seen = new Set<string>();
   const normalized: string[] = [];
@@ -18,4 +20,8 @@ export const normalizeScopes = (scopes: string[]): string[] => {
 
 export const isSupportedScope = (scope: string): scope is SupportedScope => {
   return SUPPORTED_SCOPES.includes(scope as SupportedScope);
+};
+
+export const isValidScopeValue = (scope: string): boolean => {
+  return SCOPE_VALUE_PATTERN.test(scope);
 };

--- a/src/server/services/__tests__/client-service.test.ts
+++ b/src/server/services/__tests__/client-service.test.ts
@@ -52,22 +52,22 @@ describe("client service", () => {
     const { client } = await createClient(tenant.id, {
       name: "QA Tester",
       clientType: "PUBLIC",
-      allowedScopes: ["openid", "email"],
+      allowedScopes: ["openid", "tenant:write", "profile"],
     });
 
     const stored = await prisma.client.findUnique({ where: { id: client.id } });
-    expect(stored?.allowedScopes).toEqual(["openid", "email"]);
+    expect(stored?.allowedScopes).toEqual(["openid", "tenant:write", "profile"]);
   });
 
-  it("rejects unsupported scopes", async () => {
+  it("rejects invalid scope formats", async () => {
     const tenant = await createTenant();
     await expect(
       createClient(tenant.id, {
         name: "Bad Scope",
         clientType: "PUBLIC",
-        allowedScopes: ["openid", "offline_access"],
+        allowedScopes: ["openid", "invalid scope"],
       }),
-    ).rejects.toThrowError("Unsupported scope configured: offline_access");
+    ).rejects.toThrowError("Invalid scope format: invalid scope");
   });
 
   it("fetches a client scoped to a tenant", async () => {

--- a/src/server/services/authorize-service.ts
+++ b/src/server/services/authorize-service.ts
@@ -5,7 +5,7 @@ import { getSessionUser } from "@/server/services/mock-session-service";
 import { getClientForTenant } from "@/server/services/client-service";
 import { getApiResourceWithTenant } from "@/server/services/api-resource-service";
 import { fromPrismaLoginStrategy, parseClientAuthStrategies } from "@/server/oidc/auth-strategy";
-import { isSupportedScope, normalizeScopes } from "@/server/oidc/scopes";
+import { normalizeScopes } from "@/server/oidc/scopes";
 import { verifyFreshLoginCookieValue, verifyReauthCookieValue } from "@/server/oidc/reauth-cookie";
 import { hashOpaqueToken } from "@/server/crypto/opaque-token";
 
@@ -36,11 +36,6 @@ const ensureScopes = (requestedScopes: string[], allowedScopes: string[]) => {
 
   if (!requested.includes("openid")) {
     throw new DomainError("scope must include openid", { status: 400, code: "invalid_scope" });
-  }
-
-  const unsupported = requested.filter((scope) => !isSupportedScope(scope));
-  if (unsupported.length > 0) {
-    throw new DomainError(`Unsupported scopes: ${unsupported.join(", ")}`, { status: 400, code: "invalid_scope" });
   }
 
   const notAllowed = requested.filter((scope) => !allowed.has(scope));

--- a/src/server/services/client-service.ts
+++ b/src/server/services/client-service.ts
@@ -9,19 +9,18 @@ import { DomainError } from "@/server/errors";
 import { classifyRedirect } from "@/server/oidc/redirect-uri";
 import type { ClientAuthStrategies } from "@/server/oidc/auth-strategy";
 import { DEFAULT_CLIENT_AUTH_STRATEGIES } from "@/server/oidc/auth-strategy";
-import { isSupportedScope, normalizeScopes, SUPPORTED_SCOPES } from "@/server/oidc/scopes";
+import { isValidScopeValue, normalizeScopes, SUPPORTED_SCOPES } from "@/server/oidc/scopes";
 
 const canonicalizeAllowedScopes = (scopes?: string[]) => {
-  const normalized = scopes ? normalizeScopes(scopes) : Array.from(SUPPORTED_SCOPES);
+  const normalized = scopes && scopes.length > 0 ? normalizeScopes(scopes) : Array.from(SUPPORTED_SCOPES);
   if (!normalized.includes("openid")) {
     throw new Error("Allowed scopes must include openid");
   }
-  for (const scope of normalized) {
-    if (!isSupportedScope(scope)) {
-      throw new Error(`Unsupported scope configured: ${scope}`);
-    }
+  const invalid = normalized.filter((scope) => !isValidScopeValue(scope));
+  if (invalid.length > 0) {
+    throw new Error(`Invalid scope format: ${invalid.join(", ")}`);
   }
-  return SUPPORTED_SCOPES.filter((scope) => normalized.includes(scope));
+  return ["openid", ...normalized.filter((scope) => scope !== "openid")];
 };
 
 export const getClientForTenant = async (tenantId: string, clientId: string) => {

--- a/tests/e2e/auth-strategies.spec.ts
+++ b/tests/e2e/auth-strategies.spec.ts
@@ -34,8 +34,13 @@ test.describe("auth strategy persistence", () => {
     await selectTenant(page, tenantId);
     const searchBox = page.getByRole("textbox", { name: "Search clients" });
     await searchBox.fill("QA Client");
-    await expect(page.getByRole("row", { name: /QA Client/i })).toBeVisible();
-    await page.getByRole("row", { name: /QA Client/i }).first().getByRole("link", { name: "Details →" }).click();
+    const clientRow = page.getByRole("row", { name: /QA Client/i }).first();
+    await expect(clientRow).toBeVisible();
+    const detailsLink = clientRow.getByRole("link", { name: "Details →" });
+    await expect(detailsLink).toBeVisible();
+    const clientHref = await detailsLink.getAttribute("href");
+    expect(clientHref).toBeTruthy();
+    await page.goto(clientHref!, { waitUntil: "domcontentloaded" });
     await updateSelect(page, page.getByTestId("strategy-username-subsource"), "Generate UUID (stable per identity)");
     const emailToggle = page.getByTestId("strategy-email-enabled");
     await emailToggle.check();

--- a/tests/e2e/collaboration.spec.ts
+++ b/tests/e2e/collaboration.spec.ts
@@ -123,10 +123,12 @@ test.describe("collaboration", () => {
     const readOnlyButton = readerPage.getByRole("button", { name: "Read-only access" });
     await expect(readOnlyButton).toBeDisabled();
 
-    const detailsLink = readerPage.getByRole("link", { name: /Details/ }).first();
-    await detailsLink.click();
-    await expect(readerPage.getByRole("button", { name: "Read-only" })).toBeDisabled();
-    await expect(readerPage.getByRole("button", { name: "Add" })).toBeDisabled();
+    const detailsLink = readerPage.getByRole("link", { name: "Details →" }).first();
+    const detailsHref = await detailsLink.getAttribute("href");
+    expect(detailsHref).toBeTruthy();
+    await readerPage.goto(detailsHref!, { waitUntil: "domcontentloaded" });
+    await expect(readerPage.getByTestId("scope-save-button")).toBeDisabled();
+    await expect(readerPage.getByRole("button", { name: "Add", exact: true })).toBeDisabled();
     await expect(readerPage.getByText("Client secrets can only be rotated by owners or writers.")).toBeVisible();
     await readerContext.close();
   });

--- a/tests/e2e/test-oauth-flow.spec.ts
+++ b/tests/e2e/test-oauth-flow.spec.ts
@@ -308,7 +308,11 @@ const openClientDetail = async (page: Page, tenantId: string, clientName: string
   await searchBox.fill(clientName);
   const row = page.getByRole("row", { name: new RegExp(clientName, "i") }).first();
   await expect(row).toBeVisible();
-  await row.getByRole("link", { name: "Details →" }).click();
+  const link = row.getByRole("link", { name: "Details →" });
+  await expect(link).toBeVisible();
+  const href = await link.getAttribute("href");
+  expect(href).toBeTruthy();
+  await page.goto(href!, { waitUntil: "domcontentloaded" });
   await expect(page).toHaveURL(/\/admin\/clients\//);
   const currentUrl = new URL(page.url());
   const segments = currentUrl.pathname.split("/");


### PR DESCRIPTION
## Summary
- allow client scopes to include custom values while keeping openid mandatory
- update admin console scope management UI to chip input with validation and suggestions
- ensure discovery `scopes_supported` stays at defaults and adjust tests/docs accordingly

## Testing
- pnpm lint
- pnpm test
- PLAYWRIGHT_WEB_SERVER_CMD='pnpm exec next start --hostname 127.0.0.1 --port 3000' pnpm test:e2e:serial

Closes #83
