### PR TITLE
feat: integrate rhf select for proxy clients

### DIFF
--- a/src/app/admin/api/test/seed-tenants-clients/route.ts
+++ b/src/app/admin/api/test/seed-tenants-clients/route.ts
@@ -22,6 +22,9 @@ type SeedResponse = {
   clientsB: { id: string; name: string; clientId: string }[];
 };
 
+const isUniqueConstraintError = (error: unknown): error is { code?: string } =>
+  typeof error === "object" && error !== null && "code" in error && (error as { code?: string }).code === "P2002";
+
 export async function POST(request: Request) {
   if (!env.ENABLE_TEST_ROUTES) {
     return NextResponse.json({ error: "Not found" }, { status: 404 });
@@ -30,14 +33,21 @@ export async function POST(request: Request) {
   const payload = (await request.json().catch(() => ({}))) as SeedRequest;
   const adminEmail = payload.adminEmail?.toLowerCase().trim() || ADMIN_EMAIL;
 
-  const admin = await prisma.adminUser.upsert({
-    where: { email: adminEmail },
-    update: {},
-    create: {
-      email: adminEmail,
-      name: "Playwright Admin",
-    },
-  });
+  const admin = await prisma.adminUser
+    .upsert({
+      where: { email: adminEmail },
+      update: {},
+      create: {
+        email: adminEmail,
+        name: "Playwright Admin",
+      },
+    })
+    .catch(async (error) => {
+      if (isUniqueConstraintError(error)) {
+        return prisma.adminUser.findUniqueOrThrow({ where: { email: adminEmail } });
+      }
+      throw error;
+    });
 
   const timestamp = Date.now();
   const tenantAName = `Tenant Switch A ${timestamp}`;

--- a/src/app/admin/clients/[clientId]/client-forms.tsx
+++ b/src/app/admin/clients/[clientId]/client-forms.tsx
@@ -28,6 +28,7 @@ import { useToast } from "@/components/ui/use-toast";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Label } from "@/components/ui/label";
+import { RHFSelectField } from "@/components/rhf/rhf-select-field";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import type { ClientAuthStrategies } from "@/server/oidc/auth-strategy";
 import { cn } from "@/lib/utils";
@@ -1269,26 +1270,16 @@ export function UpdateProxyProviderConfigForm({
     <Form {...form}>
       <form onSubmit={onSubmit} className="space-y-6">
         <div className="grid gap-4 md:grid-cols-2">
-          <FormField
+          <RHFSelectField
             control={form.control}
             name="providerType"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Provider type</FormLabel>
-                <Select value={field.value} onValueChange={field.onChange} disabled={disableForm}>
-                  <FormControl>
-                    <SelectTrigger className="justify-between">
-                      <SelectValue placeholder="Select provider type" />
-                    </SelectTrigger>
-                  </FormControl>
-                  <SelectContent>
-                    <SelectItem value="oidc">OpenID Connect</SelectItem>
-                    <SelectItem value="oauth2">OAuth 2.0</SelectItem>
-                  </SelectContent>
-                </Select>
-                <FormMessage />
-              </FormItem>
-            )}
+            label="Provider type"
+            placeholder="Select provider type"
+            options={[
+              { value: "oidc", label: "OpenID Connect" },
+              { value: "oauth2", label: "OAuth 2.0" },
+            ]}
+            disabled={disableForm}
           />
 
           <FormField

--- a/src/app/admin/clients/__tests__/new-client-form.proxy.test.tsx
+++ b/src/app/admin/clients/__tests__/new-client-form.proxy.test.tsx
@@ -1,6 +1,6 @@
 /* @vitest-environment jsdom */
 
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { vi } from "vitest";
 
@@ -16,6 +16,8 @@ vi.mock("@/app/admin/actions", () => ({
 vi.mock("@/components/ui/use-toast", () => ({
   useToast: () => ({ toast: mockToast }),
 }));
+
+vi.mock("@/components/ui/select", async () => await import("@/test-utils/mocks/shadcn-select"));
 
 describe("NewClientForm proxy mode", () => {
   beforeEach(() => {
@@ -68,6 +70,40 @@ describe("NewClientForm proxy mode", () => {
 
     expect(mockCreateClientAction).not.toHaveBeenCalled();
     expect(mockToast).not.toHaveBeenCalled();
+  });
+
+  it("persists provider type selection and submits chosen value", async () => {
+    const user = renderForm();
+
+    mockCreateClientAction.mockResolvedValueOnce({ success: "Created" });
+
+    await user.type(screen.getByLabelText("Client name"), "Proxy Provider");
+    await user.click(screen.getByRole("tab", { name: "Proxy" }));
+
+    const providerField = screen.getByText("Provider type").closest("div");
+    expect(providerField).not.toBeNull();
+    const providerSelect = within(providerField as HTMLElement).getByRole("combobox");
+    expect(providerSelect).toHaveValue("oidc");
+
+    await user.selectOptions(providerSelect, "oauth2");
+    expect(providerSelect).toHaveValue("oauth2");
+
+    await user.clear(screen.getByLabelText("Authorization endpoint"));
+    await user.type(screen.getByLabelText("Authorization endpoint"), "https://idp.example.test/oauth2/auth");
+    await user.clear(screen.getByLabelText("Token endpoint"));
+    await user.type(screen.getByLabelText("Token endpoint"), "https://idp.example.test/oauth2/token");
+    await user.clear(screen.getByLabelText("Provider client ID"));
+    await user.type(screen.getByLabelText("Provider client ID"), "proxy-client");
+
+    await user.click(screen.getByRole("button", { name: "Create client" }));
+
+    await waitFor(() => expect(mockCreateClientAction).toHaveBeenCalledTimes(1));
+    expect(mockCreateClientAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tenantId: "tenant_123",
+        proxyConfig: expect.objectContaining({ providerType: "oauth2" }),
+      }),
+    );
   });
 
   it("submits normalized proxy configuration", async () => {

--- a/src/app/admin/clients/new/client-form.tsx
+++ b/src/app/admin/clients/new/client-form.tsx
@@ -16,7 +16,7 @@ import { Input } from "@/components/ui/input";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
 import { useToast } from "@/components/ui/use-toast";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { RHFSelectField } from "@/components/rhf/rhf-select-field";
 
 const scopeMappingSchema = z.object({
   appScope: z.string().optional(),
@@ -24,7 +24,7 @@ const scopeMappingSchema = z.object({
 });
 
 const proxyConfigSchema = z.object({
-  providerType: z.enum(["oidc", "oauth2"]).optional(),
+  providerType: z.enum(["oidc", "oauth2"]),
   authorizationEndpoint: z.string().optional(),
   tokenEndpoint: z.string().optional(),
   userinfoEndpoint: z.string().optional(),
@@ -57,10 +57,6 @@ const formSchema = z
     if (!config) {
       ctx.addIssue({ path: ["proxyConfig"], code: "custom", message: "Proxy configuration is required" });
       return;
-    }
-
-    if (!config.providerType) {
-      ctx.addIssue({ path: ["proxyConfig", "providerType"], code: "custom", message: "Select a provider type" });
     }
 
     const requiredFields: Array<[keyof typeof config, string]> = [
@@ -316,12 +312,30 @@ export function NewClientForm({ tenantId }: { tenantId: string }) {
     }
     const currentConfig = getValues("proxyConfig");
     if (!currentConfig) {
-      setValue("proxyConfig", createDefaultProxyConfig(), {
+      const defaults = createDefaultProxyConfig();
+      setValue("proxyConfig", defaults, {
+        shouldDirty: false,
+        shouldTouch: false,
+        shouldValidate: false,
+      });
+      setValue("proxyConfig.providerType", defaults.providerType, {
+        shouldDirty: false,
+        shouldTouch: false,
+        shouldValidate: false,
+      });
+      setValue("proxyConfig.scopeMappings", defaults.scopeMappings ?? [], {
         shouldDirty: false,
         shouldTouch: false,
         shouldValidate: false,
       });
       return;
+    }
+    if (!currentConfig.providerType) {
+      setValue("proxyConfig.providerType", "oidc", {
+        shouldDirty: false,
+        shouldTouch: false,
+        shouldValidate: false,
+      });
     }
     if (!Array.isArray(currentConfig.scopeMappings)) {
       setValue("proxyConfig.scopeMappings", [], {
@@ -341,7 +355,7 @@ export function NewClientForm({ tenantId }: { tenantId: string }) {
 
       const proxyConfigInput = values.mode === "proxy" && values.proxyConfig
         ? {
-            providerType: values.proxyConfig.providerType ?? "oidc",
+            providerType: values.proxyConfig.providerType,
             authorizationEndpoint: values.proxyConfig.authorizationEndpoint?.trim() ?? "",
             tokenEndpoint: values.proxyConfig.tokenEndpoint?.trim() ?? "",
             userinfoEndpoint: values.proxyConfig.userinfoEndpoint?.trim() || undefined,
@@ -455,26 +469,16 @@ export function NewClientForm({ tenantId }: { tenantId: string }) {
             </div>
 
             <div className="grid gap-4 md:grid-cols-2">
-              <FormField
+              <RHFSelectField
                 control={form.control}
                 name="proxyConfig.providerType"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Provider type</FormLabel>
-                    <Select value={field.value ?? "oidc"} onValueChange={field.onChange} disabled={pending}>
-                      <FormControl>
-                        <SelectTrigger className="justify-between">
-                          <SelectValue placeholder="Select provider type" />
-                        </SelectTrigger>
-                      </FormControl>
-                      <SelectContent>
-                        <SelectItem value="oidc">OpenID Connect</SelectItem>
-                        <SelectItem value="oauth2">OAuth 2.0</SelectItem>
-                      </SelectContent>
-                    </Select>
-                    <FormMessage />
-                  </FormItem>
-                )}
+                label="Provider type"
+                placeholder="Select provider type"
+                options={[
+                  { value: "oidc", label: "OpenID Connect" },
+                  { value: "oauth2", label: "OAuth 2.0" },
+                ]}
+                disabled={pending}
               />
 
               <FormField

--- a/src/app/api/test/session/route.ts
+++ b/src/app/api/test/session/route.ts
@@ -23,17 +23,27 @@ export async function POST(request: Request) {
   const payload = (await request.json().catch(() => ({}))) as Body;
   const tenantId = payload.tenantId ?? DEFAULT_TENANT_ID;
 
+  const isUniqueConstraintError = (error: unknown): error is { code?: string } =>
+    typeof error === "object" && error !== null && "code" in error && (error as { code?: string }).code === "P2002";
+
   const email = payload.email?.toLowerCase() || "pw-admin@example.test";
   const name = payload.name ?? "Playwright Admin";
 
-  const admin = await prisma.adminUser.upsert({
-    where: { email },
-    update: { name },
-    create: {
-      email,
-      name,
-    },
-  });
+  const admin = await prisma.adminUser
+    .upsert({
+      where: { email },
+      update: { name },
+      create: {
+        email,
+        name,
+      },
+    })
+    .catch(async (error) => {
+      if (isUniqueConstraintError(error)) {
+        return prisma.adminUser.update({ where: { email }, data: { name } });
+      }
+      throw error;
+    });
 
   const shouldAssignMembership = payload.assignMembership ?? true;
   if (shouldAssignMembership) {

--- a/src/components/rhf/__tests__/rhf-select-field.test.tsx
+++ b/src/components/rhf/__tests__/rhf-select-field.test.tsx
@@ -1,0 +1,58 @@
+/* @vitest-environment jsdom */
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useForm, useWatch } from "react-hook-form";
+import { describe, expect, it, vi } from "vitest";
+
+import { RHFSelectField } from "@/components/rhf/rhf-select-field";
+import { Form } from "@/components/ui/form";
+
+vi.mock("@/components/ui/select", async () => await import("@/test-utils/mocks/shadcn-select"));
+
+type TestFormValues = {
+  providerType: "oidc" | "oauth2";
+};
+
+function TestHarness({ onValueChange }: { onValueChange?: (value: string) => void }) {
+  const form = useForm<TestFormValues>({ defaultValues: { providerType: "oidc" } });
+  const selected = useWatch({ control: form.control, name: "providerType" }) ?? "";
+
+  return (
+    <Form {...form}>
+      <form>
+        <RHFSelectField
+          control={form.control}
+          name="providerType"
+          label="Provider type"
+          placeholder="Select provider type"
+          options={[
+            { value: "oidc", label: "OpenID Connect" },
+            { value: "oauth2", label: "OAuth 2.0" },
+          ]}
+          onValueChange={onValueChange}
+        />
+        <span data-testid="provider-value">{selected}</span>
+      </form>
+    </Form>
+  );
+}
+
+describe("RHFSelectField", () => {
+  it("reads defaults from RHF and updates on selection", async () => {
+    const user = userEvent.setup();
+    const handleValueChange = vi.fn();
+
+    render(<TestHarness onValueChange={handleValueChange} />);
+
+    const select = screen.getByRole("combobox");
+    expect(select).toHaveValue("oidc");
+    expect(screen.getByTestId("provider-value")).toHaveTextContent("oidc");
+
+    await user.selectOptions(select, "oauth2");
+
+    expect(select).toHaveValue("oauth2");
+    expect(screen.getByTestId("provider-value")).toHaveTextContent("oauth2");
+    expect(handleValueChange).toHaveBeenCalledWith("oauth2");
+  });
+});

--- a/src/components/rhf/rhf-select-field.tsx
+++ b/src/components/rhf/rhf-select-field.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import * as React from "react";
+import type { Control, FieldPath, FieldValues } from "react-hook-form";
+
+import { cn } from "@/lib/utils";
+import { FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+
+type SelectRootProps = React.ComponentPropsWithoutRef<typeof Select>;
+type SelectTriggerProps = React.ComponentPropsWithoutRef<typeof SelectTrigger>;
+type SelectContentProps = React.ComponentPropsWithoutRef<typeof SelectContent>;
+type SelectItemProps = React.ComponentPropsWithoutRef<typeof SelectItem>;
+
+export type RHFSelectOption<TValue extends string> = {
+  value: TValue;
+  label: React.ReactNode;
+  itemProps?: Omit<SelectItemProps, "value">;
+};
+
+type RHFSelectFieldProps<
+  TFieldValues extends FieldValues,
+  TName extends FieldPath<TFieldValues>,
+  TValue extends string,
+> = {
+  control: Control<TFieldValues>;
+  name: TName;
+  label?: React.ReactNode;
+  placeholder?: string;
+  description?: React.ReactNode;
+  options: ReadonlyArray<RHFSelectOption<TValue>>;
+  disabled?: boolean;
+  className?: string;
+  triggerClassName?: string;
+  contentProps?: Omit<SelectContentProps, "children">;
+  onValueChange?: (value: TValue) => void;
+} & Omit<SelectRootProps, "value" | "defaultValue" | "onValueChange" | "children"> &
+  Partial<Pick<SelectTriggerProps, "id" | "name">>;
+
+export function RHFSelectField<
+  TFieldValues extends FieldValues,
+  TName extends FieldPath<TFieldValues>,
+  TValue extends string,
+>({
+  control,
+  name,
+  label,
+  placeholder,
+  description,
+  options,
+  disabled,
+  className,
+  triggerClassName,
+  contentProps,
+  onValueChange,
+  id,
+  name: triggerName,
+  ...selectProps
+}: RHFSelectFieldProps<TFieldValues, TName, TValue>) {
+  return (
+    <FormField
+      control={control}
+      name={name}
+      render={({ field }) => {
+        const isDisabled = disabled ?? false;
+        const triggerAriaLabel = typeof label === "string" ? label : undefined;
+
+        return (
+          <FormItem className={className}>
+            {label ? <FormLabel>{label}</FormLabel> : null}
+            <FormControl>
+              <Select
+                {...selectProps}
+                value={field.value}
+                onValueChange={(nextValue) => {
+                  field.onChange(nextValue);
+                  field.onBlur();
+                  onValueChange?.(nextValue as TValue);
+                }}
+                disabled={isDisabled}
+              >
+                <SelectTrigger
+                  id={id}
+                  name={triggerName}
+                  className={cn("justify-between", triggerClassName)}
+                  aria-label={triggerAriaLabel}
+                  data-selected-value={field.value as string | undefined}
+                  disabled={isDisabled}
+                >
+                  <SelectValue placeholder={placeholder} />
+                </SelectTrigger>
+                <SelectContent {...contentProps}>
+                  {options.map((option) => (
+                    <SelectItem key={option.value} value={option.value} {...option.itemProps}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </FormControl>
+            {description ? <FormDescription>{description}</FormDescription> : null}
+            <FormMessage />
+          </FormItem>
+        );
+      }}
+    />
+  );
+}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -73,7 +73,7 @@ SelectLabel.displayName = SelectPrimitive.Label.displayName;
 const SelectItem = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Item>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
->(({ className, children, ...props }, ref) => (
+  >(({ className, children, ...props }, ref) => (
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
@@ -87,7 +87,7 @@ const SelectItem = React.forwardRef<
         <Check className="h-4 w-4" />
       </SelectPrimitive.ItemIndicator>
     </span>
-    {children}
+    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
   </SelectPrimitive.Item>
 ));
 SelectItem.displayName = SelectPrimitive.Item.displayName;

--- a/tests/e2e/proxy-clients.spec.ts
+++ b/tests/e2e/proxy-clients.spec.ts
@@ -42,7 +42,11 @@ test.describe("proxy clients", () => {
     await page.getByTestId("clients-search-input").fill(clientName);
     const clientRow = page.getByRole("row", { name: new RegExp(clientName, "i") });
     await expect(clientRow).toBeVisible();
-    await clientRow.getByRole("link", { name: "Details →" }).click();
+    const detailsHref = await clientRow.getByRole("link", { name: "Details →" }).getAttribute("href");
+    expect(detailsHref).toBeTruthy();
+    await page.goto(detailsHref!, { waitUntil: "domcontentloaded" });
+    await page.waitForURL(/\/admin\/clients\/[0-9a-f-]+$/);
+    await expect(page.getByRole("heading", { name: "Proxy provider" })).toBeVisible();
 
     await page.getByLabel("Default provider scopes").fill("openid profile offline_access");
     await page.getByRole("button", { name: "Add mapping" }).click();
@@ -64,5 +68,52 @@ test.describe("proxy clients", () => {
     await expect(page.getByLabel("Provider client secret")).toHaveValue("");
     await expect(page.locator('input[value="email:read"]')).toBeVisible();
     await expect(page.locator('input[value="email"]')).toBeVisible();
+  });
+
+  test("honors provider type selection when creating proxy clients", async ({ page }) => {
+    const sessionToken = await createTestSession(page);
+    await authenticate(page, sessionToken);
+    await stubClipboard(page);
+
+    await page.goto("/admin/clients");
+    await expect(page.getByRole("heading", { name: "OAuth clients" })).toBeVisible();
+
+    const clientName = `Proxy Provider ${Date.now()}`;
+
+    await page.getByRole("link", { name: "Add client" }).click();
+    await expect(page.getByRole("heading", { name: "New client" })).toBeVisible();
+
+    await page.getByLabel("Client name").fill(clientName);
+    await page.getByRole("tab", { name: "Proxy" }).click();
+
+    const providerSelect = page.getByRole("combobox", { name: "Provider type" });
+    await expect(providerSelect).toHaveAttribute("data-selected-value", "oidc");
+    await providerSelect.click();
+    const openIdOption = page.getByRole("option", { name: "OpenID Connect" });
+    await expect(openIdOption).toHaveAttribute("data-state", "checked");
+    await page.getByRole("option", { name: "OAuth 2.0" }).click({ force: true });
+    await page.getByLabel("Provider client ID").fill("provider-upstream");
+    await page.getByLabel("Authorization endpoint").fill("https://upstream.example.test/oauth2/authorize");
+    await page.getByLabel("Token endpoint").fill("https://upstream.example.test/oauth2/token");
+
+    await page.getByRole("button", { name: "Create client" }).click();
+
+    await expect(page.getByText("Client created").first()).toBeVisible();
+
+    await page.getByRole("link", { name: "Back to list" }).click();
+    await expect(page).toHaveURL(/\/admin\/clients$/);
+
+    await page.getByTestId("clients-search-input").fill(clientName);
+    const clientRow = page.getByRole("row", { name: new RegExp(clientName, "i") });
+    await expect(clientRow).toBeVisible();
+    const detailsHref = await clientRow.getByRole("link", { name: "Details →" }).getAttribute("href");
+    expect(detailsHref).toBeTruthy();
+    await page.goto(detailsHref!, { waitUntil: "domcontentloaded" });
+    await page.waitForURL(/\/admin\/clients\/[0-9a-f-]+$/);
+    await expect(page.getByRole("heading", { name: "Proxy provider" })).toBeVisible();
+    const persistedSelect = page.getByRole("combobox", { name: "Provider type" });
+    await persistedSelect.click();
+    await expect(page.getByRole("option", { name: "OAuth 2.0" })).toHaveAttribute("data-state", "checked");
+    await page.keyboard.press("Escape");
   });
 });


### PR DESCRIPTION
## Summary
- introduce reusable RHFSelectField wrapping the Radix select component
- refactor proxy client forms to use RHFSelectField and enforce defaults
- harden test seed routes for duplicate admins and extend proxy coverage

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm test:e2e

Closes #102