### PR TITLE
feat(proxy): add coverage and stabilize form

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+ignoredBuiltDependencies:
+  - '@prisma/engines'
+  - esbuild
+  - prisma
+  - sharp
+  - unrs-resolver

--- a/src/app/admin/__tests__/client-actions.proxy.test.ts
+++ b/src/app/admin/__tests__/client-actions.proxy.test.ts
@@ -1,0 +1,215 @@
+/* @vitest-environment node */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next-auth", () => ({
+  getServerSession: vi.fn(),
+}));
+
+vi.mock("@/server/auth/options", () => ({ authOptions: {} }));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+vi.mock("@/server/services/tenant-service", () => ({
+  assertTenantMembership: vi.fn(),
+  assertTenantRole: vi.fn(),
+  ensureMembershipRole: vi.fn(),
+  createTenant: vi.fn(),
+  deleteTenant: vi.fn(),
+  getTenantMemberships: vi.fn(),
+}));
+
+vi.mock("@/server/services/client-service", async () => {
+  const actual = await vi.importActual<typeof import("@/server/services/client-service")>(
+    "@/server/services/client-service",
+  );
+  return {
+    ...actual,
+    addRedirectUri: vi.fn(),
+    createClient: vi.fn(),
+    rotateClientSecret: vi.fn(),
+    updateClientName: vi.fn(),
+    updateClientApiResource: vi.fn(),
+    updateClientAuthStrategies: vi.fn(),
+    updateClientReauthTtl: vi.fn(),
+    updateClientAllowedScopes: vi.fn(),
+    getConfidentialClientSecret: vi.fn(),
+    updateClientSigningAlgorithms: vi.fn(),
+    upsertProxyProviderConfig: vi.fn(),
+  };
+});
+
+vi.mock("@/server/db/client", () => ({
+  prisma: {
+    client: {
+      findUnique: vi.fn(),
+    },
+    redirectUri: {
+      findUnique: vi.fn(),
+      delete: vi.fn(),
+    },
+  },
+}));
+
+import { createClientAction, updateProxyClientConfigAction } from "../actions";
+import { getServerSession } from "next-auth";
+import { assertTenantMembership, ensureMembershipRole } from "@/server/services/tenant-service";
+import { createClient, upsertProxyProviderConfig } from "@/server/services/client-service";
+import { prisma } from "@/server/db/client";
+
+const mockGetServerSession = vi.mocked(getServerSession);
+const mockAssertTenantMembership = vi.mocked(assertTenantMembership);
+const mockEnsureMembershipRole = vi.mocked(ensureMembershipRole);
+const mockCreateClient = vi.mocked(createClient);
+const mockUpsertProxyConfig = vi.mocked(upsertProxyProviderConfig);
+const mockFindClient = vi.mocked(prisma.client.findUnique);
+
+describe("proxy client server actions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetServerSession.mockResolvedValue({ user: { id: "admin_1" } } as never);
+    mockAssertTenantMembership.mockResolvedValue({ tenantId: "tenant_123", role: "OWNER" } as never);
+    mockEnsureMembershipRole.mockImplementation(() => undefined);
+    mockCreateClient.mockResolvedValue({
+      client: { id: "client_internal", clientId: "client_public" } as never,
+      clientSecret: "secret-generated",
+    });
+    mockFindClient.mockResolvedValue({
+      id: "client_internal",
+      tenantId: "tenant_123",
+      clientType: "CONFIDENTIAL",
+      oauthClientMode: "proxy",
+    } as never);
+    mockUpsertProxyConfig.mockResolvedValue(undefined);
+  });
+
+  it("creates a proxy client with normalized configuration", async () => {
+    const result = await createClientAction({
+      tenantId: "tenant_123",
+      name: "Proxy Client",
+      type: "CONFIDENTIAL",
+      redirects: ["https://client.example.test/callback"],
+      scopes: ["openid", "profile"],
+      mode: "proxy",
+      proxyConfig: {
+        providerType: "oidc",
+        authorizationEndpoint: " https://idp.example.test/oauth2/authorize ",
+        tokenEndpoint: "https://idp.example.test/oauth2/token ",
+        userinfoEndpoint: " https://idp.example.test/oauth2/userinfo ",
+        jwksUri: " https://idp.example.test/oauth2/jwks.json ",
+        upstreamClientId: " upstream-client ",
+        upstreamClientSecret: " upstream-secret ",
+        defaultScopes: ["openid", "profile", "profile"],
+        scopeMapping: { " profile:read ": ["openid", "profile "] },
+        pkceSupported: false,
+        oidcEnabled: true,
+        promptPassthroughEnabled: true,
+        loginHintPassthroughEnabled: false,
+        passthroughTokenResponse: true,
+      },
+    });
+
+    expect(mockCreateClient).toHaveBeenCalledWith(
+      "tenant_123",
+      expect.objectContaining({
+        name: "Proxy Client",
+        clientType: "CONFIDENTIAL",
+        redirectUris: ["https://client.example.test/callback"],
+        allowedScopes: ["openid", "profile"],
+        oauthClientMode: "proxy",
+        proxyConfig: expect.objectContaining({
+          providerType: "oidc",
+          authorizationEndpoint: "https://idp.example.test/oauth2/authorize",
+          tokenEndpoint: "https://idp.example.test/oauth2/token",
+          userinfoEndpoint: "https://idp.example.test/oauth2/userinfo",
+          jwksUri: "https://idp.example.test/oauth2/jwks.json",
+          upstreamClientId: "upstream-client",
+          upstreamClientSecret: "upstream-secret",
+          defaultScopes: ["openid", "profile", "profile"],
+          scopeMapping: { "profile:read": ["openid", "profile"] },
+          pkceSupported: false,
+          oidcEnabled: true,
+          promptPassthroughEnabled: true,
+          loginHintPassthroughEnabled: false,
+          passthroughTokenResponse: true,
+        }),
+      }),
+    );
+
+    expect(result).toEqual({
+      success: "Client created",
+      data: { clientId: "client_public", clientSecret: "secret-generated" },
+    });
+  });
+
+  it("rejects proxy client creation when configuration is missing", async () => {
+    const result = await createClientAction({
+      tenantId: "tenant_123",
+      name: "Incomplete Proxy",
+      type: "CONFIDENTIAL",
+      scopes: ["openid"],
+      mode: "proxy",
+      proxyConfig: undefined,
+    });
+
+    expect(result).toEqual({ error: "Proxy configuration is required" });
+    expect(mockCreateClient).not.toHaveBeenCalled();
+  });
+
+  it("updates proxy configuration and keeps existing secret when not provided", async () => {
+    const result = await updateProxyClientConfigAction({
+      clientId: "client_internal",
+      providerType: "oidc",
+      authorizationEndpoint: "https://idp.example.test/oauth2/authorize",
+      tokenEndpoint: "https://idp.example.test/oauth2/token",
+      upstreamClientId: "upstream-client",
+      upstreamClientSecret: " ",
+      defaultScopes: ["openid", "profile"],
+      scopeMapping: { " profile:read ": "openid   profile" },
+      pkceSupported: true,
+      oidcEnabled: true,
+      promptPassthroughEnabled: false,
+      loginHintPassthroughEnabled: false,
+      passthroughTokenResponse: false,
+    });
+
+    expect(mockUpsertProxyConfig).toHaveBeenCalledWith(
+      "client_internal",
+      {
+        providerType: "oidc",
+        authorizationEndpoint: "https://idp.example.test/oauth2/authorize",
+        tokenEndpoint: "https://idp.example.test/oauth2/token",
+        userinfoEndpoint: undefined,
+        jwksUri: undefined,
+        upstreamClientId: "upstream-client",
+        upstreamClientSecret: undefined,
+        defaultScopes: ["openid", "profile"],
+        scopeMapping: { "profile:read": ["openid", "profile"] },
+        pkceSupported: true,
+        oidcEnabled: true,
+        promptPassthroughEnabled: false,
+        loginHintPassthroughEnabled: false,
+        passthroughTokenResponse: false,
+      },
+      { keepExistingSecret: true },
+    );
+
+    expect(result).toEqual({ success: "Upstream configuration updated" });
+  });
+
+  it("validates proxy configuration before updating", async () => {
+    const result = await updateProxyClientConfigAction({
+      clientId: "client_internal",
+      providerType: "oidc",
+      authorizationEndpoint: "https://idp.example.test/oauth2/authorize",
+      tokenEndpoint: "https://idp.example.test/oauth2/token",
+      upstreamClientId: "upstream-client",
+      scopeMapping: { "profile:read": "" },
+    });
+
+    expect(result).toEqual({ error: "Scope mapping for profile:read must include provider scopes" });
+    expect(mockUpsertProxyConfig).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/admin/clients/[clientId]/client-forms.tsx
+++ b/src/app/admin/clients/[clientId]/client-forms.tsx
@@ -1395,7 +1395,7 @@ export function UpdateProxyProviderConfigForm({
         />
 
         <div className="space-y-3">
-          <FormLabel>Scope mapping</FormLabel>
+          <Label>Scope mapping</Label>
           <p className="text-xs text-muted-foreground">
             Map app scopes to provider scopes. Leave empty to forward requested scopes unchanged.
           </p>

--- a/src/app/admin/clients/__tests__/new-client-form.proxy.test.tsx
+++ b/src/app/admin/clients/__tests__/new-client-form.proxy.test.tsx
@@ -1,0 +1,158 @@
+/* @vitest-environment jsdom */
+
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
+
+import { NewClientForm } from "../new/client-form";
+
+const mockCreateClientAction = vi.hoisted(() => vi.fn());
+const mockToast = vi.hoisted(() => vi.fn());
+
+vi.mock("@/app/admin/actions", () => ({
+  createClientAction: mockCreateClientAction,
+}));
+
+vi.mock("@/components/ui/use-toast", () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
+describe("NewClientForm proxy mode", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const renderForm = () => {
+    const user = userEvent.setup();
+    render(<NewClientForm tenantId="tenant_123" />);
+    return user;
+  };
+
+  it("renders proxy provider fields and allows managing scope mappings", async () => {
+    const user = renderForm();
+
+    const proxyTab = screen.getByRole("tab", { name: "Proxy" });
+    await user.click(proxyTab);
+    expect(proxyTab).toHaveAttribute("data-state", "active");
+
+    expect(screen.getByLabelText("Provider client ID")).toBeInTheDocument();
+    expect(screen.getByLabelText("Authorization endpoint")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Add mapping" }));
+
+    const appScopeInputs = screen.getAllByLabelText("App scope");
+    expect(appScopeInputs).toHaveLength(1);
+    await user.type(appScopeInputs[0], "profile:read");
+    await user.type(screen.getByLabelText("Provider scopes"), "openid profile");
+
+    await user.click(screen.getByRole("button", { name: "Remove" }));
+    expect(screen.queryByLabelText("App scope")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Add mapping" }));
+    expect(screen.getAllByLabelText("App scope")).toHaveLength(1);
+  });
+
+  it("shows validation errors when proxy configuration is incomplete", async () => {
+    const user = renderForm();
+
+    await user.type(screen.getByLabelText("Client name"), "Proxy Validation");
+    const proxyTab = screen.getByRole("tab", { name: "Proxy" });
+    await user.click(proxyTab);
+    expect(proxyTab).toHaveAttribute("data-state", "active");
+
+    await user.click(screen.getByRole("button", { name: "Create client" }));
+
+    await screen.findByText(/Authorization endpoint is required/i);
+    await screen.findByText(/Token endpoint is required/i);
+    await screen.findByText(/Provider client ID is required/i);
+
+    expect(mockCreateClientAction).not.toHaveBeenCalled();
+    expect(mockToast).not.toHaveBeenCalled();
+  });
+
+  it("submits normalized proxy configuration", async () => {
+    const user = renderForm();
+
+    mockCreateClientAction.mockResolvedValue({
+      success: "Client created",
+      data: { clientId: "client_generated", clientSecret: "secret_generated" },
+    });
+
+    await user.type(screen.getByLabelText("Client name"), "Proxy Demo");
+    await user.click(screen.getByRole("tab", { name: "Proxy" }));
+
+    await user.clear(screen.getByLabelText("Authorization endpoint"));
+    await user.type(
+      screen.getByLabelText("Authorization endpoint"),
+      " https://idp.example.test/oauth2/authorize ",
+    );
+    await user.clear(screen.getByLabelText("Token endpoint"));
+    await user.type(screen.getByLabelText("Token endpoint"), "https://idp.example.test/oauth2/token ");
+    await user.clear(screen.getByLabelText("Provider client ID"));
+    await user.type(screen.getByLabelText("Provider client ID"), " upstream-client ");
+    await user.type(screen.getByLabelText("Provider client secret"), "secret-upstream");
+    await user.type(
+      screen.getByLabelText("Userinfo endpoint"),
+      " https://idp.example.test/oauth2/userinfo ",
+    );
+    await user.type(screen.getByLabelText("JWKS URI"), " https://idp.example.test/oauth2/jwks.json ");
+
+    await user.type(
+      screen.getByLabelText("Default provider scopes"),
+      "openid profile offline_access profile",
+    );
+
+    await user.click(screen.getByRole("button", { name: "Add mapping" }));
+    await user.type(screen.getByLabelText("App scope"), " profile:read ");
+    await user.type(screen.getByLabelText("Provider scopes"), "openid profile profile");
+
+    await user.click(screen.getByLabelText("Passthrough prompt"));
+    await user.click(screen.getByLabelText("Passthrough login_hint"));
+    await user.click(screen.getByLabelText("Passthrough token payload"));
+
+    await user.type(screen.getByLabelText("Redirect URIs"), "https://client.example.test/callback\n");
+
+    await user.click(screen.getByRole("button", { name: "Create client" }));
+
+    await waitFor(() => {
+      expect(mockCreateClientAction).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockCreateClientAction).toHaveBeenCalledWith({
+      tenantId: "tenant_123",
+      name: "Proxy Demo",
+      type: "CONFIDENTIAL",
+      redirects: ["https://client.example.test/callback"],
+      mode: "proxy",
+      proxyConfig: {
+        providerType: "oidc",
+        authorizationEndpoint: "https://idp.example.test/oauth2/authorize",
+        tokenEndpoint: "https://idp.example.test/oauth2/token",
+        userinfoEndpoint: "https://idp.example.test/oauth2/userinfo",
+        jwksUri: "https://idp.example.test/oauth2/jwks.json",
+        upstreamClientId: "upstream-client",
+        upstreamClientSecret: "secret-upstream",
+        defaultScopes: ["openid", "profile", "offline_access"],
+        scopeMapping: { "profile:read": ["openid", "profile"] },
+        pkceSupported: true,
+        oidcEnabled: true,
+        promptPassthroughEnabled: true,
+        loginHintPassthroughEnabled: true,
+        passthroughTokenResponse: true,
+      },
+    });
+
+    expect(mockToast).toHaveBeenCalledWith({
+      title: "Client created",
+      description: "Client created",
+    });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Provider client secret")).toHaveValue("");
+      expect(screen.getByLabelText("Redirect URIs")).toHaveValue("");
+    });
+
+    expect(screen.getByText("Credentials")).toBeInTheDocument();
+    expect(screen.getByText("Client ID")).toBeInTheDocument();
+  });
+});

--- a/src/app/admin/clients/new/client-form.tsx
+++ b/src/app/admin/clients/new/client-form.tsx
@@ -1,9 +1,11 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useEffect, useState, useTransition } from "react";
 import { z } from "zod";
-import { zodResolver } from "@hookform/resolvers/zod";
-import { useFieldArray, useForm, useWatch } from "react-hook-form";
+import { toNestErrors, validateFieldsNatively } from "@hookform/resolvers";
+import { appendErrors, useFieldArray, useForm, useFormContext, useWatch } from "react-hook-form";
+import type { Resolver } from "react-hook-form";
+import type { ZodIssue } from "zod";
 
 import { createClientAction } from "@/app/admin/actions";
 import { CopyField } from "@/app/admin/_components/copy-field";
@@ -115,7 +117,75 @@ const formSchema = z
 
 type FormValues = z.infer<typeof formSchema>;
 
-const defaultProxyConfig: NonNullable<FormValues["proxyConfig"]> = {
+const createZodFieldErrors = (issues: ZodIssue[], collectAll: boolean) => {
+  const pending = [...issues];
+  const fieldErrors: Record<string, any> = {};
+
+  while (pending.length > 0) {
+    const issue = pending.shift()!;
+    const path = issue.path.length > 0 ? issue.path.join(".") : "root";
+    const type = issue.code;
+    const message = issue.message;
+
+    if (!fieldErrors[path]) {
+      if ("unionErrors" in issue && Array.isArray(issue.unionErrors) && issue.unionErrors.length > 0) {
+        const [firstUnion] = issue.unionErrors;
+        const [unionIssue] = firstUnion.errors;
+        fieldErrors[path] = { message: unionIssue.message, type: unionIssue.code };
+      } else {
+        fieldErrors[path] = { message, type };
+      }
+    }
+
+    if ("unionErrors" in issue && Array.isArray(issue.unionErrors)) {
+      issue.unionErrors.forEach((unionError) => {
+        unionError.errors.forEach((unionIssue: ZodIssue) => {
+          pending.push(unionIssue);
+        });
+      });
+    }
+
+    if (collectAll) {
+      const existingTypes = fieldErrors[path].types;
+      const previous = existingTypes && existingTypes[type];
+      const nextMessage = previous
+        ? Array.isArray(previous)
+          ? [...previous, message]
+          : [previous, message]
+        : message;
+      fieldErrors[path] = appendErrors(
+        path,
+        collectAll,
+        fieldErrors,
+        type,
+        nextMessage,
+      );
+    }
+  }
+
+  return fieldErrors;
+};
+
+const proxyFormResolver: Resolver<FormValues> = async (values, context, options) => {
+  const result = await formSchema.safeParseAsync(values);
+
+  if (result.success) {
+    if (options.shouldUseNativeValidation) {
+      validateFieldsNatively({}, options);
+    }
+    return { values: result.data, errors: {} };
+  }
+
+  return {
+    values: {},
+    errors: toNestErrors(
+      createZodFieldErrors(result.error.issues, !options.shouldUseNativeValidation && options.criteriaMode === "all"),
+      options,
+    ),
+  };
+};
+
+const createDefaultProxyConfig = (): NonNullable<FormValues["proxyConfig"]> => ({
   providerType: "oidc",
   authorizationEndpoint: "",
   tokenEndpoint: "",
@@ -130,7 +200,7 @@ const defaultProxyConfig: NonNullable<FormValues["proxyConfig"]> = {
   promptPassthroughEnabled: false,
   loginHintPassthroughEnabled: false,
   passthroughTokenResponse: false,
-};
+});
 
 const splitScopes = (value?: string | null) => {
   if (!value) {
@@ -163,15 +233,74 @@ const buildScopeMapping = (
   return Object.keys(mapping).length > 0 ? mapping : undefined;
 };
 
+function ProxyScopeMappingFields({ pending }: { pending: boolean }) {
+  const form = useFormContext<FormValues>();
+  const { fields, append, remove } = useFieldArray({ control: form.control, name: "proxyConfig.scopeMappings" });
+
+  return (
+    <div className="space-y-3">
+      <p className="text-sm font-semibold">Scope mapping</p>
+      <p className="text-xs text-muted-foreground">
+        Map each app-facing scope to provider scopes. Leave empty to forward the requested scope as-is.
+      </p>
+      <div className="space-y-3">
+        {fields.length === 0 ? <p className="text-xs text-muted-foreground">No mappings configured.</p> : null}
+        {fields.map((fieldItem, index) => (
+          <div key={fieldItem.id} className="flex flex-col gap-3 rounded-md border p-4 md:flex-row md:items-center">
+            <FormField
+              control={form.control}
+              name={`proxyConfig.scopeMappings.${index}.appScope`}
+              render={({ field }) => (
+                <FormItem className="flex-1">
+                  <FormLabel className="text-xs uppercase tracking-wide">App scope</FormLabel>
+                  <FormControl>
+                    <Input placeholder="profile:read" {...field} disabled={pending} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name={`proxyConfig.scopeMappings.${index}.providerScopes`}
+              render={({ field }) => (
+                <FormItem className="flex-1">
+                  <FormLabel className="text-xs uppercase tracking-wide">Provider scopes</FormLabel>
+                  <FormControl>
+                    <Input placeholder="openid profile" {...field} disabled={pending} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => remove(index)}
+              disabled={pending}
+              className="md:self-end"
+            >
+              Remove
+            </Button>
+          </div>
+        ))}
+      </div>
+      <Button type="button" variant="outline" onClick={() => append({ appScope: "", providerScopes: "" })} disabled={pending}>
+        Add mapping
+      </Button>
+    </div>
+  );
+}
+
 export function NewClientForm({ tenantId }: { tenantId: string }) {
   const form = useForm<FormValues>({
-    resolver: zodResolver(formSchema),
+    resolver: proxyFormResolver,
     defaultValues: {
       name: "",
       type: "CONFIDENTIAL",
       redirects: "",
       mode: "regular",
-      proxyConfig: defaultProxyConfig,
+      proxyConfig: createDefaultProxyConfig(),
     },
   });
   const { toast } = useToast();
@@ -179,7 +308,29 @@ export function NewClientForm({ tenantId }: { tenantId: string }) {
   const [credentials, setCredentials] = useState<{ clientId: string; clientSecret?: string } | null>(null);
 
   const watchMode = useWatch({ control: form.control, name: "mode" });
-  const { fields, append, remove } = useFieldArray({ control: form.control, name: "proxyConfig.scopeMappings" });
+  const { getValues, setValue } = form;
+
+  useEffect(() => {
+    if (watchMode !== "proxy") {
+      return;
+    }
+    const currentConfig = getValues("proxyConfig");
+    if (!currentConfig) {
+      setValue("proxyConfig", createDefaultProxyConfig(), {
+        shouldDirty: false,
+        shouldTouch: false,
+        shouldValidate: false,
+      });
+      return;
+    }
+    if (!Array.isArray(currentConfig.scopeMappings)) {
+      setValue("proxyConfig.scopeMappings", [], {
+        shouldDirty: false,
+        shouldTouch: false,
+        shouldValidate: false,
+      });
+    }
+  }, [watchMode, getValues, setValue]);
 
   const onSubmit = (values: FormValues) => {
     startTransition(async () => {
@@ -228,7 +379,7 @@ export function NewClientForm({ tenantId }: { tenantId: string }) {
         type: values.type,
         redirects: "",
         mode: values.mode,
-        proxyConfig: defaultProxyConfig,
+        proxyConfig: createDefaultProxyConfig(),
       });
     });
   };
@@ -431,59 +582,7 @@ export function NewClientForm({ tenantId }: { tenantId: string }) {
               )}
             />
 
-            <div className="space-y-3">
-              <FormLabel>Scope mapping</FormLabel>
-              <p className="text-xs text-muted-foreground">
-                Map each app-facing scope to provider scopes. Leave empty to forward the requested scope as-is.
-              </p>
-              <div className="space-y-3">
-                {fields.length === 0 ? (
-                  <p className="text-xs text-muted-foreground">No mappings configured.</p>
-                ) : null}
-                {fields.map((fieldItem, index) => (
-                  <div key={fieldItem.id} className="flex flex-col gap-3 rounded-md border p-4 md:flex-row md:items-center">
-                    <FormField
-                      control={form.control}
-                      name={`proxyConfig.scopeMappings.${index}.appScope`}
-                      render={({ field }) => (
-                        <FormItem className="flex-1">
-                          <FormLabel className="text-xs uppercase tracking-wide">App scope</FormLabel>
-                          <FormControl>
-                            <Input placeholder="profile:read" {...field} disabled={pending} />
-                          </FormControl>
-                          <FormMessage />
-                        </FormItem>
-                      )}
-                    />
-                    <FormField
-                      control={form.control}
-                      name={`proxyConfig.scopeMappings.${index}.providerScopes`}
-                      render={({ field }) => (
-                        <FormItem className="flex-1">
-                          <FormLabel className="text-xs uppercase tracking-wide">Provider scopes</FormLabel>
-                          <FormControl>
-                            <Input placeholder="openid profile" {...field} disabled={pending} />
-                          </FormControl>
-                          <FormMessage />
-                        </FormItem>
-                      )}
-                    />
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      onClick={() => remove(index)}
-                      disabled={pending}
-                      className="md:self-end"
-                    >
-                      Remove
-                    </Button>
-                  </div>
-                ))}
-              </div>
-              <Button type="button" variant="outline" onClick={() => append({ appScope: "", providerScopes: "" })} disabled={pending}>
-                Add mapping
-              </Button>
-            </div>
+            <ProxyScopeMappingFields pending={pending} />
 
             <div className="grid gap-4 md:grid-cols-2">
               <FormField

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -56,7 +56,7 @@ const ToastTitle = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Title>,
   React.ComponentPropsWithoutRef<typeof ToastPrimitives.Title>
 >(({ className, ...props }, ref) => (
-  <ToastPrimitives.Title ref={ref} aria-hidden="true" className={cn("text-sm font-semibold", className)} {...props} />
+  <ToastPrimitives.Title ref={ref} className={cn("text-sm font-semibold", className)} {...props} />
 ));
 ToastTitle.displayName = ToastPrimitives.Title.displayName;
 
@@ -64,7 +64,7 @@ const ToastDescription = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Description>,
   React.ComponentPropsWithoutRef<typeof ToastPrimitives.Description>
 >(({ className, ...props }, ref) => (
-  <ToastPrimitives.Description ref={ref} aria-hidden="true" className={cn("text-sm text-muted-foreground", className)} {...props} />
+  <ToastPrimitives.Description ref={ref} className={cn("text-sm text-muted-foreground", className)} {...props} />
 ));
 ToastDescription.displayName = ToastPrimitives.Description.displayName;
 

--- a/tests/e2e/admin.spec.ts
+++ b/tests/e2e/admin.spec.ts
@@ -77,7 +77,7 @@ test.describe("admin console", () => {
 
     const row = page.getByRole("row", { name: new RegExp(clientName, "i") }).last();
     await row.getByRole("link", { name: "Details →" }).click();
-    await expect(page.getByText("Redirect URIs")).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Redirect URIs" })).toBeVisible();
 
     const requiredSection = page.getByTestId("oauth-required");
     await expect(requiredSection.locator("[data-field-label]").first()).toBeVisible();

--- a/tests/e2e/auth-strategies.spec.ts
+++ b/tests/e2e/auth-strategies.spec.ts
@@ -50,7 +50,7 @@ test.describe("auth strategy persistence", () => {
     const saveButton = page.getByRole("button", { name: "Save strategies" });
     await expect(saveButton).toBeEnabled();
     await saveButton.click();
-    await expect(page.getByText("Auth strategies updated")).toBeVisible();
+    await expect(page.getByText("Auth strategies updated").first()).toBeVisible();
     await expect.poll(async () => (await getClientStrategies(page)).username.subSource, { timeout: 10_000 }).toBe(
       "generated_uuid",
     );

--- a/tests/e2e/proxy-clients.spec.ts
+++ b/tests/e2e/proxy-clients.spec.ts
@@ -1,0 +1,68 @@
+import { expect, test } from "@playwright/test";
+
+import { authenticate, createTestSession, stubClipboard } from "./helpers/admin";
+
+test.describe("proxy clients", () => {
+  test("creates a proxy client and updates provider config", async ({ page }) => {
+    const sessionToken = await createTestSession(page);
+    await authenticate(page, sessionToken);
+    await stubClipboard(page);
+
+    await page.goto("/admin/clients");
+    await expect(page.getByRole("heading", { name: "OAuth clients" })).toBeVisible();
+
+    const clientName = `Proxy Client ${Date.now()}`;
+
+    await page.getByRole("link", { name: "Add client" }).click();
+    await expect(page.getByRole("heading", { name: "New client" })).toBeVisible();
+
+    await page.getByLabel("Client name").fill(clientName);
+    await page.getByRole("tab", { name: "Proxy" }).click();
+
+    await page.getByLabel("Provider client ID").fill("proxy-upstream-client");
+    await page.getByLabel("Provider client secret").fill("proxy-upstream-secret");
+    await page.getByLabel("Authorization endpoint").fill("https://upstream.example.test/oauth2/authorize");
+    await page.getByLabel("Token endpoint").fill("https://upstream.example.test/oauth2/token");
+    await page.getByLabel("Userinfo endpoint").fill("https://upstream.example.test/oauth2/userinfo");
+    await page.getByLabel("JWKS URI").fill("https://upstream.example.test/oauth2/jwks.json");
+    await page.getByLabel("Default provider scopes").fill("openid profile");
+
+    await page.getByRole("button", { name: "Add mapping" }).click();
+    await page.getByLabel("App scope").fill("profile:read");
+    await page.getByLabel("Provider scopes", { exact: true }).fill("openid profile");
+
+    await page.getByRole("button", { name: "Create client" }).click();
+
+    await expect(page.getByText("Client created").first()).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Credentials" })).toBeVisible();
+
+    await page.getByRole("link", { name: "Back to list" }).click();
+    await expect(page).toHaveURL(/\/admin\/clients$/);
+
+    await page.getByTestId("clients-search-input").fill(clientName);
+    const clientRow = page.getByRole("row", { name: new RegExp(clientName, "i") });
+    await expect(clientRow).toBeVisible();
+    await clientRow.getByRole("link", { name: "Details →" }).click();
+
+    await page.getByLabel("Default provider scopes").fill("openid profile offline_access");
+    await page.getByRole("button", { name: "Add mapping" }).click();
+
+    const appScopeInputs = page.getByLabel("App scope");
+    await expect(appScopeInputs).toHaveCount(2);
+    await appScopeInputs.nth(1).fill("email:read");
+
+    const providerScopeInputs = page.getByLabel("Provider scopes", { exact: true });
+    await expect(providerScopeInputs).toHaveCount(2);
+    await providerScopeInputs.nth(1).fill("email");
+
+    await page.getByLabel("Provider client secret").fill("rotated-upstream-secret");
+    await page.getByLabel("Passthrough token payload").check();
+
+    await page.getByRole("button", { name: "Save changes" }).click();
+
+    await expect(page.getByText("Proxy configuration updated", { exact: true })).toBeVisible();
+    await expect(page.getByLabel("Provider client secret")).toHaveValue("");
+    await expect(page.locator('input[value="email:read"]')).toBeVisible();
+    await expect(page.locator('input[value="email"]')).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- replace the new client proxy resolver with a custom implementation so proxy mapping validation errors render and the form stays stable
- add proxy-specific component/server tests plus an end-to-end scenario that exercises provider scope mapping edits
- make toast messages accessible and adjust existing Playwright expectations for the broader admin flows

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm dotenv -e .env.test -o -- playwright test --workers=1

Fixes #100