### PR TITLE
fix: short-circuit proxy authorization code redemption

### DIFF
--- a/src/server/oidc/__tests__/proxy-flow.test.ts
+++ b/src/server/oidc/__tests__/proxy-flow.test.ts
@@ -478,6 +478,80 @@ describe("Proxy client OAuth flow", () => {
     fetchMock.mockRestore();
   });
 
+  it("does not contact the upstream provider when redeeming proxy authorization codes", async () => {
+    const codeVerifier = "verifier-no-upstream-ABCDEFGHIJKLMNOPQRSTUVWXYZ012345";
+    const codeChallenge = computeS256Challenge(codeVerifier);
+    const { proxyCookie, transactionId } = await startProxyAuthorization({
+      clientId: proxyClientClientId,
+      redirectUri: "https://proxy-client.test/callback",
+      codeChallenge,
+      state: "no-upstream-state",
+    });
+
+    const fetchMock = vi.spyOn(global, "fetch").mockImplementation(async () => {
+      const payload = upstreamTokenResponses.shift();
+      if (!payload) {
+        return new Response(JSON.stringify({ error: "unexpected" }), {
+          status: 500,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response(JSON.stringify(payload), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    upstreamTokenResponses.push({
+      access_token: "up-access-token",
+      token_type: "Bearer",
+      expires_in: 3600,
+      refresh_token: "up-refresh-token",
+      scope: "openid profile",
+    });
+
+    const callbackContext = buildCallbackContext({
+      state: transactionId!,
+      code: "provider-code-no-upstream",
+      sessionState: "session-no-upstream",
+    });
+
+    const callback = await handleProxyCallback({
+      apiResourceId,
+      state: transactionId!,
+      code: "provider-code-no-upstream",
+      transactionCookie: proxyCookie?.value,
+      origin: "https://mockauth.test",
+      callbackRequest: callbackContext.callbackRequest,
+      callbackParams: callbackContext.callbackParams,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const proxyCode = new URL(callback.redirectTo).searchParams.get("code");
+    expect(proxyCode).toBeTruthy();
+
+    const issued = await completeProxyAuthorizationCodeGrant({
+      apiResourceId,
+      code: proxyCode!,
+      redirectUri: "https://proxy-client.test/callback",
+      codeVerifier,
+      authMethod: "none",
+      clientIdFromRequest: null,
+      clientSecret: null,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(issued).toMatchObject({
+      access_token: "up-access-token",
+      refresh_token: "up-refresh-token",
+      token_type: "Bearer",
+      expires_in: 3600,
+      scope: "openid profile",
+    });
+
+    fetchMock.mockRestore();
+  });
+
   it("logs diagnostics when callback is missing a code", async () => {
     const codeChallenge = computeS256Challenge("verifier-missing-code-ABCDEFGHIJKLMNOPQRSTUVWXYZ");
 

--- a/src/server/services/proxy-service.ts
+++ b/src/server/services/proxy-service.ts
@@ -177,7 +177,7 @@ export const consumeProxyAuthorizationCode = async (code: string): Promise<Consu
     }
 
     if (!record.tokenExchange || record.tokenExchange.consumedAt || record.tokenExchange.expiresAt < now) {
-      throw new DomainError("Token exchange expired", { status: 400, code: "invalid_grant" });
+      throw new DomainError("Proxy provider tokens are no longer available", { status: 400, code: "invalid_grant" });
     }
 
     await tx.proxyAuthorizationCode.update({

--- a/src/server/services/token-service.ts
+++ b/src/server/services/token-service.ts
@@ -268,6 +268,14 @@ export const issueTokensFromCode = async (params: {
 }) => {
   const { code, codeVerifier, redirectUri, clientSecret, origin, authorizationCode, auditContext } = params;
   const traceId = code.traceId ?? null;
+
+  if (code.client.oauthClientMode === "proxy") {
+    throw new DomainError("Proxy authorization codes must be redeemed via proxy token flow", {
+      status: 400,
+      code: "invalid_grant",
+    });
+  }
+
   const allowedMethods = parseTokenAuthMethods(code.client.tokenEndpointAuthMethods);
   const authMethod = auditContext?.authMethod ?? allowedMethods[0];
   const violationContext = {


### PR DESCRIPTION
## Root Cause
- Proxy clients could redeem authorization codes via the regular /token path, allowing a cached code to trigger local token minting and potentially re-hit upstream

## Fix
- Guard token-service to reject proxy authorization codes and force callers onto the proxy redemption flow
- Clarify the invalid_grant message when stored provider tokens are missing or expired
- Add regression coverage to confirm upstream fetch is skipped when issuing proxy tokens

## Testing
- pnpm typecheck
- pnpm lint
- pnpm test
- PLAYWRIGHT_BROWSERS_PATH=.playwright-browsers pnpm test:e2e

Closes #106