### PR TITLE
Extend token exchange diagnostics

### DIFF
--- a/src/server/oidc/__tests__/proxy-flow.test.ts
+++ b/src/server/oidc/__tests__/proxy-flow.test.ts
@@ -292,7 +292,11 @@ describe("Proxy client OAuth flow", () => {
     });
     const callbackDetails = auditLog?.details as Record<string, unknown>;
     expect(callbackDetails).toMatchObject({
+      tokenEndpointUrl: "https://upstream.example.com/oauth2/token",
       tokenEndpointHost: "upstream.example.com",
+      tokenEndpointPath: "/oauth2/token",
+      contentType: "application/x-www-form-urlencoded",
+      bodyKeys: ["grant_type", "code", "redirect_uri", "client_id", "code_verifier"],
       authMethod: "none",
       includeAuthHeader: false,
       includeClientSecretInBody: false,
@@ -393,7 +397,11 @@ describe("Proxy client OAuth flow", () => {
     });
     const tokenErrorDetails = auditLog?.details as Record<string, unknown>;
     expect(tokenErrorDetails).toMatchObject({
+      tokenEndpointUrl: "https://upstream.example.com/oauth2/token",
       tokenEndpointHost: "upstream.example.com",
+      tokenEndpointPath: "/oauth2/token",
+      contentType: "application/x-www-form-urlencoded",
+      bodyKeys: ["grant_type", "code", "redirect_uri", "client_id", "code_verifier"],
       authMethod: "none",
       includeAuthHeader: false,
       includeClientSecretInBody: false,
@@ -444,7 +452,11 @@ describe("Proxy client OAuth flow", () => {
     });
     const refreshDetails = auditLog?.details as Record<string, unknown>;
     expect(refreshDetails).toMatchObject({
+      tokenEndpointUrl: "https://upstream.example.com/oauth2/token",
       tokenEndpointHost: "upstream.example.com",
+      tokenEndpointPath: "/oauth2/token",
+      contentType: "application/x-www-form-urlencoded",
+      bodyKeys: ["grant_type", "refresh_token", "client_id", "scope"],
       authMethod: "none",
       includeAuthHeader: false,
       includeClientSecretInBody: false,

--- a/src/server/services/audit-event.ts
+++ b/src/server/services/audit-event.ts
@@ -70,7 +70,11 @@ export type ProxyCallbackSuccessDetails = {
 };
 
 export type ProviderTokenExchangeDiagnostics = {
+  tokenEndpointUrl: string;
   tokenEndpointHost: string;
+  tokenEndpointPath: string;
+  contentType: string;
+  bodyKeys: string[];
   authMethod: TokenAuthMethod;
   includeAuthHeader: boolean;
   includeClientSecretInBody: boolean;
@@ -294,6 +298,8 @@ type ProviderTokenExchangeDiagnosticsParams = {
   authMethod: TokenAuthMethod;
   clientId: string;
   grantType: string;
+  contentType: string;
+  bodyKeys: string[];
   redirectUri?: string | null;
   codeVerifierPresent?: boolean | null;
 };
@@ -301,8 +307,13 @@ type ProviderTokenExchangeDiagnosticsParams = {
 export function buildProviderTokenExchangeDiagnostics(
   params: ProviderTokenExchangeDiagnosticsParams,
 ): ProviderTokenExchangeDiagnostics {
+  const tokenEndpointUrl = new URL(params.tokenEndpoint);
   return {
-    tokenEndpointHost: new URL(params.tokenEndpoint).host,
+    tokenEndpointUrl: tokenEndpointUrl.toString(),
+    tokenEndpointHost: tokenEndpointUrl.host,
+    tokenEndpointPath: tokenEndpointUrl.pathname,
+    contentType: params.contentType,
+    bodyKeys: params.bodyKeys,
     authMethod: params.authMethod,
     includeAuthHeader: params.authMethod === "client_secret_basic",
     includeClientSecretInBody: params.authMethod === "client_secret_post",

--- a/src/server/services/proxy-callback-service.ts
+++ b/src/server/services/proxy-callback-service.ts
@@ -17,6 +17,8 @@ import {
   storeProxyTokenExchange,
   createProxyAuthorizationCode,
   deleteProxyAuthTransaction,
+  getProviderTokenRequestKeys,
+  PROXY_TOKEN_REQUEST_CONTENT_TYPE,
   requestProviderTokens,
 } from "@/server/services/proxy-service";
 import { sanitizeProviderError, sanitizeProviderErrorDescription } from "@/server/services/proxy-utils";
@@ -169,11 +171,15 @@ export const handleProxyCallback = async (params: ProxyCallbackParams): Promise<
     tokenRequest.set("code_verifier", transaction.providerCodeVerifier);
   }
 
+  const authMethod = config.upstreamTokenEndpointAuthMethod ?? "client_secret_basic";
+  const bodyKeys = getProviderTokenRequestKeys(config, tokenRequest);
   exchangeDiagnostics = buildProviderTokenExchangeDiagnostics({
     tokenEndpoint: config.tokenEndpoint,
-    authMethod: config.upstreamTokenEndpointAuthMethod ?? "client_secret_basic",
+    authMethod,
     clientId: config.upstreamClientId,
     grantType: "authorization_code",
+    contentType: PROXY_TOKEN_REQUEST_CONTENT_TYPE,
+    bodyKeys,
     redirectUri: callbackUrl,
     codeVerifierPresent: transaction.providerPkceEnabled ? tokenRequest.has("code_verifier") : undefined,
   });

--- a/src/server/services/proxy-service.ts
+++ b/src/server/services/proxy-service.ts
@@ -9,6 +9,7 @@ import { encrypt, decrypt } from "@/server/crypto/key-vault";
 const PROXY_TRANSACTION_TTL_MINUTES = 5;
 const PROXY_TOKEN_EXCHANGE_TTL_MINUTES = 5;
 const PROXY_AUTH_CODE_TTL_MINUTES = 10;
+export const PROXY_TOKEN_REQUEST_CONTENT_TYPE = "application/x-www-form-urlencoded";
 
 export const PROXY_TRANSACTION_TTL_SECONDS = PROXY_TRANSACTION_TTL_MINUTES * 60;
 export const PROXY_AUTH_CODE_TTL_SECONDS = PROXY_AUTH_CODE_TTL_MINUTES * 60;
@@ -220,12 +221,26 @@ type ProviderTokenResponse = {
   json: Record<string, unknown>;
 };
 
+export const getProviderTokenRequestKeys = (config: ProxyProviderConfig, body: URLSearchParams): string[] => {
+  const params = new URLSearchParams(body);
+  params.set("client_id", config.upstreamClientId);
+
+  const authMethod = config.upstreamTokenEndpointAuthMethod ?? "client_secret_basic";
+  params.delete("client_secret");
+
+  if (authMethod === "client_secret_post") {
+    params.set("client_secret", "redacted");
+  }
+
+  return Array.from(params.keys());
+};
+
 export const requestProviderTokens = async (
   config: ProxyProviderConfig,
   body: URLSearchParams,
 ): Promise<ProviderTokenResponse> => {
   const headers: Record<string, string> = {
-    "content-type": "application/x-www-form-urlencoded",
+    "content-type": PROXY_TOKEN_REQUEST_CONTENT_TYPE,
     accept: "application/json",
   };
 

--- a/src/server/services/proxy-token-service.ts
+++ b/src/server/services/proxy-token-service.ts
@@ -6,6 +6,8 @@ import { buildProxyCallbackUrl } from "@/server/oidc/proxy/constants";
 import {
   isProxyAuthorizationCode,
   consumeProxyAuthorizationCode,
+  getProviderTokenRequestKeys,
+  PROXY_TOKEN_REQUEST_CONTENT_TYPE,
   requestProviderTokens,
 } from "@/server/services/proxy-service";
 import { buildProxyTokenResponse, sanitizeProviderError, sanitizeProviderErrorDescription } from "@/server/services/proxy-utils";
@@ -68,18 +70,31 @@ export const completeProxyAuthorizationCodeGrant = async (
   const callbackUrl = params.auditContext?.origin
     ? buildProxyCallbackUrl(params.auditContext.origin, record.apiResourceId)
     : undefined;
-  const exchangeDiagnostics = proxyConfig
-    ? buildProviderTokenExchangeDiagnostics({
-        tokenEndpoint: proxyConfig.tokenEndpoint,
-        authMethod: proxyConfig.upstreamTokenEndpointAuthMethod ?? "client_secret_basic",
-        clientId: proxyConfig.upstreamClientId,
-        grantType: "authorization_code",
-        redirectUri: callbackUrl,
-        codeVerifierPresent: record.tokenExchange.transaction?.providerPkceEnabled
-          ? Boolean(record.tokenExchange.transaction?.providerCodeVerifier)
-          : undefined,
-      })
-    : null;
+  let exchangeDiagnostics: ReturnType<typeof buildProviderTokenExchangeDiagnostics> | null = null;
+  if (proxyConfig) {
+    const authMethod = proxyConfig.upstreamTokenEndpointAuthMethod ?? "client_secret_basic";
+    const tokenRequest = new URLSearchParams();
+    tokenRequest.set("grant_type", "authorization_code");
+    tokenRequest.set("code", "provider_code");
+    tokenRequest.set("redirect_uri", callbackUrl ?? "unknown");
+    tokenRequest.set("client_id", proxyConfig.upstreamClientId);
+    if (record.tokenExchange.transaction?.providerPkceEnabled && record.tokenExchange.transaction?.providerCodeVerifier) {
+      tokenRequest.set("code_verifier", "redacted");
+    }
+
+    exchangeDiagnostics = buildProviderTokenExchangeDiagnostics({
+      tokenEndpoint: proxyConfig.tokenEndpoint,
+      authMethod,
+      clientId: proxyConfig.upstreamClientId,
+      grantType: "authorization_code",
+      contentType: PROXY_TOKEN_REQUEST_CONTENT_TYPE,
+      bodyKeys: getProviderTokenRequestKeys(proxyConfig, tokenRequest),
+      redirectUri: callbackUrl,
+      codeVerifierPresent: record.tokenExchange.transaction?.providerPkceEnabled
+        ? Boolean(record.tokenExchange.transaction?.providerCodeVerifier)
+        : undefined,
+    });
+  }
 
   void emitAuditEvent({
     tenantId: record.tenantId,
@@ -268,13 +283,6 @@ export const completeProxyRefreshGrant = async (
 
   await withSecurityViolationAudit(() => assertClientSecret(client, params.clientSecret), violationContext);
 
-  const refreshDiagnostics = buildProviderTokenExchangeDiagnostics({
-    tokenEndpoint: proxyConfig.tokenEndpoint,
-    authMethod: proxyConfig.upstreamTokenEndpointAuthMethod ?? "client_secret_basic",
-    clientId: proxyConfig.upstreamClientId,
-    grantType: "refresh_token",
-  });
-
   const body = new URLSearchParams();
   body.set("grant_type", "refresh_token");
   body.set("refresh_token", params.refreshToken);
@@ -282,6 +290,15 @@ export const completeProxyRefreshGrant = async (
   if (params.scope) {
     body.set("scope", params.scope);
   }
+
+  const refreshDiagnostics = buildProviderTokenExchangeDiagnostics({
+    tokenEndpoint: proxyConfig.tokenEndpoint,
+    authMethod: proxyConfig.upstreamTokenEndpointAuthMethod ?? "client_secret_basic",
+    clientId: proxyConfig.upstreamClientId,
+    grantType: "refresh_token",
+    contentType: PROXY_TOKEN_REQUEST_CONTENT_TYPE,
+    bodyKeys: getProviderTokenRequestKeys(proxyConfig, body),
+  });
 
   let response;
   try {


### PR DESCRIPTION
## Summary
- add token endpoint url/path, content type, and body key order to token exchange diagnostics
- share body-key derivation across proxy callback/token flows
- expand proxy-flow diagnostics assertions

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm test:e2e
- pnpm exec dotenv -e .env.test -o -- pnpm build

Related: #120