### PR TITLE
fix(audit): add provider exchange details

### DIFF
--- a/src/app/r/[apiResourceId]/oidc/token/route.ts
+++ b/src/app/r/[apiResourceId]/oidc/token/route.ts
@@ -61,6 +61,7 @@ export async function POST(request: NextRequest, context: ApiResourceRouteContex
     const clientId = basic?.clientId ?? validation.data.client_id ?? null;
     const clientSecret = basic?.clientSecret ?? validation.data.client_secret ?? null;
     const requestContext = getRequestContextFromRequest(request);
+    const origin = resolveOrigin(request);
     const clientSecretInBody = Boolean(validation.data.client_secret);
     const clientIdProvided = Boolean(clientId);
     const includeAuthHeader = Boolean(basic);
@@ -81,6 +82,7 @@ export async function POST(request: NextRequest, context: ApiResourceRouteContex
           clientSecret,
           auditContext: {
             requestContext,
+            origin,
             clientSecretInBody,
             clientIdProvided,
             includeAuthHeader,
@@ -129,7 +131,7 @@ export async function POST(request: NextRequest, context: ApiResourceRouteContex
         codeVerifier: validation.data.code_verifier,
         redirectUri: validation.data.redirect_uri,
         clientSecret,
-        origin: resolveOrigin(request),
+        origin,
         authorizationCode: validation.data.code,
         auditContext: {
           requestContext,

--- a/src/server/oidc/__tests__/proxy-flow.test.ts
+++ b/src/server/oidc/__tests__/proxy-flow.test.ts
@@ -13,7 +13,7 @@ import {
   completeProxyRefreshGrant,
 } from "@/server/services/proxy-token-service";
 import { createSession, clearSession } from "@/server/services/mock-session-service";
-import { PROXY_TRANSACTION_COOKIE } from "@/server/oidc/proxy/constants";
+import { PROXY_TRANSACTION_COOKIE, buildProxyCallbackUrl } from "@/server/oidc/proxy/constants";
 import { DEFAULT_CLIENT_AUTH_STRATEGIES } from "@/server/oidc/auth-strategy";
 
 const DEFAULT_TENANT_ID = "tenant_qa";
@@ -290,6 +290,118 @@ describe("Proxy client OAuth flow", () => {
       traceId: transactionId,
       eventType: "PROXY_CALLBACK_ERROR",
     });
+    const callbackDetails = auditLog?.details as Record<string, unknown>;
+    expect(callbackDetails).toMatchObject({
+      tokenEndpointHost: "upstream.example.com",
+      authMethod: "none",
+      includeAuthHeader: false,
+      includeClientSecretInBody: false,
+      client_id: "up-client",
+      redirect_uri: buildProxyCallbackUrl("https://mockauth.test", apiResourceId),
+      grant_type: "authorization_code",
+      code_verifier_present: true,
+    });
+
+    fetchMock.mockRestore();
+  });
+
+  it("records TOKEN_AUTHCODE_COMPLETED error details for proxy token failures", async () => {
+    const codeVerifier = "verifier-error-token-ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    const codeChallenge = computeS256Challenge(codeVerifier);
+
+    const authorize = await handleAuthorize(
+      {
+        apiResourceId,
+        clientId: proxyClientClientId,
+        redirectUri: "https://proxy-client.test/callback",
+        responseType: "code",
+        scope: "openid profile",
+        state: "app-state-token-error",
+        codeChallenge,
+        codeChallengeMethod: "S256",
+        sessionToken,
+      },
+      "https://mockauth.test",
+      `https://mockauth.test/r/${apiResourceId}/oidc/authorize?client_id=${proxyClientClientId}`,
+    );
+
+    const proxyCookie = authorize.cookies?.find((cookie) => cookie.name === PROXY_TRANSACTION_COOKIE);
+    const providerAuthorizeUrl = new URL(authorize.redirectTo);
+    const transactionId = providerAuthorizeUrl.searchParams.get("state");
+    expect(proxyCookie?.value).toBeDefined();
+    expect(transactionId).toBe(proxyCookie?.value);
+
+    const fetchMock = vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          access_token: "up-access-error",
+          token_type: "Bearer",
+          expires_in: 3600,
+          refresh_token: "up-refresh-error",
+          scope: "openid profile",
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+    );
+
+    const callback = await handleProxyCallback({
+      apiResourceId,
+      state: transactionId!,
+      code: "provider-good-code",
+      transactionCookie: proxyCookie?.value,
+      origin: "https://mockauth.test",
+    });
+
+    const appRedirect = new URL(callback.redirectTo);
+    const appCode = appRedirect.searchParams.get("code");
+    expect(appCode).toBeTruthy();
+
+    await expect(
+      completeProxyAuthorizationCodeGrant({
+        apiResourceId,
+        code: appCode!,
+        redirectUri: "https://proxy-client.test/wrong-callback",
+        codeVerifier,
+        authMethod: "none",
+        clientIdFromRequest: null,
+        clientSecret: null,
+        auditContext: {
+          origin: "https://mockauth.test",
+        },
+      }),
+    ).rejects.toMatchObject({ options: { code: "invalid_redirect_uri" } });
+
+    const auditLog = await prisma.auditLog.findFirst({
+      where: {
+        tenantId,
+        traceId: transactionId ?? undefined,
+        eventType: "TOKEN_AUTHCODE_COMPLETED",
+        severity: "ERROR",
+      },
+      orderBy: { createdAt: "desc" },
+    });
+
+    expect(auditLog).not.toBeNull();
+    expect(auditLog).toMatchObject({
+      severity: "ERROR",
+      clientId: proxyClientId,
+      traceId: transactionId,
+      eventType: "TOKEN_AUTHCODE_COMPLETED",
+    });
+    const tokenErrorDetails = auditLog?.details as Record<string, unknown>;
+    expect(tokenErrorDetails).toMatchObject({
+      tokenEndpointHost: "upstream.example.com",
+      authMethod: "none",
+      includeAuthHeader: false,
+      includeClientSecretInBody: false,
+      client_id: "up-client",
+      redirect_uri: buildProxyCallbackUrl("https://mockauth.test", apiResourceId),
+      grant_type: "authorization_code",
+      code_verifier_present: true,
+    });
 
     fetchMock.mockRestore();
   });
@@ -329,6 +441,15 @@ describe("Proxy client OAuth flow", () => {
       clientId: proxyClientId,
       traceId: null,
       eventType: "PROXY_CALLBACK_ERROR",
+    });
+    const refreshDetails = auditLog?.details as Record<string, unknown>;
+    expect(refreshDetails).toMatchObject({
+      tokenEndpointHost: "upstream.example.com",
+      authMethod: "none",
+      includeAuthHeader: false,
+      includeClientSecretInBody: false,
+      client_id: "up-client",
+      grant_type: "refresh_token",
     });
 
     fetchMock.mockRestore();

--- a/src/server/oidc/proxy/constants.ts
+++ b/src/server/oidc/proxy/constants.ts
@@ -1,3 +1,6 @@
 export const PROXY_TRANSACTION_COOKIE = "mockauth_proxy_tx";
 
 export const buildProxyTransactionCookiePath = (apiResourceId: string) => `/r/${apiResourceId}/oidc`;
+
+export const buildProxyCallbackUrl = (origin: string, apiResourceId: string) =>
+  new URL(`/r/${apiResourceId}/oidc/proxy/callback`, origin).toString();

--- a/src/server/services/audit-event.ts
+++ b/src/server/services/audit-event.ts
@@ -69,12 +69,30 @@ export type ProxyCallbackSuccessDetails = {
   tokenResponse: TokenResponsePayload;
 };
 
+export type ProviderTokenExchangeDiagnostics = {
+  tokenEndpointHost: string;
+  authMethod: TokenAuthMethod;
+  includeAuthHeader: boolean;
+  includeClientSecretInBody: boolean;
+  client_id: string;
+  redirect_uri?: string;
+  grant_type: string;
+  code_verifier_present?: boolean;
+};
+
 export type ProxyCallbackErrorDetails = {
   error: string;
   errorDescription?: string;
   providerType?: string;
   code?: string;
+} & Partial<ProviderTokenExchangeDiagnostics>;
+
+export type TokenAuthCodeErrorDetails = ProviderTokenExchangeDiagnostics & {
+  error: string;
+  errorDescription?: string;
 };
+
+export type TokenAuthCodeCompletedDetails = TokenResponsePayload | TokenAuthCodeErrorDetails;
 
 export type ProxyCodeIssuedDetails = {
   scope: string;
@@ -161,7 +179,7 @@ export type AuditEventDetailsMap = {
   PROXY_CALLBACK_ERROR: ProxyCallbackErrorDetails;
   PROXY_CODE_ISSUED: ProxyCodeIssuedDetails;
   TOKEN_AUTHCODE_RECEIVED: TokenAuthCodeReceivedDetails;
-  TOKEN_AUTHCODE_COMPLETED: TokenResponsePayload;
+  TOKEN_AUTHCODE_COMPLETED: TokenAuthCodeCompletedDetails;
   TOKEN_REFRESH_RECEIVED: TokenRefreshReceivedDetails;
   TOKEN_REFRESH_COMPLETED: TokenResponsePayload;
   CONFIG_CHANGED: ConfigChangedDetails;
@@ -258,14 +276,54 @@ type ProxyCallbackErrorDetailsParams = {
   code?: string | null;
   rawError?: string | null;
   rawErrorDescription?: string | null;
-};
+} & Partial<ProviderTokenExchangeDiagnostics>;
 
 export function buildProxyCallbackErrorDetails(params: ProxyCallbackErrorDetailsParams): ProxyCallbackErrorDetails {
+  const { rawError, rawErrorDescription, error, errorDescription, providerType, code, ...exchangeDetails } = params;
   return {
-    error: params.rawError ?? params.error,
-    errorDescription: params.rawErrorDescription ?? params.errorDescription ?? undefined,
-    providerType: params.providerType ?? undefined,
-    code: params.code ?? undefined,
+    error: rawError ?? error,
+    errorDescription: rawErrorDescription ?? errorDescription ?? undefined,
+    providerType: providerType ?? undefined,
+    code: code ?? undefined,
+    ...exchangeDetails,
+  };
+}
+
+type ProviderTokenExchangeDiagnosticsParams = {
+  tokenEndpoint: string;
+  authMethod: TokenAuthMethod;
+  clientId: string;
+  grantType: string;
+  redirectUri?: string | null;
+  codeVerifierPresent?: boolean | null;
+};
+
+export function buildProviderTokenExchangeDiagnostics(
+  params: ProviderTokenExchangeDiagnosticsParams,
+): ProviderTokenExchangeDiagnostics {
+  return {
+    tokenEndpointHost: new URL(params.tokenEndpoint).host,
+    authMethod: params.authMethod,
+    includeAuthHeader: params.authMethod === "client_secret_basic",
+    includeClientSecretInBody: params.authMethod === "client_secret_post",
+    client_id: params.clientId,
+    redirect_uri: params.redirectUri ?? undefined,
+    grant_type: params.grantType,
+    code_verifier_present: params.codeVerifierPresent ?? undefined,
+  };
+}
+
+type TokenAuthCodeErrorDetailsParams = {
+  error: string;
+  errorDescription?: string | null;
+  diagnostics: ProviderTokenExchangeDiagnostics;
+};
+
+export function buildTokenAuthCodeErrorDetails(params: TokenAuthCodeErrorDetailsParams): TokenAuthCodeErrorDetails {
+  return {
+    error: params.error,
+    errorDescription: params.errorDescription ?? undefined,
+    ...params.diagnostics,
   };
 }
 

--- a/src/server/services/proxy-callback-service.ts
+++ b/src/server/services/proxy-callback-service.ts
@@ -6,8 +6,10 @@ import {
   buildProxyCallbackErrorDetails,
   buildProxyCallbackSuccessDetails,
   buildProxyCodeIssuedDetails,
+  buildProviderTokenExchangeDiagnostics,
   toTokenResponsePayload,
 } from "@/server/services/audit-event";
+import { buildProxyCallbackUrl } from "@/server/oidc/proxy/constants";
 import { getApiResourceWithTenant } from "@/server/services/api-resource-service";
 import {
   getProxyAuthTransaction,
@@ -35,9 +37,6 @@ type ProxyCallbackResult = {
   redirectTo: string;
   clearTransactionCookie: boolean;
 };
-
-const buildCallbackUrl = (origin: string, apiResourceId: string) =>
-  new URL(`/r/${apiResourceId}/oidc/proxy/callback`, origin).toString();
 
 export const handleProxyCallback = async (params: ProxyCallbackParams): Promise<ProxyCallbackResult> => {
   if (!params.transactionCookie || params.transactionCookie !== params.state) {
@@ -88,6 +87,7 @@ export const handleProxyCallback = async (params: ProxyCallbackParams): Promise<
 
   type ProxyCallbackErrorParams = Parameters<typeof buildProxyCallbackErrorDetails>[0];
   let errorLogged = false;
+  let exchangeDiagnostics: ReturnType<typeof buildProviderTokenExchangeDiagnostics> | null = null;
   const recordCallbackError = async (message: string, details: ProxyCallbackErrorParams) => {
     errorLogged = true;
     await emitAuditEvent({
@@ -158,7 +158,7 @@ export const handleProxyCallback = async (params: ProxyCallbackParams): Promise<
     throw new DomainError("Authorization code not provided by provider", { status: 400, code: "invalid_request" });
   }
 
-  const callbackUrl = buildCallbackUrl(params.origin, params.apiResourceId);
+  const callbackUrl = buildProxyCallbackUrl(params.origin, params.apiResourceId);
   const tokenRequest = new URLSearchParams();
   tokenRequest.set("grant_type", "authorization_code");
   tokenRequest.set("code", params.code);
@@ -168,6 +168,16 @@ export const handleProxyCallback = async (params: ProxyCallbackParams): Promise<
   if (transaction.providerPkceEnabled && transaction.providerCodeVerifier) {
     tokenRequest.set("code_verifier", transaction.providerCodeVerifier);
   }
+
+  exchangeDiagnostics = buildProviderTokenExchangeDiagnostics({
+    tokenEndpoint: config.tokenEndpoint,
+    authMethod: config.upstreamTokenEndpointAuthMethod ?? "client_secret_basic",
+    clientId: config.upstreamClientId,
+    grantType: "authorization_code",
+    redirectUri: callbackUrl,
+    codeVerifierPresent: transaction.providerPkceEnabled ? tokenRequest.has("code_verifier") : undefined,
+  });
+  const exchangeDetails = exchangeDiagnostics ?? {};
 
   try {
     const result = await requestProviderTokens(config, tokenRequest).catch(async (error) => {
@@ -180,6 +190,7 @@ export const handleProxyCallback = async (params: ProxyCallbackParams): Promise<
         errorDescription: description,
         providerType: config.providerType,
         code: params.code ?? undefined,
+        ...exchangeDetails,
       });
       throw error;
     });
@@ -204,6 +215,7 @@ export const handleProxyCallback = async (params: ProxyCallbackParams): Promise<
         code: params.code ?? undefined,
         rawError,
         rawErrorDescription: rawDescription,
+        ...exchangeDetails,
       });
       await markProxyTransactionCompleted(transaction.id);
       return { redirectTo: redirectUrl.toString(), clearTransactionCookie: true };
@@ -214,6 +226,7 @@ export const handleProxyCallback = async (params: ProxyCallbackParams): Promise<
         error: "missing_token_response",
         providerType: config.providerType,
         code: params.code ?? undefined,
+        ...exchangeDetails,
       });
       throw new DomainError("Provider token response missing", { status: 502 });
     }
@@ -292,6 +305,7 @@ export const handleProxyCallback = async (params: ProxyCallbackParams): Promise<
         errorDescription: description,
         providerType: config.providerType,
         code: params.code ?? undefined,
+        ...(exchangeDiagnostics ?? {}),
       });
     }
     if (error instanceof DomainError) {

--- a/src/server/services/proxy-token-service.ts
+++ b/src/server/services/proxy-token-service.ts
@@ -2,6 +2,7 @@ import { URLSearchParams } from "node:url";
 
 import { DomainError } from "@/server/errors";
 import { resolveRedirectUri } from "@/server/oidc/redirect-uri";
+import { buildProxyCallbackUrl } from "@/server/oidc/proxy/constants";
 import {
   isProxyAuthorizationCode,
   consumeProxyAuthorizationCode,
@@ -14,6 +15,8 @@ import { getClientForTenant } from "@/server/services/client-service";
 import { emitAuditEvent } from "@/server/services/audit-service";
 import {
   buildProxyCallbackErrorDetails,
+  buildProviderTokenExchangeDiagnostics,
+  buildTokenAuthCodeErrorDetails,
   buildTokenAuthCodeReceivedDetails,
   buildTokenRefreshReceivedDetails,
   toTokenResponsePayload,
@@ -38,6 +41,7 @@ type AuthorizationCodeGrantParams = {
 
 type ProxyTokenAuditContext = {
   requestContext?: RequestContext | null;
+  origin?: string | null;
   clientSecretInBody?: boolean;
   clientIdProvided?: boolean;
   includeAuthHeader?: boolean;
@@ -60,6 +64,22 @@ export const completeProxyAuthorizationCodeGrant = async (
     requestContext: params.auditContext?.requestContext ?? null,
   };
   const reportViolation = createSecurityViolationReporter(violationContext);
+  const proxyConfig = record.client.proxyConfig;
+  const callbackUrl = params.auditContext?.origin
+    ? buildProxyCallbackUrl(params.auditContext.origin, record.apiResourceId)
+    : undefined;
+  const exchangeDiagnostics = proxyConfig
+    ? buildProviderTokenExchangeDiagnostics({
+        tokenEndpoint: proxyConfig.tokenEndpoint,
+        authMethod: proxyConfig.upstreamTokenEndpointAuthMethod ?? "client_secret_basic",
+        clientId: proxyConfig.upstreamClientId,
+        grantType: "authorization_code",
+        redirectUri: callbackUrl,
+        codeVerifierPresent: record.tokenExchange.transaction?.providerPkceEnabled
+          ? Boolean(record.tokenExchange.transaction?.providerCodeVerifier)
+          : undefined,
+      })
+    : null;
 
   void emitAuditEvent({
     tenantId: record.tenantId,
@@ -83,71 +103,94 @@ export const completeProxyAuthorizationCodeGrant = async (
     requestContext: params.auditContext?.requestContext ?? null,
   });
 
-  if (record.apiResourceId !== params.apiResourceId) {
-    await reportViolation("issuer_mismatch", {
-      expectedApiResourceId: record.apiResourceId,
-      receivedApiResourceId: params.apiResourceId,
+  try {
+    if (record.apiResourceId !== params.apiResourceId) {
+      await reportViolation("issuer_mismatch", {
+        expectedApiResourceId: record.apiResourceId,
+        receivedApiResourceId: params.apiResourceId,
+      });
+      throw new DomainError("Authorization code does not match issuer", { status: 400, code: "invalid_grant" });
+    }
+
+    if (params.clientIdFromRequest && record.client.clientId !== params.clientIdFromRequest) {
+      await reportViolation("client_mismatch", {
+        expectedClientId: record.client.clientId,
+        receivedClientId: params.clientIdFromRequest,
+      });
+      throw new DomainError("Client mismatch", { status: 401, code: "invalid_client" });
+    }
+
+    if (record.client.tokenEndpointAuthMethod !== params.authMethod) {
+      await reportViolation("auth_method_mismatch", {
+        expectedAuthMethod: record.client.tokenEndpointAuthMethod,
+        receivedAuthMethod: params.authMethod,
+      });
+      throw new DomainError("Client authentication method mismatch", { status: 401, code: "invalid_client" });
+    }
+
+    await withSecurityViolationAudit(() => assertClientSecret(record.client, params.clientSecret), violationContext);
+
+    const normalizedRedirect = resolveRedirectUri(params.redirectUri, record.client.redirectUris ?? []);
+    if (normalizedRedirect !== record.redirectUri) {
+      await reportViolation("redirect_uri_mismatch", {
+        expectedRedirectUri: record.redirectUri,
+        receivedRedirectUri: params.redirectUri,
+      });
+      throw new DomainError("redirect_uri mismatch", { status: 400, code: "invalid_grant" });
+    }
+
+    await withSecurityViolationAudit(async () => verifyPkce(record, params.codeVerifier), violationContext);
+
+    if (!proxyConfig) {
+      throw new DomainError("Proxy configuration missing", { status: 500 });
+    }
+
+    const providerScope = record.tokenExchange.transaction?.providerScope;
+    if (typeof providerScope !== "string" || providerScope.trim().length === 0) {
+      throw new DomainError("Proxy transaction is missing provider scope", { status: 500 });
+    }
+
+    const response = buildProxyTokenResponse(providerResponse, {
+      passthrough: proxyConfig.passthroughTokenResponse,
+      fallbackScope: providerScope,
     });
-    throw new DomainError("Authorization code does not match issuer", { status: 400, code: "invalid_grant" });
-  }
 
-  if (params.clientIdFromRequest && record.client.clientId !== params.clientIdFromRequest) {
-    await reportViolation("client_mismatch", {
-      expectedClientId: record.client.clientId,
-      receivedClientId: params.clientIdFromRequest,
+    void emitAuditEvent({
+      tenantId: record.tenantId,
+      clientId: record.clientId,
+      traceId,
+      actorId: null,
+      eventType: "TOKEN_AUTHCODE_COMPLETED",
+      severity: "INFO",
+      message: "Token response issued",
+      details: toTokenResponsePayload(response),
+      requestContext: params.auditContext?.requestContext ?? null,
     });
-    throw new DomainError("Client mismatch", { status: 401, code: "invalid_client" });
+
+    return response;
+  } catch (error) {
+    if (exchangeDiagnostics) {
+      const errorCode = error instanceof DomainError && error.options.code ? error.options.code : "server_error";
+      const description =
+        error instanceof Error ? error.message : typeof error === "string" ? error : String(error);
+      await emitAuditEvent({
+        tenantId: record.tenantId,
+        clientId: record.clientId,
+        traceId,
+        actorId: null,
+        eventType: "TOKEN_AUTHCODE_COMPLETED",
+        severity: "ERROR",
+        message: "Token exchange failed",
+        details: buildTokenAuthCodeErrorDetails({
+          error: errorCode,
+          errorDescription: description,
+          diagnostics: exchangeDiagnostics,
+        }),
+        requestContext: params.auditContext?.requestContext ?? null,
+      });
+    }
+    throw error;
   }
-
-  if (record.client.tokenEndpointAuthMethod !== params.authMethod) {
-    await reportViolation("auth_method_mismatch", {
-      expectedAuthMethod: record.client.tokenEndpointAuthMethod,
-      receivedAuthMethod: params.authMethod,
-    });
-    throw new DomainError("Client authentication method mismatch", { status: 401, code: "invalid_client" });
-  }
-
-  await withSecurityViolationAudit(() => assertClientSecret(record.client, params.clientSecret), violationContext);
-
-  const normalizedRedirect = resolveRedirectUri(params.redirectUri, record.client.redirectUris ?? []);
-  if (normalizedRedirect !== record.redirectUri) {
-    await reportViolation("redirect_uri_mismatch", {
-      expectedRedirectUri: record.redirectUri,
-      receivedRedirectUri: params.redirectUri,
-    });
-    throw new DomainError("redirect_uri mismatch", { status: 400, code: "invalid_grant" });
-  }
-
-  await withSecurityViolationAudit(async () => verifyPkce(record, params.codeVerifier), violationContext);
-
-  const proxyConfig = record.client.proxyConfig;
-  if (!proxyConfig) {
-    throw new DomainError("Proxy configuration missing", { status: 500 });
-  }
-
-  const providerScope = record.tokenExchange.transaction?.providerScope;
-  if (typeof providerScope !== "string" || providerScope.trim().length === 0) {
-    throw new DomainError("Proxy transaction is missing provider scope", { status: 500 });
-  }
-
-  const response = buildProxyTokenResponse(providerResponse, {
-    passthrough: proxyConfig.passthroughTokenResponse,
-    fallbackScope: providerScope,
-  });
-
-  void emitAuditEvent({
-    tenantId: record.tenantId,
-    clientId: record.clientId,
-    traceId,
-    actorId: null,
-    eventType: "TOKEN_AUTHCODE_COMPLETED",
-    severity: "INFO",
-    message: "Token response issued",
-    details: toTokenResponsePayload(response),
-    requestContext: params.auditContext?.requestContext ?? null,
-  });
-
-  return response;
 };
 
 type RefreshTokenGrantParams = {
@@ -225,6 +268,13 @@ export const completeProxyRefreshGrant = async (
 
   await withSecurityViolationAudit(() => assertClientSecret(client, params.clientSecret), violationContext);
 
+  const refreshDiagnostics = buildProviderTokenExchangeDiagnostics({
+    tokenEndpoint: proxyConfig.tokenEndpoint,
+    authMethod: proxyConfig.upstreamTokenEndpointAuthMethod ?? "client_secret_basic",
+    clientId: proxyConfig.upstreamClientId,
+    grantType: "refresh_token",
+  });
+
   const body = new URLSearchParams();
   body.set("grant_type", "refresh_token");
   body.set("refresh_token", params.refreshToken);
@@ -253,6 +303,7 @@ export const completeProxyRefreshGrant = async (
         error: sanitizeProviderError(errorCode),
         errorDescription: description,
         providerType: proxyConfig.providerType,
+        ...refreshDiagnostics,
       }),
       requestContext: params.auditContext?.requestContext ?? null,
     });
@@ -282,6 +333,7 @@ export const completeProxyRefreshGrant = async (
         rawError: typeof response.json?.error === "string" ? response.json.error : undefined,
         rawErrorDescription:
           typeof response.json?.error_description === "string" ? response.json.error_description : undefined,
+        ...refreshDiagnostics,
       }),
       requestContext: params.auditContext?.requestContext ?? null,
     });


### PR DESCRIPTION
## Summary
- add provider token exchange diagnostics to proxy callback/token error logs
- log TOKEN_AUTHCODE_COMPLETED error details with diagnostics
- cover new audit details in proxy flow tests

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm test:e2e
- pnpm exec dotenv -e .env.test -o -- pnpm build

#119