### PR TITLE
chore(ci): add merge queue trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: ["main", "noa/**"]
   pull_request:
     branches: ["main"]
+  merge_group:
+    branches: ["main"]
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- add the merge_group trigger so merge-queue runs CI before merging

Closes #88

## Testing
- nix shell nixpkgs#nodejs_20 nixpkgs#pnpm -c pnpm -v
- nix shell nixpkgs#nodejs_20 nixpkgs#pnpm -c pnpm lint
- nix shell nixpkgs#nodejs_20 nixpkgs#pnpm -c pnpm typecheck
- nix shell nixpkgs#nodejs_20 nixpkgs#pnpm -c pnpm test
- CI=1 nix shell nixpkgs#nodejs_20 nixpkgs#pnpm -c pnpm test:e2e