### PR TITLE
feat(admin): rebuild signing alg form

### DIFF
--- a/src/app/admin/clients/[clientId]/client-forms.tsx
+++ b/src/app/admin/clients/[clientId]/client-forms.tsx
@@ -279,29 +279,47 @@ export function UpdateClientSigningAlgorithmsForm({
           name="idTokenAlg"
           render={({ field }) => (
             <FormItem>
-              <FormLabel className="text-xs text-muted-foreground">ID token algorithm</FormLabel>
-              <FormControl>
-                <Select
-                  value={field.value}
-                  defaultValue={field.value}
-                  onValueChange={field.onChange}
-                  disabled={!canEdit || pending}
-                >
-                  <SelectTrigger>
-                    <span className={cn("truncate", !field.value && "text-muted-foreground")}>
+              <FormLabel className="text-xs text-muted-foreground" htmlFor="signing-id-token-alg-trigger">
+                ID token algorithm
+              </FormLabel>
+              <Select
+                value={field.value}
+                onValueChange={(value) => {
+                  if (!value) {
+                    return;
+                  }
+                  field.onChange(value);
+                  form.setValue("idTokenAlg", value as (typeof idTokenAlgOptions)[number], {
+                    shouldValidate: true,
+                    shouldDirty: true,
+                  });
+                }}
+                disabled={!canEdit || pending}
+              >
+                <FormControl>
+                  <SelectTrigger
+                    id="signing-id-token-alg-trigger"
+                    className="text-left"
+                    aria-label="ID token algorithm"
+                    data-testid="signing-id-token-alg-trigger"
+                  >
+                    <SelectValue aria-hidden="true" className="sr-only" />
+                    <span className={cn("flex-1 truncate text-left", !field.value && "text-muted-foreground")}>
                       {renderSigningAlgLabel(field.value, "id")}
                     </span>
                   </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="default">Platform default ({DEFAULT_JWT_SIGNING_ALG})</SelectItem>
-                    {SUPPORTED_JWT_SIGNING_ALGS.map((alg) => (
-                      <SelectItem key={alg} value={alg}>
-                        {SIGNING_ALG_LABELS[alg]}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </FormControl>
+                </FormControl>
+                <SelectContent>
+                  <SelectItem value="default" data-testid="signing-id-token-alg-option-default">
+                    Platform default ({DEFAULT_JWT_SIGNING_ALG})
+                  </SelectItem>
+                  {SUPPORTED_JWT_SIGNING_ALGS.map((alg) => (
+                    <SelectItem key={alg} value={alg} data-testid={`signing-id-token-alg-option-${alg}`}>
+                      {SIGNING_ALG_LABELS[alg]}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
               <FormDescription className="text-xs">
                 Defaults to {DEFAULT_JWT_SIGNING_ALG}. Change when relying parties require a different signature.
               </FormDescription>
@@ -315,29 +333,47 @@ export function UpdateClientSigningAlgorithmsForm({
           name="accessTokenAlg"
           render={({ field }) => (
             <FormItem>
-              <FormLabel className="text-xs text-muted-foreground">Access token algorithm</FormLabel>
-              <FormControl>
-                <Select
-                  value={field.value}
-                  defaultValue={field.value}
-                  onValueChange={field.onChange}
-                  disabled={!canEdit || pending}
-                >
-                  <SelectTrigger>
-                    <span className={cn("truncate", !field.value && "text-muted-foreground")}>
+              <FormLabel className="text-xs text-muted-foreground" htmlFor="signing-access-token-alg-trigger">
+                Access token algorithm
+              </FormLabel>
+              <Select
+                value={field.value}
+                onValueChange={(value) => {
+                  if (!value) {
+                    return;
+                  }
+                  field.onChange(value);
+                  form.setValue("accessTokenAlg", value as (typeof accessTokenAlgOptions)[number], {
+                    shouldValidate: true,
+                    shouldDirty: true,
+                  });
+                }}
+                disabled={!canEdit || pending}
+              >
+                <FormControl>
+                  <SelectTrigger
+                    id="signing-access-token-alg-trigger"
+                    className="text-left"
+                    aria-label="Access token algorithm"
+                    data-testid="signing-access-token-alg-trigger"
+                  >
+                    <SelectValue aria-hidden="true" className="sr-only" />
+                    <span className={cn("flex-1 truncate text-left", !field.value && "text-muted-foreground")}>
                       {renderSigningAlgLabel(field.value, "access")}
                     </span>
                   </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="match_id">Match ID token (default)</SelectItem>
-                    {SUPPORTED_JWT_SIGNING_ALGS.map((alg) => (
-                      <SelectItem key={alg} value={alg}>
-                        {SIGNING_ALG_LABELS[alg]}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </FormControl>
+                </FormControl>
+                <SelectContent>
+                  <SelectItem value="match_id" data-testid="signing-access-token-alg-option-match_id">
+                    Match ID token (default)
+                  </SelectItem>
+                  {SUPPORTED_JWT_SIGNING_ALGS.map((alg) => (
+                    <SelectItem key={alg} value={alg} data-testid={`signing-access-token-alg-option-${alg}`}>
+                      {SIGNING_ALG_LABELS[alg]}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
               <FormDescription className="text-xs">
                 Inherits the ID token algorithm unless overridden. Useful for asymmetric access token policies.
               </FormDescription>
@@ -352,8 +388,8 @@ export function UpdateClientSigningAlgorithmsForm({
         </p>
 
         {canEdit ? (
-          <Button type="submit" disabled={pending}>
-            {pending ? <Loader2 className="h-4 w-4 animate-spin" /> : "Save algorithms"}
+          <Button type="submit" disabled={pending} data-testid="signing-algs-save">
+            {pending ? <Loader2 className="h-4 w-4 animate-spin" /> : "Save"}
           </Button>
         ) : (
           <Button type="button" variant="outline" disabled className="cursor-not-allowed opacity-70">

--- a/tests/e2e/client-signing-algorithms.spec.ts
+++ b/tests/e2e/client-signing-algorithms.spec.ts
@@ -1,0 +1,89 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import { authenticate, createTestSession } from "./helpers/admin";
+
+test.describe("client signing algorithms", () => {
+  test("admin updates ID and access token algorithms", async ({ page }) => {
+    const seed = await seedTenantClient(page);
+    const sessionToken = await createTestSession(page, { tenantId: seed.tenantId });
+    await authenticate(page, sessionToken);
+    await setActiveTenantCookie(page, seed.tenantId);
+
+    await page.goto("/admin/clients");
+    await expect(page.getByRole("heading", { name: "OAuth clients" })).toBeVisible();
+    await selectTenant(page, seed.tenantId);
+    await expect(page.getByRole("row", { name: new RegExp(seed.clientName, "i") })).toBeVisible();
+
+    await page.goto(`/admin/clients/${seed.clientInternalId}`);
+    await expect(page.getByRole("heading", { name: "Signing algorithms" })).toBeVisible();
+
+    const idTrigger = page.getByTestId("signing-id-token-alg-trigger");
+    await expect(idTrigger).toBeVisible();
+    await idTrigger.click();
+    await page.getByTestId("signing-id-token-alg-option-RS256").click();
+    await expect(idTrigger).toContainText("RS256 (RSA SHA-256)");
+
+    const accessTrigger = page.getByTestId("signing-access-token-alg-trigger");
+    const summary = page.getByText(/Access tokens will use/);
+    await accessTrigger.click();
+    await page.getByTestId("signing-access-token-alg-option-match_id").click();
+    await expect(summary).toContainText("RS256");
+
+    await accessTrigger.click();
+    await page.getByTestId("signing-access-token-alg-option-PS256").click();
+    await expect(accessTrigger).toContainText("PS256 (RSA-PSS SHA-256)");
+    await expect(summary).toContainText("PS256");
+
+    const saveButton = page.getByTestId("signing-algs-save");
+    await expect(saveButton).toBeEnabled();
+    await saveButton.click();
+    await expect(page.getByText("Signing algorithms updated", { exact: true }).first()).toBeVisible();
+
+    await page.reload();
+    await expect(page.getByTestId("signing-id-token-alg-trigger")).toContainText("RS256 (RSA SHA-256)");
+    await expect(page.getByTestId("signing-access-token-alg-trigger")).toContainText("PS256 (RSA-PSS SHA-256)");
+    await expect(summary).toContainText("PS256");
+  });
+});
+
+const seedTenantClient = async (page: Page) => {
+  const response = await page.request.post("/admin/api/test/seed-tenants-clients", { data: {} });
+  expect(response.ok()).toBeTruthy();
+  const payload = (await response.json()) as {
+    tenantAId: string;
+    clientsA: { id: string; clientId: string; name: string }[];
+  };
+  const client = payload.clientsA[0];
+  if (!client) {
+    throw new Error("missing_seeded_client");
+  }
+  return {
+    tenantId: payload.tenantAId,
+    clientInternalId: client.id,
+    clientId: client.clientId,
+    clientName: client.name,
+  };
+};
+
+const setActiveTenantCookie = async (page: Page, tenantId: string) => {
+  await page.context().addCookies([
+    {
+      name: "admin_active_tenant",
+      value: tenantId,
+      domain: "127.0.0.1",
+      path: "/admin",
+      httpOnly: true,
+      sameSite: "Lax",
+      secure: false,
+      expires: Math.floor(Date.now() / 1000) + 60 * 60,
+    },
+  ]);
+};
+
+const selectTenant = async (page: Page, tenantId: string) => {
+  const switcher = page.getByTestId("tenant-switcher");
+  await switcher.click();
+  const option = page.getByTestId(`tenant-option-${tenantId}`);
+  await option.click();
+  await expect(page.getByTestId("tenant-switcher-id")).toHaveText(tenantId.slice(0, 8));
+};


### PR DESCRIPTION
## Summary
- rebuild the admin signing algorithms form with issuer-pattern selects and test IDs
- align form state handling with form.setValue and update button copy
- add Playwright coverage for signing algorithm updates using test routes

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test
- CI=1 pnpm test:e2e tests/e2e/client-signing-algorithms.spec.ts

Closes #91
Closes #94