### PR TITLE
refactor(audit): reuse collectParams

### DIFF
--- a/src/server/services/authorize-service.ts
+++ b/src/server/services/authorize-service.ts
@@ -13,6 +13,7 @@ import { hashOpaqueToken, generateOpaqueToken } from "@/server/crypto/opaque-tok
 import { computeS256Challenge } from "@/server/crypto/pkce";
 import { emitAuditEvent } from "@/server/services/audit-service";
 import { buildAuthorizeReceivedDetails, buildProxyRedirectOutDetails } from "@/server/services/audit-event";
+import { collectParams } from "@/server/utils/diagnostics";
 import {
   PROXY_TRANSACTION_TTL_SECONDS,
   startProxyAuthTransaction,
@@ -75,24 +76,6 @@ const ensureScopes = (requestedScopes: string[], allowedScopes: string[]) => {
   }
 };
 
-const toSearchParamsRecord = (searchParams: URLSearchParams): Record<string, string | string[]> => {
-  const record: Record<string, string | string[]> = {};
-
-  for (const [key, value] of searchParams.entries()) {
-    const existing = record[key];
-    if (!existing) {
-      record[key] = value;
-      continue;
-    }
-    if (Array.isArray(existing)) {
-      existing.push(value);
-      continue;
-    }
-    record[key] = [existing, value];
-  }
-
-  return record;
-};
 
 export const handleAuthorize = async (
   params: AuthorizeParams,
@@ -326,7 +309,7 @@ const handleProxyAuthorize = async (args: {
     }
 
     const providerAuthorizationUrl = authorizeUrl.toString();
-    const providerAuthorizationParams = toSearchParamsRecord(authorizeUrl.searchParams);
+    const providerAuthorizationParams = collectParams(authorizeUrl.searchParams.entries());
 
     await emitAuditEvent({
       tenantId,


### PR DESCRIPTION
## Summary
- reuse collectParams for proxy redirect audit params to avoid duplicate logic
- fix empty-string handling by removing the custom search params collector

## Testing
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm exec dotenv -e .env.development -o -- pnpm build

Refs #122