### PR TITLE
fix(admin): signing selects update on selection (defaultValue for RHF-controlled Radix Select)

### DIFF
--- a/src/app/admin/clients/[clientId]/client-forms.tsx
+++ b/src/app/admin/clients/[clientId]/client-forms.tsx
@@ -269,7 +269,12 @@ export function UpdateClientSigningAlgorithmsForm({
             <FormItem>
               <FormLabel className="text-xs text-muted-foreground">ID token algorithm</FormLabel>
               <FormControl>
-                <Select value={field.value} onValueChange={field.onChange} disabled={!canEdit || pending}>
+                <Select
+                  value={field.value}
+                  defaultValue={field.value}
+                  onValueChange={field.onChange}
+                  disabled={!canEdit || pending}
+                >
                   <SelectTrigger>
                     <SelectValue placeholder="Select ID token algorithm" />
                   </SelectTrigger>
@@ -298,7 +303,12 @@ export function UpdateClientSigningAlgorithmsForm({
             <FormItem>
               <FormLabel className="text-xs text-muted-foreground">Access token algorithm</FormLabel>
               <FormControl>
-                <Select value={field.value} onValueChange={field.onChange} disabled={!canEdit || pending}>
+                <Select
+                  value={field.value}
+                  defaultValue={field.value}
+                  onValueChange={field.onChange}
+                  disabled={!canEdit || pending}
+                >
                   <SelectTrigger>
                     <SelectValue placeholder="Select access token algorithm" />
                   </SelectTrigger>


### PR DESCRIPTION
## Summary
- ensure signing algorithm selects stay in sync with form state by setting `defaultValue` alongside `value`

## Testing
- `pnpm lint`
- `pnpm typecheck`
