### PR TITLE
feat: support per-client signing algorithms

### DIFF
--- a/prisma/migrations/20260226022330_issue_86_jwt_algs/migration.sql
+++ b/prisma/migrations/20260226022330_issue_86_jwt_algs/migration.sql
@@ -1,0 +1,17 @@
+-- CreateEnum
+CREATE TYPE "JwtSigningAlg" AS ENUM ('RS256', 'PS256', 'ES256', 'ES384');
+
+-- DropIndex
+DROP INDEX "TenantKey_tenantId_status_idx";
+
+-- AlterTable
+ALTER TABLE "Client" ADD COLUMN     "accessTokenSigningAlg" "JwtSigningAlg",
+ADD COLUMN     "idTokenSignedResponseAlg" "JwtSigningAlg";
+
+-- AlterTable
+ALTER TABLE "TenantKey"
+    ALTER COLUMN "alg" TYPE "JwtSigningAlg" USING ("alg"::"JwtSigningAlg"),
+    ALTER COLUMN "alg" SET DEFAULT 'RS256';
+
+-- CreateIndex
+CREATE INDEX "TenantKey_tenantId_alg_status_idx" ON "TenantKey"("tenantId", "alg", "status");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -42,6 +42,13 @@ enum TokenEndpointAuthMethod {
   none
 }
 
+enum JwtSigningAlg {
+  RS256
+  PS256
+  ES256
+  ES384
+}
+
 enum LoginStrategy {
   USERNAME
   EMAIL
@@ -145,6 +152,8 @@ model Client {
   allowedResponseTypes     String[]                 @default(["code"])
   pkceRequired             Boolean                  @default(true)
   tokenEndpointAuthMethod  TokenEndpointAuthMethod  @default(client_secret_basic)
+  idTokenSignedResponseAlg JwtSigningAlg?
+  accessTokenSigningAlg    JwtSigningAlg?
   authStrategies           Json                     @default("{\"username\":{\"enabled\":true,\"subSource\":\"entered\"},\"email\":{\"enabled\":false,\"subSource\":\"entered\",\"emailVerifiedMode\":\"false\"}}")
   reauthTtlSeconds         Int                      @default(0)
   redirectUris             RedirectUri[]
@@ -168,20 +177,20 @@ model RedirectUri {
 }
 
 model TenantKey {
-  id                   String     @id @default(uuid())
-  tenant               Tenant     @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  id                   String        @id @default(uuid())
+  tenant               Tenant        @relation(fields: [tenantId], references: [id], onDelete: Cascade)
   tenantId             String
   kid                  String
   kty                  String
-  alg                  String
-  use                  String     @default("sig")
-  status               KeyStatus  @default(ACTIVE)
+  alg                  JwtSigningAlg @default(RS256)
+  use                  String        @default("sig")
+  status               KeyStatus     @default(ACTIVE)
   publicJwk            Json
   privateJwkEncrypted  String
-  createdAt            DateTime   @default(now())
-  updatedAt            DateTime   @updatedAt
+  createdAt            DateTime      @default(now())
+  updatedAt            DateTime      @updatedAt
   @@unique([tenantId, kid])
-  @@index([tenantId, status])
+  @@index([tenantId, alg, status])
 }
 
 model MockUser {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -2,7 +2,8 @@ import { hashSecret } from "@/server/crypto/hash";
 import { encrypt } from "@/server/crypto/key-vault";
 import { prisma } from "@/server/db/client";
 import { classifyRedirect } from "@/server/oidc/redirect-uri";
-import { ensureActiveKey } from "@/server/services/key-service";
+import { ensureActiveKeyForAlg } from "@/server/services/key-service";
+import { DEFAULT_JWT_SIGNING_ALG } from "@/server/oidc/signing-alg";
 
 const DEFAULT_TENANT_ID = "tenant_qa";
 const DEFAULT_TENANT_NAME = "QA Sandbox";
@@ -30,7 +31,7 @@ async function main() {
     await prisma.tenant.update({ where: { id: tenant.id }, data: { defaultApiResourceId: apiResource.id } });
   }
 
-  await ensureActiveKey(tenant.id);
+  await ensureActiveKeyForAlg(tenant.id, DEFAULT_JWT_SIGNING_ALG);
 
   const client = await prisma.client.upsert({
     where: { tenantId_clientId: { tenantId: tenant.id, clientId: DEFAULT_CLIENT_ID } },

--- a/src/app/admin/__tests__/update-client-signing-algs-action.test.ts
+++ b/src/app/admin/__tests__/update-client-signing-algs-action.test.ts
@@ -1,0 +1,121 @@
+/* @vitest-environment node */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next-auth", () => ({
+  getServerSession: vi.fn(),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+vi.mock("@/server/auth/options", () => ({ authOptions: {} }));
+
+vi.mock("@/server/services/tenant-service", () => ({
+  assertTenantMembership: vi.fn(),
+  assertTenantRole: vi.fn(),
+  ensureMembershipRole: vi.fn(),
+  createTenant: vi.fn(),
+  deleteTenant: vi.fn(),
+  getTenantMemberships: vi.fn(),
+}));
+
+vi.mock("@/server/services/client-service", () => ({
+  addRedirectUri: vi.fn(),
+  createClient: vi.fn(),
+  rotateClientSecret: vi.fn(),
+  updateClientName: vi.fn(),
+  updateClientApiResource: vi.fn(),
+  updateClientAuthStrategies: vi.fn(),
+  updateClientReauthTtl: vi.fn(),
+  updateClientAllowedScopes: vi.fn(),
+  updateClientSigningAlgorithms: vi.fn(),
+  getConfidentialClientSecret: vi.fn(),
+}));
+
+vi.mock("@/server/db/client", () => ({
+  prisma: {
+    client: {
+      findUnique: vi.fn(),
+    },
+  },
+}));
+
+import { updateClientSigningAlgsAction } from "../actions";
+import { getServerSession } from "next-auth";
+import { revalidatePath } from "next/cache";
+import { prisma } from "@/server/db/client";
+import { assertTenantMembership } from "@/server/services/tenant-service";
+import { updateClientSigningAlgorithms } from "@/server/services/client-service";
+
+const mockSession = vi.mocked(getServerSession);
+const mockRevalidate = vi.mocked(revalidatePath);
+const mockFindClient = vi.mocked(prisma.client.findUnique);
+const mockAssertMembership = vi.mocked(assertTenantMembership);
+const mockUpdateSigning = vi.mocked(updateClientSigningAlgorithms);
+
+describe("updateClientSigningAlgsAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSession.mockResolvedValue({ user: { id: "admin_1" } } as never);
+    mockAssertMembership.mockResolvedValue({ role: "OWNER" } as never);
+    mockFindClient.mockResolvedValue({ id: "client_internal", tenantId: "tenant_1", clientType: "CONFIDENTIAL" } as never);
+    mockUpdateSigning.mockResolvedValue({} as never);
+  });
+
+  it("updates signing algorithms when overrides are provided", async () => {
+    const result = await updateClientSigningAlgsAction({
+      clientId: "client_internal",
+      idTokenAlg: "ES384",
+      accessTokenAlg: "PS256",
+    });
+
+    expect(result).toEqual({ success: "Signing algorithms updated" });
+    expect(mockUpdateSigning).toHaveBeenCalledWith("client_internal", {
+      idTokenAlg: "ES384",
+      accessTokenAlg: "PS256",
+    });
+    expect(mockRevalidate).toHaveBeenCalledWith("/admin/clients/client_internal");
+    expect(mockRevalidate).toHaveBeenCalledWith("/admin/clients");
+    expect(mockRevalidate).toHaveBeenCalledWith("/admin", "layout");
+  });
+
+  it("resets algorithms to defaults when using match options", async () => {
+    const result = await updateClientSigningAlgsAction({
+      clientId: "client_internal",
+      idTokenAlg: "default",
+      accessTokenAlg: "match_id",
+    });
+
+    expect(result).toEqual({ success: "Signing algorithms updated" });
+    expect(mockUpdateSigning).toHaveBeenCalledWith("client_internal", {
+      idTokenAlg: null,
+      accessTokenAlg: null,
+    });
+  });
+
+  it("returns an error when the client is missing", async () => {
+    mockFindClient.mockResolvedValueOnce(null as never);
+
+    const result = await updateClientSigningAlgsAction({
+      clientId: "missing",
+      idTokenAlg: "RS256",
+      accessTokenAlg: "match_id",
+    });
+
+    expect(result).toEqual({ error: "Client not found" });
+    expect(mockUpdateSigning).not.toHaveBeenCalled();
+  });
+
+  it("fails validation for unsupported algorithms", async () => {
+    const result = await updateClientSigningAlgsAction({
+      clientId: "client_internal",
+      idTokenAlg: "HS256" as never,
+      accessTokenAlg: "match_id",
+    });
+
+    expect(result).toEqual({ error: "Unable to update signing algorithms" });
+    expect(mockUpdateSigning).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/admin/_components/rotate-key-button.tsx
+++ b/src/app/admin/_components/rotate-key-button.tsx
@@ -7,23 +7,37 @@ import { Loader2 } from "lucide-react";
 import { rotateKeyAction } from "@/app/admin/actions";
 import { Button } from "@/components/ui/button";
 import { useToast } from "@/components/ui/use-toast";
+import type { JwtSigningAlg } from "@/generated/prisma/client";
 
-export const RotateKeyButton = ({ tenantId, canRotate }: { tenantId: string; canRotate: boolean }) => {
+export const RotateKeyButton = ({
+  tenantId,
+  alg,
+  canRotate,
+  hasActiveKey,
+}: {
+  tenantId: string;
+  alg: JwtSigningAlg;
+  canRotate: boolean;
+  hasActiveKey: boolean;
+}) => {
   const router = useRouter();
   const [pending, startTransition] = useTransition();
   const { toast } = useToast();
 
   const handleRotate = () => {
     startTransition(async () => {
-      const result = await rotateKeyAction({ tenantId });
+      const result = await rotateKeyAction({ tenantId, alg });
       if (result.error) {
         toast({ variant: "destructive", title: "Unable to rotate key", description: result.error });
         return;
       }
       router.refresh();
-      toast({ title: "Signing key rotated", description: "JWKS now contains the new key" });
+      toast({ title: result.success ?? "Signing key rotated", description: "JWKS now contains the new key" });
     });
   };
+
+  const label = hasActiveKey ? `Rotate ${alg}` : `Generate ${alg}`;
+  const disabledLabel = canRotate ? label : "Owner access required";
 
   return (
     <Button
@@ -31,9 +45,9 @@ export const RotateKeyButton = ({ tenantId, canRotate }: { tenantId: string; can
       variant="secondary"
       onClick={handleRotate}
       disabled={pending || !canRotate}
-      className="mt-4"
+      className="mt-2 w-full sm:mt-0 sm:w-auto"
     >
-      {pending ? <Loader2 className="h-4 w-4 animate-spin" /> : canRotate ? "Rotate signing key" : "Owner access required"}
+      {pending ? <Loader2 className="h-4 w-4 animate-spin" /> : disabledLabel}
     </Button>
   );
 };

--- a/src/app/admin/actions.ts
+++ b/src/app/admin/actions.ts
@@ -22,8 +22,9 @@ import {
   updateClientReauthTtl,
   updateClientAllowedScopes,
   getConfidentialClientSecret,
+  updateClientSigningAlgorithms,
 } from "@/server/services/client-service";
-import { rotateKey } from "@/server/services/key-service";
+import { rotateKeyForAlg } from "@/server/services/key-service";
 import {
   ADMIN_ACTIVE_TENANT_COOKIE,
   clearAdminActiveTenantCookie,
@@ -52,6 +53,7 @@ import { resolveRedirectUri } from "@/server/oidc/redirect-uri";
 import { createOauthTestSession, resetOauthTestSessionsForClient } from "@/server/services/oauth-test-service";
 import { clearOauthTestSecretCookie, setOauthTestSecretCookie } from "@/server/oauth/test-cookie";
 import { isValidScopeValue, normalizeScopes, SUPPORTED_SCOPES } from "@/server/oidc/scopes";
+import { SUPPORTED_JWT_SIGNING_ALGS } from "@/server/oidc/signing-alg";
 
 const OAUTH_TEST_SESSION_TTL_MINUTES = 15;
 
@@ -67,7 +69,7 @@ const clientSchema = z.object({
   scopes: z.array(z.string().min(1)).optional(),
 });
 
-const keySchema = z.object({ tenantId: z.string().min(1) });
+const keySchema = z.object({ tenantId: z.string().min(1), alg: z.enum(SUPPORTED_JWT_SIGNING_ALGS) });
 const setTenantSchema = z.object({ tenantId: z.string().min(1) });
 const rotateSecretSchema = z.object({ clientId: z.string().min(1) });
 const redirectSchema = z.object({ clientId: z.string().min(1), uri: z.string().min(1) });
@@ -122,6 +124,14 @@ const updateClientStrategiesSchema = z.object({
 const updateClientReauthSchema = z.object({
   clientId: z.string().min(1),
   reauthTtlSeconds: z.number().int().min(0).max(86400),
+});
+
+const idTokenAlgOptions = ["default", ...SUPPORTED_JWT_SIGNING_ALGS] as const;
+const accessTokenAlgOptions = ["match_id", ...SUPPORTED_JWT_SIGNING_ALGS] as const;
+const updateClientSigningAlgsSchema = z.object({
+  clientId: z.string().min(1),
+  idTokenAlg: z.enum(idTokenAlgOptions),
+  accessTokenAlg: z.enum(accessTokenAlgOptions),
 });
 
 const requireSession = async () => {
@@ -283,9 +293,9 @@ export const rotateKeyAction = async (input: z.infer<typeof keySchema>): Promise
     const adminId = await requireSession();
     const parsed = keySchema.parse(input);
     await assertTenantRole(adminId, parsed.tenantId, ["OWNER"]);
-    await rotateKey(parsed.tenantId);
+    await rotateKeyForAlg(parsed.tenantId, parsed.alg);
     revalidatePath("/admin", "layout");
-    return { success: "Signing key rotated" };
+    return { success: `Signing key rotated (${parsed.alg})` };
   } catch (error) {
     console.error(error);
     return { error: "Unable to rotate key" };
@@ -465,6 +475,35 @@ export const updateClientReauthTtlAction = async (input: z.infer<typeof updateCl
   } catch (error) {
     console.error(error);
     return { error: "Unable to update re-auth TTL" };
+  }
+};
+
+export const updateClientSigningAlgsAction = async (
+  input: z.infer<typeof updateClientSigningAlgsSchema>,
+): Promise<ActionState> => {
+  try {
+    const adminId = await requireSession();
+    const parsed = updateClientSigningAlgsSchema.parse(input);
+    const client = await getClientForAdmin(parsed.clientId, adminId, ["OWNER", "WRITER"]);
+    if (!client) {
+      return { error: "Client not found" };
+    }
+
+    const idTokenAlg = parsed.idTokenAlg === "default" ? null : parsed.idTokenAlg;
+    const accessTokenAlg = parsed.accessTokenAlg === "match_id" ? null : parsed.accessTokenAlg;
+
+    await updateClientSigningAlgorithms(client.id, {
+      idTokenAlg,
+      accessTokenAlg,
+    });
+
+    revalidatePath(clientPath(client.id));
+    revalidatePath("/admin/clients");
+    revalidatePath("/admin", "layout");
+    return { success: "Signing algorithms updated" };
+  } catch (error) {
+    console.error(error);
+    return { error: "Unable to update signing algorithms" };
   }
 };
 

--- a/src/app/admin/clients/[clientId]/client-forms.tsx
+++ b/src/app/admin/clients/[clientId]/client-forms.tsx
@@ -16,6 +16,7 @@ import {
   updateClientIssuerAction,
   updateClientNameAction,
   updateClientReauthTtlAction,
+  updateClientSigningAlgsAction,
 } from "@/app/admin/actions";
 import { CopyField } from "@/app/admin/_components/copy-field";
 import { Badge } from "@/components/ui/badge";
@@ -23,12 +24,14 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { useToast } from "@/components/ui/use-toast";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import type { ClientAuthStrategies } from "@/server/oidc/auth-strategy";
 import { cn } from "@/lib/utils";
 import { isValidScopeValue, normalizeScopes } from "@/server/oidc/scopes";
+import { DEFAULT_JWT_SIGNING_ALG, SUPPORTED_JWT_SIGNING_ALGS } from "@/server/oidc/signing-alg";
+import type { JwtSigningAlg } from "@/generated/prisma/client";
 
 const nameSchema = z.object({ name: z.string().min(2, "Name must be at least 2 characters") });
 const redirectSchema = z.object({
@@ -65,6 +68,20 @@ const reauthTtlSchema = z.object({
     .number()
     .int("Enter a whole number"),
 });
+
+const idTokenAlgOptions = ["default", ...SUPPORTED_JWT_SIGNING_ALGS] as const;
+const accessTokenAlgOptions = ["match_id", ...SUPPORTED_JWT_SIGNING_ALGS] as const;
+const signingAlgsSchema = z.object({
+  idTokenAlg: z.enum(idTokenAlgOptions),
+  accessTokenAlg: z.enum(accessTokenAlgOptions),
+});
+
+const SIGNING_ALG_LABELS: Record<JwtSigningAlg, string> = {
+  RS256: "RS256 (RSA SHA-256)",
+  PS256: "PS256 (RSA-PSS SHA-256)",
+  ES256: "ES256 (ECDSA P-256)",
+  ES384: "ES384 (ECDSA P-384)",
+};
 
 const formatReauthTtlSummary = (seconds: number) => {
   if (!seconds) {
@@ -187,6 +204,133 @@ export function UpdateClientNameForm({
           </Button>
         ) : (
           <Button type="button" variant="outline" disabled className="self-end">
+            Read-only
+          </Button>
+        )}
+      </form>
+    </Form>
+  );
+}
+
+export function UpdateClientSigningAlgorithmsForm({
+  clientId,
+  initialIdTokenAlg,
+  initialAccessTokenAlg,
+  canEdit,
+}: {
+  clientId: string;
+  initialIdTokenAlg: JwtSigningAlg | null;
+  initialAccessTokenAlg: JwtSigningAlg | null;
+  canEdit: boolean;
+}) {
+  const router = useRouter();
+  const { toast } = useToast();
+  const [pending, startTransition] = useTransition();
+  const form = useForm<z.infer<typeof signingAlgsSchema>>({
+    resolver: zodResolver(signingAlgsSchema),
+    defaultValues: {
+      idTokenAlg: initialIdTokenAlg ?? "default",
+      accessTokenAlg: initialAccessTokenAlg ?? "match_id",
+    },
+  });
+
+  useEffect(() => {
+    form.reset({
+      idTokenAlg: initialIdTokenAlg ?? "default",
+      accessTokenAlg: initialAccessTokenAlg ?? "match_id",
+    });
+  }, [initialIdTokenAlg, initialAccessTokenAlg, form]);
+
+  const watchedIdAlg = useWatch({ control: form.control, name: "idTokenAlg" });
+  const watchedAccessAlg = useWatch({ control: form.control, name: "accessTokenAlg" });
+
+  const resolvedIdAlg: JwtSigningAlg = watchedIdAlg === "default" ? DEFAULT_JWT_SIGNING_ALG : (watchedIdAlg as JwtSigningAlg);
+  const resolvedAccessAlg: JwtSigningAlg = watchedAccessAlg === "match_id" ? resolvedIdAlg : (watchedAccessAlg as JwtSigningAlg);
+
+  const onSubmit = (values: z.infer<typeof signingAlgsSchema>) => {
+    startTransition(async () => {
+      const result = await updateClientSigningAlgsAction({ clientId, ...values });
+      if (result.error) {
+        toast({ variant: "destructive", title: "Unable to update", description: result.error });
+        return;
+      }
+      router.refresh();
+      toast({ title: "Signing algorithms updated", description: result.success ?? "Saved" });
+    });
+  };
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+        <FormField
+          control={form.control}
+          name="idTokenAlg"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel className="text-xs text-muted-foreground">ID token algorithm</FormLabel>
+              <FormControl>
+                <Select value={field.value} onValueChange={field.onChange} disabled={!canEdit || pending}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select ID token algorithm" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="default">Platform default ({DEFAULT_JWT_SIGNING_ALG})</SelectItem>
+                    {SUPPORTED_JWT_SIGNING_ALGS.map((alg) => (
+                      <SelectItem key={alg} value={alg}>
+                        {SIGNING_ALG_LABELS[alg]}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </FormControl>
+              <FormDescription className="text-xs">
+                Defaults to {DEFAULT_JWT_SIGNING_ALG}. Change when relying parties require a different signature.
+              </FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="accessTokenAlg"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel className="text-xs text-muted-foreground">Access token algorithm</FormLabel>
+              <FormControl>
+                <Select value={field.value} onValueChange={field.onChange} disabled={!canEdit || pending}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select access token algorithm" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="match_id">Match ID token (default)</SelectItem>
+                    {SUPPORTED_JWT_SIGNING_ALGS.map((alg) => (
+                      <SelectItem key={alg} value={alg}>
+                        {SIGNING_ALG_LABELS[alg]}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </FormControl>
+              <FormDescription className="text-xs">
+                Inherits the ID token algorithm unless overridden. Useful for asymmetric access token policies.
+              </FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <p className="text-xs text-muted-foreground">
+          ID tokens will use <span className="font-medium text-foreground">{resolvedIdAlg}</span>. Access tokens will use
+          <span className="font-medium text-foreground"> {resolvedAccessAlg}</span>.
+        </p>
+
+        {canEdit ? (
+          <Button type="submit" disabled={pending}>
+            {pending ? <Loader2 className="h-4 w-4 animate-spin" /> : "Save algorithms"}
+          </Button>
+        ) : (
+          <Button type="button" variant="outline" disabled className="cursor-not-allowed opacity-70">
             Read-only
           </Button>
         )}

--- a/src/app/admin/clients/[clientId]/page.tsx
+++ b/src/app/admin/clients/[clientId]/page.tsx
@@ -9,6 +9,7 @@ import {
   DeleteRedirectButton,
   RotateSecretForm,
   UpdateAuthStrategiesForm,
+  UpdateClientSigningAlgorithmsForm,
   UpdateClientScopesForm,
   UpdateClientReauthTtlForm,
   UpdateClientIssuerForm,
@@ -234,6 +235,24 @@ export default async function ClientDetailPage({ params }: { params: PageParams 
             canEdit={canManageClients}
             initialStrategies={authStrategies}
           />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Signing algorithms</CardTitle>
+          <CardDescription>Configure how Mockauth signs ID tokens and access tokens.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <UpdateClientSigningAlgorithmsForm
+            clientId={client.id}
+            canEdit={canManageClients}
+            initialIdTokenAlg={client.idTokenSignedResponseAlg}
+            initialAccessTokenAlg={client.accessTokenSigningAlg}
+          />
+          <p className="text-xs text-muted-foreground">
+            Each algorithm maintains its own active signing key. Mockauth rotates keys on demand when you switch algorithms.
+          </p>
         </CardContent>
       </Card>
 

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -11,8 +11,9 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { authOptions } from "@/server/auth/options";
 import { getAdminTenantContext } from "@/server/services/admin-tenant-context";
 import { listClients } from "@/server/services/client-service";
-import { getActiveKey } from "@/server/services/key-service";
+import { getActiveKeyForAlg } from "@/server/services/key-service";
 import { getRequestOrigin } from "@/server/utils/request-origin";
+import { SUPPORTED_JWT_SIGNING_ALGS } from "@/server/oidc/signing-alg";
 
 export default async function AdminPage() {
   const session = await getServerSession(authOptions);
@@ -34,10 +35,15 @@ export default async function AdminPage() {
     );
   }
 
-  const [clientSnapshot, activeKey, origin] = await Promise.all([
+  const [clientSnapshot, origin, signingKeys] = await Promise.all([
     listClients(activeTenant.id, { pageSize: 5 }),
-    getActiveKey(activeTenant.id).catch(() => null),
     getRequestOrigin(),
+    Promise.all(
+      SUPPORTED_JWT_SIGNING_ALGS.map(async (alg) => ({
+        alg,
+        key: await getActiveKeyForAlg(activeTenant.id, alg).catch(() => null),
+      })),
+    ),
   ]);
 
   const redirectCount = clientSnapshot.clients.reduce((acc, client) => acc + client._count.redirectUris, 0);
@@ -100,24 +106,43 @@ export default async function AdminPage() {
       <div className="grid gap-6 lg:grid-cols-2">
         <Card>
           <CardHeader>
-            <CardTitle>Signing key</CardTitle>
-            <CardDescription>Rotate keys to invalidate existing tokens.</CardDescription>
+            <CardTitle>Signing keys</CardTitle>
+            <CardDescription>Manage per-algorithm signing keys for issued tokens.</CardDescription>
           </CardHeader>
-          <CardContent className="space-y-2">
-            {activeKey ? (
-              <>
-                <div className="text-sm">
-                  <p className="font-semibold">KID</p>
-                  <p className="font-mono text-xs text-muted-foreground">{activeKey.kid}</p>
+          <CardContent className="space-y-4">
+            {signingKeys.map(({ alg, key }) => (
+              <div
+                key={alg}
+                className="flex flex-col gap-3 rounded-lg border p-3 sm:flex-row sm:items-center sm:justify-between"
+              >
+                <div className="space-y-1">
+                  <div className="flex items-center gap-2">
+                    <p className="text-sm font-semibold">{alg}</p>
+                    <span className="text-xs uppercase text-muted-foreground">
+                      {key ? "Active" : "Pending"}
+                    </span>
+                  </div>
+                  {key ? (
+                    <div className="space-y-1">
+                      <p className="font-mono text-xs text-muted-foreground break-all">{key.kid}</p>
+                      <p className="text-xs text-muted-foreground">
+                        Created {formatDistanceToNow(key.createdAt, { addSuffix: true })}
+                      </p>
+                    </div>
+                  ) : (
+                    <p className="text-xs text-muted-foreground">
+                      No key generated yet. One will be created automatically on first use.
+                    </p>
+                  )}
                 </div>
-                <p className="text-xs text-muted-foreground">
-                  Created {formatDistanceToNow(activeKey.createdAt, { addSuffix: true })}
-                </p>
-              </>
-            ) : (
-              <p className="text-sm text-muted-foreground">No active signing key found.</p>
-            )}
-            <RotateKeyButton tenantId={activeTenant.id} canRotate={viewerRole === "OWNER"} />
+                <RotateKeyButton
+                  tenantId={activeTenant.id}
+                  alg={alg}
+                  canRotate={viewerRole === "OWNER"}
+                  hasActiveKey={Boolean(key)}
+                />
+              </div>
+            ))}
           </CardContent>
         </Card>
 

--- a/src/server/oidc/__tests__/oidc-flow.test.ts
+++ b/src/server/oidc/__tests__/oidc-flow.test.ts
@@ -2,7 +2,8 @@ import { randomUUID } from "node:crypto";
 import { vi } from "vitest";
 
 import { $Enums } from "@/generated/prisma/client";
-import { decodeJwt } from "jose";
+import type { JwtSigningAlg, Prisma } from "@/generated/prisma/client";
+import { decodeJwt, decodeProtectedHeader } from "jose";
 
 import { prisma } from "@/server/db/client";
 import { computeS256Challenge } from "@/server/crypto/pkce";
@@ -25,15 +26,17 @@ describe("OIDC flow", () => {
   let sessionToken: string;
   let codeVerifier: string;
   let clientInternalId: string;
-  let originalStrategies: unknown;
+  let originalStrategies: Prisma.JsonValue;
   let originalReauthTtlSeconds: number;
   let originalAllowedScopes: string[];
+  let originalIdTokenAlg: JwtSigningAlg | null | undefined;
+  let originalAccessTokenAlg: JwtSigningAlg | null | undefined;
 
-  const buildReauthCookie = (token: string, ttlSeconds = DEFAULT_REAUTH_TTL_SECONDS) => {
+  const buildReauthCookie = (token: string, ttlSeconds = DEFAULT_REAUTH_TTL_SECONDS, clientId = CLIENT_ID) => {
     const cookie = createReauthCookieValue({
       tenantId,
       apiResourceId,
-      clientId: CLIENT_ID,
+      clientId,
       sessionHash: hashOpaqueToken(token),
       ttlSeconds,
     });
@@ -43,11 +46,11 @@ describe("OIDC flow", () => {
     return cookie;
   };
 
-  const buildFreshLoginCookie = (token: string) =>
+  const buildFreshLoginCookie = (token: string, clientId = CLIENT_ID) =>
     createFreshLoginCookieValue({
       tenantId,
       apiResourceId,
-      clientId: CLIENT_ID,
+      clientId,
       sessionHash: hashOpaqueToken(token),
     });
 
@@ -63,9 +66,11 @@ describe("OIDC flow", () => {
     codeVerifier = "verifier-1234567890123456789012345678901234567890";
     const client = await prisma.client.findFirstOrThrow({ where: { tenantId: tenant.id, clientId: CLIENT_ID } });
     clientInternalId = client.id;
-    originalStrategies = client.authStrategies;
+    originalStrategies = client.authStrategies as Prisma.JsonValue;
     originalReauthTtlSeconds = client.reauthTtlSeconds;
     originalAllowedScopes = client.allowedScopes;
+    originalIdTokenAlg = client.idTokenSignedResponseAlg;
+    originalAccessTokenAlg = client.accessTokenSigningAlg;
     await prisma.client.update({
       where: { id: client.id },
       data: { reauthTtlSeconds: DEFAULT_REAUTH_TTL_SECONDS },
@@ -93,6 +98,8 @@ describe("OIDC flow", () => {
           ...(originalStrategies ? { authStrategies: originalStrategies } : {}),
           ...(typeof originalReauthTtlSeconds === "number" ? { reauthTtlSeconds: originalReauthTtlSeconds } : {}),
           ...(originalAllowedScopes ? { allowedScopes: originalAllowedScopes } : {}),
+          idTokenSignedResponseAlg: originalIdTokenAlg ?? null,
+          accessTokenSigningAlg: originalAccessTokenAlg ?? null,
         },
       });
     }
@@ -467,6 +474,7 @@ describe("OIDC flow", () => {
     );
 
     expect(authorize.type).toBe("redirect");
+    expect(authorize.type).toBe("redirect");
     const code = new URL(authorize.redirectTo).searchParams.get("code");
     const consumed = await consumeAuthorizationCode(code!);
     const tokenResponse = await issueTokensFromCode({
@@ -651,5 +659,171 @@ describe("OIDC flow", () => {
 
     await expect(authorizeFlow(true)).resolves.toBe(true);
     await expect(authorizeFlow(false)).resolves.toBe(false);
+  });
+
+  it("signs tokens with configured algorithms", async () => {
+    await prisma.client.update({
+      where: { id: clientInternalId },
+      data: { authStrategies: originalStrategies as Prisma.InputJsonValue },
+    });
+    await prisma.client.update({
+      where: { id: clientInternalId },
+      data: { idTokenSignedResponseAlg: "ES384", accessTokenSigningAlg: "PS256" },
+    });
+
+    const challenge = computeS256Challenge(codeVerifier);
+    const authorize = await handleAuthorize(
+      {
+        apiResourceId,
+        clientId: CLIENT_ID,
+        redirectUri: "https://client.example.test/callback",
+        responseType: "code",
+        scope: "openid profile",
+        state: "alg-test",
+        codeChallenge: challenge,
+        codeChallengeMethod: "S256",
+        sessionToken,
+        reauthCookie: buildReauthCookie(sessionToken, DEFAULT_REAUTH_TTL_SECONDS, CLIENT_ID),
+      },
+      "https://mockauth.test",
+      `https://mockauth.test/r/${apiResourceId}/oidc/authorize?client_id=${CLIENT_ID}`,
+    );
+
+    const code = new URL(authorize.redirectTo).searchParams.get("code");
+    const consumed = await consumeAuthorizationCode(code!);
+    const tokens = await issueTokensFromCode({
+      code: consumed,
+      codeVerifier,
+      redirectUri: "https://client.example.test/callback",
+      origin: "https://mockauth.test",
+      clientSecret: CLIENT_SECRET,
+    });
+
+    const idHeader = decodeProtectedHeader(tokens.id_token);
+    const accessHeader = decodeProtectedHeader(tokens.access_token);
+
+    expect(idHeader.alg).toBe("ES384");
+    expect(accessHeader.alg).toBe("PS256");
+    expect(idHeader.kid).toBeTruthy();
+    expect(accessHeader.kid).toBeTruthy();
+
+    const idKey = await prisma.tenantKey.findFirstOrThrow({ where: { tenantId, kid: idHeader.kid as string } });
+    const accessKey = await prisma.tenantKey.findFirstOrThrow({ where: { tenantId, kid: accessHeader.kid as string } });
+    expect(idKey.alg).toBe("ES384");
+    expect(accessKey.alg).toBe("PS256");
+  });
+
+  it("supports multiple clients with distinct signing algorithms", async () => {
+    await prisma.client.update({
+      where: { id: clientInternalId },
+      data: { authStrategies: originalStrategies as Prisma.InputJsonValue },
+    });
+    const alternateClientId = `client_${randomUUID().slice(0, 12)}`;
+    const alternateRedirect = `https://${alternateClientId}.example.test/callback`;
+
+    const alternateClient = await prisma.client.create({
+      data: {
+        tenantId,
+        name: "Alternate signing client",
+        clientId: alternateClientId,
+        clientType: "PUBLIC",
+        tokenEndpointAuthMethod: "none",
+        idTokenSignedResponseAlg: "ES256",
+        accessTokenSigningAlg: "ES256",
+        redirectUris: {
+          create: {
+            uri: alternateRedirect,
+          },
+        },
+      },
+    });
+
+    try {
+      await prisma.client.update({
+        where: { id: clientInternalId },
+        data: { idTokenSignedResponseAlg: "PS256", accessTokenSigningAlg: null },
+      });
+
+      const challenge = computeS256Challenge(codeVerifier);
+
+      const primaryAuthorize = await handleAuthorize(
+        {
+          apiResourceId,
+          clientId: CLIENT_ID,
+          redirectUri: "https://client.example.test/callback",
+          responseType: "code",
+          scope: "openid profile",
+          state: "primary-client",
+          codeChallenge: challenge,
+          codeChallengeMethod: "S256",
+          sessionToken,
+          reauthCookie: buildReauthCookie(sessionToken, DEFAULT_REAUTH_TTL_SECONDS, CLIENT_ID),
+          freshLoginRequested: true,
+          freshLoginCookie: buildFreshLoginCookie(sessionToken, CLIENT_ID),
+        },
+        "https://mockauth.test",
+        `https://mockauth.test/r/${apiResourceId}/oidc/authorize?client_id=${CLIENT_ID}`,
+      );
+
+      const altAuthorize = await handleAuthorize(
+        {
+          apiResourceId,
+          clientId: alternateClient.clientId,
+          redirectUri: alternateRedirect,
+          responseType: "code",
+          scope: "openid profile",
+          state: "alternate-client",
+          codeChallenge: challenge,
+          codeChallengeMethod: "S256",
+          sessionToken,
+          reauthCookie: buildReauthCookie(sessionToken, DEFAULT_REAUTH_TTL_SECONDS, alternateClient.clientId),
+          freshLoginRequested: true,
+          freshLoginCookie: buildFreshLoginCookie(sessionToken, alternateClient.clientId),
+        },
+        "https://mockauth.test",
+        `https://mockauth.test/r/${apiResourceId}/oidc/authorize?client_id=${alternateClient.clientId}`,
+      );
+
+      expect(primaryAuthorize.type).toBe("redirect");
+      expect(altAuthorize.type).toBe("redirect");
+      const primaryCode = new URL(primaryAuthorize.redirectTo).searchParams.get("code");
+      const alternateCode = new URL(altAuthorize.redirectTo).searchParams.get("code");
+
+      const [primaryConsumed, alternateConsumed] = await Promise.all([
+        consumeAuthorizationCode(primaryCode!),
+        consumeAuthorizationCode(alternateCode!),
+      ]);
+
+      const [primaryTokens, alternateTokens] = await Promise.all([
+        issueTokensFromCode({
+          code: primaryConsumed,
+          codeVerifier,
+          redirectUri: "https://client.example.test/callback",
+          origin: "https://mockauth.test",
+          clientSecret: CLIENT_SECRET,
+        }),
+        issueTokensFromCode({
+          code: alternateConsumed,
+          codeVerifier,
+          redirectUri: alternateRedirect,
+          origin: "https://mockauth.test",
+          clientSecret: null,
+        }),
+      ]);
+
+      const primaryHeader = decodeProtectedHeader(primaryTokens.id_token);
+      const alternateHeader = decodeProtectedHeader(alternateTokens.id_token);
+
+      expect(primaryHeader.alg).toBe("PS256");
+      expect(alternateHeader.alg).toBe("ES256");
+      expect(primaryHeader.kid).not.toBe(alternateHeader.kid);
+
+      const activeKeys = await prisma.tenantKey.findMany({ where: { tenantId, status: "ACTIVE" } });
+      expect(activeKeys.some((key) => key.alg === "PS256")).toBe(true);
+      expect(activeKeys.some((key) => key.alg === "ES256")).toBe(true);
+    } finally {
+      await prisma.redirectUri.deleteMany({ where: { clientId: alternateClient.id } });
+      await prisma.client.delete({ where: { id: alternateClient.id } });
+    }
   });
 });

--- a/src/server/oidc/signing-alg.ts
+++ b/src/server/oidc/signing-alg.ts
@@ -1,0 +1,23 @@
+import { JwtSigningAlg } from "@/generated/prisma/client";
+
+export const SUPPORTED_JWT_SIGNING_ALGS = [
+  "RS256",
+  "PS256",
+  "ES256",
+  "ES384",
+] as const satisfies readonly JwtSigningAlg[];
+
+export const DEFAULT_JWT_SIGNING_ALG: JwtSigningAlg = "RS256";
+
+const SUPPORTED_SET = new Set<JwtSigningAlg>(SUPPORTED_JWT_SIGNING_ALGS);
+
+export const isJwtSigningAlg = (value: unknown): value is JwtSigningAlg => {
+  return typeof value === "string" && SUPPORTED_SET.has(value as JwtSigningAlg);
+};
+
+export const assertJwtSigningAlg = (value: unknown): JwtSigningAlg => {
+  if (!isJwtSigningAlg(value)) {
+    throw new Error(`Unsupported JWT signing alg: ${value}`);
+  }
+  return value;
+};

--- a/src/server/services/__tests__/client-service.test.ts
+++ b/src/server/services/__tests__/client-service.test.ts
@@ -2,7 +2,12 @@ import { randomUUID } from "crypto";
 
 import { prisma } from "@/server/db/client";
 import { decrypt } from "@/server/crypto/key-vault";
-import { createClient, getClientByIdForTenant, rotateClientSecret } from "@/server/services/client-service";
+import {
+  createClient,
+  getClientByIdForTenant,
+  rotateClientSecret,
+  updateClientSigningAlgorithms,
+} from "@/server/services/client-service";
 import { describe, expect, it } from "vitest";
 
 const createTenant = async () => {
@@ -98,5 +103,25 @@ describe("client service", () => {
     expect(updated?.clientSecretHash).not.toEqual(original?.clientSecretHash);
     expect(updated?.clientSecretEncrypted).not.toEqual(original?.clientSecretEncrypted);
     expect(decrypt(updated?.clientSecretEncrypted as string)).toEqual(nextSecret);
+  });
+
+  it("updates signing algorithms with nullable defaults", async () => {
+    const tenant = await createTenant();
+    const { client } = await createClient(tenant.id, {
+      name: "Alg Tester",
+      clientType: "PUBLIC",
+    });
+
+    await updateClientSigningAlgorithms(client.id, { idTokenAlg: "ES384", accessTokenAlg: "PS256" });
+
+    let refreshed = await prisma.client.findUnique({ where: { id: client.id } });
+    expect(refreshed?.idTokenSignedResponseAlg).toBe("ES384");
+    expect(refreshed?.accessTokenSigningAlg).toBe("PS256");
+
+    await updateClientSigningAlgorithms(client.id, { idTokenAlg: null, accessTokenAlg: null });
+
+    refreshed = await prisma.client.findUnique({ where: { id: client.id } });
+    expect(refreshed?.idTokenSignedResponseAlg).toBeNull();
+    expect(refreshed?.accessTokenSigningAlg).toBeNull();
   });
 });

--- a/src/server/services/__tests__/discovery-service.test.ts
+++ b/src/server/services/__tests__/discovery-service.test.ts
@@ -8,5 +8,6 @@ describe("discovery document", () => {
     expect(doc.issuer).toBe("https://mockauth.test/r/resource_999/oidc");
     expect(doc.authorization_endpoint).toBe("https://mockauth.test/r/resource_999/oidc/authorize");
     expect(doc.jwks_uri).toBe("https://mockauth.test/r/resource_999/oidc/jwks.json");
+    expect(doc.id_token_signing_alg_values_supported).toEqual(["RS256", "PS256", "ES256", "ES384"]);
   });
 });

--- a/src/server/services/__tests__/key-service.test.ts
+++ b/src/server/services/__tests__/key-service.test.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "crypto";
 
 import { KeyStatus } from "@/generated/prisma/client";
 import { prisma } from "@/server/db/client";
-import { getJwks, getPublicJwkByKid, ensureActiveKey, rotateKey } from "@/server/services/key-service";
+import { getJwks, getPublicJwkByKid, ensureActiveKeyForAlg, rotateKeyForAlg } from "@/server/services/key-service";
 import { describe, expect, it, vi } from "vitest";
 
 const createTenant = async () => {
@@ -19,13 +19,15 @@ const createTenant = async () => {
 describe("key rotation", () => {
   it("keeps the previous key available as rotated", async () => {
     const tenant = await createTenant();
-    const current = await ensureActiveKey(tenant.id);
-    const next = await rotateKey(tenant.id);
+    const current = await ensureActiveKeyForAlg(tenant.id, "RS256");
+    const next = await rotateKeyForAlg(tenant.id, "RS256");
 
     expect(next.tenantId).toBe(tenant.id);
+    expect(next.alg).toBe("RS256");
 
     const original = await prisma.tenantKey.findUnique({ where: { id: current.id } });
     expect(original?.status).toBe(KeyStatus.ROTATED);
+    expect(original?.alg).toBe("RS256");
 
     const jwks = await getJwks(tenant.id);
     expect(jwks.some((jwk) => jwk.kid === original?.kid)).toBe(true);
@@ -36,7 +38,7 @@ describe("key rotation", () => {
 
   it("reuses an existing transaction client", async () => {
     const tenant = await createTenant();
-    await ensureActiveKey(tenant.id);
+    await ensureActiveKeyForAlg(tenant.id, "RS256");
 
     const outerTransaction = prisma.$transaction.bind(prisma);
     await outerTransaction(async (tx) => {
@@ -47,10 +49,26 @@ describe("key rotation", () => {
       }) as typeof prisma.$transaction;
 
       try {
-        await rotateKey(tenant.id, tx);
+        await rotateKeyForAlg(tenant.id, "RS256", tx);
       } finally {
         proxy.$transaction = original;
       }
     });
+  });
+
+  it("maintains separate active keys per algorithm", async () => {
+    const tenant = await createTenant();
+    const rsaKey = await ensureActiveKeyForAlg(tenant.id, "RS256");
+    const esKey = await ensureActiveKeyForAlg(tenant.id, "ES384");
+
+    expect(rsaKey.alg).toBe("RS256");
+    expect(esKey.alg).toBe("ES384");
+
+    const activeKeys = await prisma.tenantKey.findMany({
+      where: { tenantId: tenant.id, status: KeyStatus.ACTIVE },
+    });
+
+    expect(activeKeys.filter((key) => key.alg === "RS256")).toHaveLength(1);
+    expect(activeKeys.filter((key) => key.alg === "ES384")).toHaveLength(1);
   });
 });

--- a/src/server/services/client-service.ts
+++ b/src/server/services/client-service.ts
@@ -1,6 +1,6 @@
 import { nanoid } from "nanoid";
 
-import type { Prisma } from "@/generated/prisma/client";
+import type { Prisma, JwtSigningAlg } from "@/generated/prisma/client";
 import { prisma } from "@/server/db/client";
 import { hashSecret } from "@/server/crypto/hash";
 import { encrypt, decrypt } from "@/server/crypto/key-vault";
@@ -185,6 +185,19 @@ export const updateClientAllowedScopes = async (clientId: string, scopes: string
 
 export const updateClientReauthTtl = async (clientId: string, reauthTtlSeconds: number) => {
   return prisma.client.update({ where: { id: clientId }, data: { reauthTtlSeconds } });
+};
+
+export const updateClientSigningAlgorithms = async (
+  clientId: string,
+  options: { idTokenAlg: JwtSigningAlg | null; accessTokenAlg: JwtSigningAlg | null },
+) => {
+  return prisma.client.update({
+    where: { id: clientId },
+    data: {
+      idTokenSignedResponseAlg: options.idTokenAlg,
+      accessTokenSigningAlg: options.accessTokenAlg,
+    },
+  });
 };
 
 export const getConfidentialClientSecret = async (clientId: string): Promise<string | null> => {

--- a/src/server/services/discovery-service.ts
+++ b/src/server/services/discovery-service.ts
@@ -1,5 +1,6 @@
 import { issuerForResource } from "@/server/oidc/issuer";
 import { SUPPORTED_SCOPES } from "@/server/oidc/scopes";
+import { SUPPORTED_JWT_SIGNING_ALGS } from "@/server/oidc/signing-alg";
 
 export const buildDiscoveryDocument = (origin: string, apiResourceId: string) => {
   const issuer = issuerForResource(origin, apiResourceId);
@@ -14,6 +15,6 @@ export const buildDiscoveryDocument = (origin: string, apiResourceId: string) =>
     scopes_supported: SUPPORTED_SCOPES,
     code_challenge_methods_supported: ["S256"],
     token_endpoint_auth_methods_supported: ["client_secret_basic", "client_secret_post", "none"],
-    id_token_signing_alg_values_supported: ["RS256"],
+    id_token_signing_alg_values_supported: SUPPORTED_JWT_SIGNING_ALGS,
   };
 };

--- a/src/server/services/key-service.ts
+++ b/src/server/services/key-service.ts
@@ -1,32 +1,37 @@
 import { randomUUID } from "crypto";
 
-import { KeyStatus, Prisma } from "@/generated/prisma/client";
+import { JwtSigningAlg, KeyStatus, Prisma } from "@/generated/prisma/client";
 import { exportJWK, generateKeyPair, importJWK, type JWK } from "jose";
 
 import { prisma } from "@/server/db/client";
 import { encrypt, decrypt } from "@/server/crypto/key-vault";
 import { DomainError } from "@/server/errors";
+import { DEFAULT_JWT_SIGNING_ALG } from "@/server/oidc/signing-alg";
 
-export const getActiveKey = async (tenantId: string) => {
+export const getActiveKeyForAlg = async (tenantId: string, alg: JwtSigningAlg) => {
   const key = await prisma.tenantKey.findFirst({
-    where: { tenantId, status: KeyStatus.ACTIVE },
+    where: { tenantId, alg, status: KeyStatus.ACTIVE },
     orderBy: { createdAt: "desc" },
   });
 
   if (!key) {
-    throw new DomainError("No active signing key", { status: 500 });
+    throw new DomainError(`No active signing key for ${alg}`, { status: 500 });
   }
 
   return key;
 };
 
-export const ensureActiveKey = async (tenantId: string) => {
-  const existing = await prisma.tenantKey.count({ where: { tenantId } });
-  if (existing > 0) {
-    return getActiveKey(tenantId);
+export const ensureActiveKeyForAlg = async (tenantId: string, alg: JwtSigningAlg) => {
+  const existing = await prisma.tenantKey.findFirst({
+    where: { tenantId, alg, status: KeyStatus.ACTIVE },
+    orderBy: { createdAt: "desc" },
+  });
+
+  if (existing) {
+    return existing;
   }
 
-  return rotateKey(tenantId);
+  return rotateKeyForAlg(tenantId, alg);
 };
 
 const runWithTransaction = async <T>(
@@ -39,8 +44,12 @@ const runWithTransaction = async <T>(
   return prisma.$transaction(operation);
 };
 
-export const rotateKey = async (tenantId: string, tx?: Prisma.TransactionClient) => {
-  const { publicKey, privateKey } = await generateKeyPair("RS256", { extractable: true });
+export const rotateKeyForAlg = async (
+  tenantId: string,
+  alg: JwtSigningAlg = DEFAULT_JWT_SIGNING_ALG,
+  tx?: Prisma.TransactionClient,
+) => {
+  const { publicKey, privateKey } = await generateKeyPair(alg, { extractable: true });
   const [publicJwk, privateJwk] = await Promise.all([
     exportJWK(publicKey),
     exportJWK(privateKey),
@@ -49,14 +58,19 @@ export const rotateKey = async (tenantId: string, tx?: Prisma.TransactionClient)
   const kid = randomUUID();
   publicJwk.kid = kid;
   publicJwk.use = "sig";
-  publicJwk.alg = "RS256";
+  publicJwk.alg = alg;
   privateJwk.kid = kid;
   privateJwk.use = "sig";
-  privateJwk.alg = "RS256";
+  privateJwk.alg = alg;
+
+  const kty = publicJwk.kty;
+  if (!kty) {
+    throw new DomainError("Generated key missing key type", { status: 500 });
+  }
 
   return runWithTransaction(tx, async (client) => {
     await client.tenantKey.updateMany({
-      where: { tenantId, status: KeyStatus.ACTIVE },
+      where: { tenantId, alg, status: KeyStatus.ACTIVE },
       data: { status: KeyStatus.ROTATED },
     });
 
@@ -64,8 +78,8 @@ export const rotateKey = async (tenantId: string, tx?: Prisma.TransactionClient)
       data: {
         tenantId,
         kid,
-        kty: publicJwk.kty ?? "RSA",
-        alg: "RS256",
+        kty,
+        alg,
         use: "sig",
         status: KeyStatus.ACTIVE,
         publicJwk: publicJwk as Prisma.InputJsonValue,
@@ -107,5 +121,9 @@ export const getPrivateJwk = async (keyId: string, tenantId: string) => {
 
 export const importPrivateKey = async (keyRecord: { id: string; tenantId: string; privateJwkEncrypted: string; kid: string }) => {
   const jwk = JSON.parse(decrypt(keyRecord.privateJwkEncrypted)) as JWK;
-  return importJWK(jwk, "RS256");
+  const alg = jwk.alg;
+  if (!alg) {
+    throw new DomainError("Signing key missing algorithm", { status: 500 });
+  }
+  return importJWK(jwk, alg);
 };

--- a/src/server/services/tenant-service.ts
+++ b/src/server/services/tenant-service.ts
@@ -1,7 +1,8 @@
 import type { MembershipRole, Prisma, Tenant, TenantMembership } from "@/generated/prisma/client";
 import { prisma } from "@/server/db/client";
 import { DomainError } from "@/server/errors";
-import { rotateKey } from "@/server/services/key-service";
+import { rotateKeyForAlg } from "@/server/services/key-service";
+import { DEFAULT_JWT_SIGNING_ALG } from "@/server/oidc/signing-alg";
 
 const ROLE_RANK: Record<MembershipRole, number> = {
   OWNER: 3,
@@ -86,7 +87,7 @@ export const createTenant = async (adminUserId: string, data: { name: string }) 
         role: "OWNER",
       },
     });
-    await rotateKey(tenant.id, tx);
+    await rotateKeyForAlg(tenant.id, DEFAULT_JWT_SIGNING_ALG, tx);
     return tenantWithDefault;
   });
 };

--- a/src/server/services/token-service.ts
+++ b/src/server/services/token-service.ts
@@ -11,8 +11,10 @@ import { DomainError } from "@/server/errors";
 import { claimsForScopes } from "@/server/oidc/claims";
 import { issuerForResource } from "@/server/oidc/issuer";
 import { resolveRedirectUri } from "@/server/oidc/redirect-uri";
-import { getActiveKey } from "@/server/services/key-service";
+import { ensureActiveKeyForAlg } from "@/server/services/key-service";
 import { fromPrismaLoginStrategy, parseClientAuthStrategies } from "@/server/oidc/auth-strategy";
+import { DEFAULT_JWT_SIGNING_ALG } from "@/server/oidc/signing-alg";
+import type { JwtSigningAlg } from "@/generated/prisma/client";
 
 const ID_TOKEN_TTL_SECONDS = 600;
 const ACCESS_TOKEN_TTL_SECONDS = 3600;
@@ -66,9 +68,19 @@ export const issueTokensFromCode = async (params: {
   await validateClientSecret(code.client, clientSecret);
   verifyPkce(code, codeVerifier);
 
-  const activeKey = await getActiveKey(code.tenantId);
-  const privateJwk = JSON.parse(decrypt(activeKey.privateJwkEncrypted));
-  const signingKey = await importJWK(privateJwk, "RS256");
+  const idTokenAlg: JwtSigningAlg = code.client.idTokenSignedResponseAlg ?? DEFAULT_JWT_SIGNING_ALG;
+  const accessTokenAlg: JwtSigningAlg = code.client.accessTokenSigningAlg ?? idTokenAlg;
+
+  const requiredAlgs = Array.from(new Set<JwtSigningAlg>([idTokenAlg, accessTokenAlg]));
+  type ImportedKey = Awaited<ReturnType<typeof importJWK>>;
+  const signingKeys = new Map<JwtSigningAlg, { keyId: string; cryptoKey: ImportedKey }>();
+
+  for (const alg of requiredAlgs) {
+    const activeKey = await ensureActiveKeyForAlg(code.tenantId, alg);
+    const privateJwk = JSON.parse(decrypt(activeKey.privateJwkEncrypted));
+    const cryptoKey = await importJWK(privateJwk, alg);
+    signingKeys.set(alg, { keyId: activeKey.kid, cryptoKey });
+  }
 
   const now = Math.floor(Date.now() / 1000);
   const issuer = issuerForResource(origin, code.apiResourceId);
@@ -81,6 +93,11 @@ export const issueTokensFromCode = async (params: {
         ? Boolean(code.emailVerifiedOverride)
         : strategies.email.emailVerifiedMode === "true"
       : undefined;
+  const idTokenKey = signingKeys.get(idTokenAlg);
+  if (!idTokenKey) {
+    throw new DomainError("Missing signing key for id_token", { status: 500 });
+  }
+
   const idToken = await new SignJWT({
     ...claimsForScopes(code.user, scopes, strategy, { emailVerified: emailVerifiedClaim }),
     sub: code.subject,
@@ -89,12 +106,17 @@ export const issueTokensFromCode = async (params: {
     scope: code.scope,
     nonce: code.nonce,
   })
-    .setProtectedHeader({ alg: "RS256", kid: activeKey.kid })
+    .setProtectedHeader({ alg: idTokenAlg, kid: idTokenKey.keyId })
     .setIssuedAt(now)
     .setExpirationTime(now + ID_TOKEN_TTL_SECONDS)
-    .sign(signingKey);
+    .sign(idTokenKey.cryptoKey);
 
   const jti = randomUUID();
+  const accessTokenKey = signingKeys.get(accessTokenAlg);
+  if (!accessTokenKey) {
+    throw new DomainError("Missing signing key for access_token", { status: 500 });
+  }
+
   const accessToken = await new SignJWT({
     ...claimsForScopes(code.user, scopes, strategy, { emailVerified: emailVerifiedClaim }),
     sub: code.subject,
@@ -103,10 +125,10 @@ export const issueTokensFromCode = async (params: {
     scope: code.scope,
     jti,
   })
-    .setProtectedHeader({ alg: "RS256", kid: activeKey.kid })
+    .setProtectedHeader({ alg: accessTokenAlg, kid: accessTokenKey.keyId })
     .setIssuedAt(now)
     .setExpirationTime(now + ACCESS_TOKEN_TTL_SECONDS)
-    .sign(signingKey);
+    .sign(accessTokenKey.cryptoKey);
 
   await prisma.accessToken.create({
     data: {

--- a/src/server/services/userinfo-service.ts
+++ b/src/server/services/userinfo-service.ts
@@ -4,6 +4,7 @@ import { DomainError } from "@/server/errors";
 import { issuerForResource, parseIssuerSegments } from "@/server/oidc/issuer";
 import { getPublicJwkByKid } from "@/server/services/key-service";
 import { getApiResourceWithTenant } from "@/server/services/api-resource-service";
+import { isJwtSigningAlg } from "@/server/oidc/signing-alg";
 
 const parseBearer = (header?: string | null) => {
   if (!header) {
@@ -45,11 +46,14 @@ export const getUserInfo = async (
   if (!header.kid) {
     throw new DomainError("Missing key id", { status: 400, code: "invalid_token" });
   }
+  if (!header.alg || !isJwtSigningAlg(header.alg)) {
+    throw new DomainError("Unsupported signing algorithm", { status: 400, code: "invalid_token" });
+  }
 
   const keyJwk = await getPublicJwkByKid(tenant.id, header.kid);
-  const key = await importJWK(keyJwk, "RS256");
+  const key = await importJWK(keyJwk, header.alg);
   const expectedIssuer = issuerForResource(origin, expectedApiResourceId);
-  const { payload } = await jwtVerify(token, key, { issuer: expectedIssuer });
+  const { payload } = await jwtVerify(token, key, { issuer: expectedIssuer, algorithms: [header.alg] });
   const claims: Record<string, unknown> = { sub: payload.sub };
   if (typeof payload.name === "string") {
     claims.name = payload.name;


### PR DESCRIPTION
## Summary
- add per-algorithm tenant keys and expose signing alg helpers in services
- allow admins to configure id/access token algorithms per client in UI and actions
- cover new algorithms in discovery, token issuance, key rotation, and flow tests

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test

Resolves #86