### PR TITLE
fix(proxy): harden test oauth flow

### DIFF
--- a/src/app/admin/clients/[clientId]/test/redirect/page.tsx
+++ b/src/app/admin/clients/[clientId]/test/redirect/page.tsx
@@ -7,6 +7,12 @@ import { TestSecretCleanup } from "@/app/admin/clients/[clientId]/test/test-secr
 import { TestRunAgainButton } from "@/app/admin/clients/[clientId]/test/test-run-again-button";
 import { DEFAULT_TEST_SCOPES } from "@/app/admin/clients/[clientId]/test/constants";
 import { authOptions } from "@/server/auth/options";
+import { emitAuditEvent } from "@/server/services/audit-service";
+import {
+  buildProviderTokenExchangeDiagnostics,
+  buildTokenAuthCodeErrorDetails,
+  type TokenAuthMethod,
+} from "@/server/services/audit-event";
 import { getAdminTenantContext } from "@/server/services/admin-tenant-context";
 import { getClientByIdForTenant } from "@/server/services/client-service";
 import { getRequestOrigin } from "@/server/utils/request-origin";
@@ -14,6 +20,7 @@ import { buildOidcUrls } from "@/server/oidc/url-builder";
 import { consumeOauthTestSession } from "@/server/services/oauth-test-service";
 import { readOauthTestSecretCookie } from "@/server/oauth/test-cookie";
 import { parseTokenAuthMethods, requiresClientSecret } from "@/server/oidc/token-auth-method";
+import { getRequestContext } from "@/server/utils/request-context";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
@@ -58,6 +65,45 @@ const formatJson = (value: unknown) => {
   }
 };
 
+const emitTestOauthPrecheckAudit = async (input: {
+  tenantId: string;
+  clientId: string;
+  traceId: string;
+  tokenEndpoint: string;
+  tokenAuthMethod: TokenAuthMethod;
+  oauthClientId: string;
+  redirectUri?: string | null;
+  codeVerifierPresent?: boolean | null;
+  error: string;
+  errorDescription: string;
+}) => {
+  const requestContext = await getRequestContext().catch(() => null);
+  const exchangeDiagnostics = buildProviderTokenExchangeDiagnostics({
+    tokenEndpoint: input.tokenEndpoint,
+    authMethod: input.tokenAuthMethod,
+    clientId: input.oauthClientId,
+    grantType: "authorization_code",
+    redirectUri: input.redirectUri ?? undefined,
+    codeVerifierPresent: input.codeVerifierPresent ?? undefined,
+  });
+  await emitAuditEvent({
+    tenantId: input.tenantId,
+    clientId: input.clientId,
+    traceId: input.traceId,
+    actorId: null,
+    eventType: "TOKEN_AUTHCODE_COMPLETED",
+    severity: "ERROR",
+    message: "Token exchange failed",
+    details: buildTokenAuthCodeErrorDetails({
+      error: input.error,
+      errorDescription: input.errorDescription,
+      exchangeDiagnostics,
+      upstreamCall: false,
+    }),
+    requestContext,
+  });
+};
+
 export default async function ClientTestRedirectPage({ params, searchParams }: { params: PageParams; searchParams?: SearchParams }) {
   const session = await getServerSession(authOptions);
   if (!session?.user?.id) {
@@ -93,6 +139,9 @@ export default async function ClientTestRedirectPage({ params, searchParams }: {
   const cookieSecret = state ? await readOauthTestSecretCookie(client.id, state) : null;
   const sessionRecord = state ? await consumeOauthTestSession(state) : null;
   const now = new Date();
+  const sessionMissingMessage = "Test session expired or already used.";
+  const sessionExpiredMessage = "Test session expired.";
+  const secretExpiredMessage = "Client secret expired.";
   let rerunScopes = DEFAULT_TEST_SCOPES;
   let rerunRedirectUri = testRedirectUri;
   if (sessionRecord?.scopes?.trim()) {
@@ -102,6 +151,7 @@ export default async function ClientTestRedirectPage({ params, searchParams }: {
     rerunRedirectUri = sessionRecord.redirectUri;
   }
   let result: TokenResult | ErrorResult;
+  let precheckAudit: { error: string; errorDescription: string } | null = null;
 
   if (error) {
     result = {
@@ -111,17 +161,20 @@ export default async function ClientTestRedirectPage({ params, searchParams }: {
   } else if (!state) {
     result = { status: "error", message: `Missing state parameter. ${RERUN_HINT}` };
   } else if (!sessionRecord) {
-    result = { status: "error", message: `Test session expired or already used. ${RERUN_HINT}` };
+    result = { status: "error", message: `${sessionMissingMessage} ${RERUN_HINT}` };
+    precheckAudit = { error: "invalid_grant", errorDescription: sessionMissingMessage };
   } else if (sessionRecord.clientId !== client.id) {
     result = { status: "error", message: "State does not belong to this client." };
   } else if (sessionRecord.tenantId !== activeTenant.id) {
     result = { status: "error", message: "State is scoped to a different tenant." };
   } else if (sessionRecord.expiresAt < now) {
-    result = { status: "error", message: `Test session expired. ${RERUN_HINT}` };
+    result = { status: "error", message: `${sessionExpiredMessage} ${RERUN_HINT}` };
+    precheckAudit = { error: "invalid_grant", errorDescription: sessionExpiredMessage };
   } else if (!code) {
     result = { status: "error", message: "Authorization code missing from redirect." };
   } else if (requiresSecret && !cookieSecret) {
-    result = { status: "error", message: `Client secret expired. ${RERUN_HINT}` };
+    result = { status: "error", message: `${secretExpiredMessage} ${RERUN_HINT}` };
+    precheckAudit = { error: "invalid_client", errorDescription: secretExpiredMessage };
   } else {
     const exchange = await exchangeAuthorizationCode({
       tokenUrl: urls.token,
@@ -134,6 +187,21 @@ export default async function ClientTestRedirectPage({ params, searchParams }: {
       requestedScope: sessionRecord.scopes,
     });
     result = exchange;
+  }
+
+  if (precheckAudit && state) {
+    await emitTestOauthPrecheckAudit({
+      tenantId: activeTenant.id,
+      clientId: client.id,
+      traceId: state,
+      tokenEndpoint: urls.token,
+      tokenAuthMethod,
+      oauthClientId: client.clientId,
+      redirectUri: sessionRecord?.redirectUri,
+      codeVerifierPresent: sessionRecord?.codeVerifier ? true : undefined,
+      error: precheckAudit.error,
+      errorDescription: precheckAudit.errorDescription,
+    });
   }
 
   const isError = result.status === "error";

--- a/src/server/oauth/test-cookie.ts
+++ b/src/server/oauth/test-cookie.ts
@@ -17,7 +17,7 @@ export const setOauthTestSecretCookie = async (clientId: string, state: string, 
     value: secret,
     httpOnly: true,
     secure: shouldUseSecureCookie(),
-    sameSite: "strict",
+    sameSite: "lax",
     path: buildTestSecretCookiePath(clientId),
     maxAge: COOKIE_TTL_SECONDS,
   });
@@ -36,7 +36,7 @@ export const clearOauthTestSecretCookie = async (clientId: string, state: string
     value: "",
     httpOnly: true,
     secure: shouldUseSecureCookie(),
-    sameSite: "strict",
+    sameSite: "lax",
     path: buildTestSecretCookiePath(clientId),
     maxAge: 0,
   });

--- a/src/server/services/authorize-service.ts
+++ b/src/server/services/authorize-service.ts
@@ -304,7 +304,7 @@ const handleProxyAuthorize = async (args: {
     loginHint: providerLoginHint,
   });
 
-  void emitAuditEvent({
+  await emitAuditEvent({
     tenantId,
     clientId: client.id,
     traceId: transaction.id,

--- a/src/server/services/proxy-token-service.ts
+++ b/src/server/services/proxy-token-service.ts
@@ -27,6 +27,7 @@ import {
   type TokenAuthCodeCompletedDetails,
   type ProxyFlowDiagnostics,
   type ProxyFlowRequestDetails,
+  type ProviderTokenExchangeDiagnostics,
   type TokenAuthMethod,
 } from "@/server/services/audit-event";
 import {
@@ -154,14 +155,36 @@ const emitProxyAuthCodeErrorAudit = async (
   auditContext: ProxyAuthCodeAuditContext,
   error: unknown,
 ) => {
-  if (!auditContext.exchangeDiagnostics) {
-    return;
-  }
   const errorCode = resolveErrorCode(error);
   if (!errorCode) {
     return;
   }
   const description = resolveErrorDescription(error);
+  const exchangeDiagnostics =
+    auditContext.exchangeDiagnostics ??
+    (() => {
+      const tokenEndpoint = params.auditContext?.request?.url ?? record.client.proxyConfig?.tokenEndpoint;
+      if (tokenEndpoint) {
+        return buildProviderTokenExchangeDiagnostics({
+          tokenEndpoint,
+          authMethod: params.authMethod,
+          clientId: params.clientIdFromRequest ?? record.client.clientId,
+          grantType: "authorization_code",
+          redirectUri: params.redirectUri,
+          codeVerifierPresent: params.codeVerifier ? true : undefined,
+        });
+      }
+      return {
+        tokenEndpointHost: "unknown",
+        authMethod: params.authMethod,
+        includeAuthHeader: params.authMethod === "client_secret_basic",
+        includeClientSecretInBody: params.authMethod === "client_secret_post",
+        client_id: params.clientIdFromRequest ?? record.client.clientId,
+        redirect_uri: params.redirectUri,
+        grant_type: "authorization_code",
+        code_verifier_present: params.codeVerifier ? true : undefined,
+      } satisfies ProviderTokenExchangeDiagnostics;
+    })();
   await emitAuditEvent({
     tenantId: record.tenantId,
     clientId: record.clientId,
@@ -173,7 +196,7 @@ const emitProxyAuthCodeErrorAudit = async (
     details: buildTokenAuthCodeErrorDetails({
       error: errorCode,
       errorDescription: description,
-      exchangeDiagnostics: auditContext.exchangeDiagnostics,
+      exchangeDiagnostics,
       diagnostics: auditContext.requestDiagnostics,
       upstreamCall: false,
     }),

--- a/tests/e2e/proxy-mockauth-upstream.spec.ts
+++ b/tests/e2e/proxy-mockauth-upstream.spec.ts
@@ -400,6 +400,76 @@ const findAuditEvent = (logs: AuditLogEntry[], eventType: string, severity?: str
   return match!;
 };
 
+const addTestRedirectIfNeeded = async (page: Page) => {
+  const warning = page.getByTestId("test-oauth-warning");
+  if ((await warning.count()) === 0) {
+    return;
+  }
+  await expect(warning).toBeVisible();
+  await page.getByTestId("test-oauth-add-redirect").click();
+  await expect(warning).toHaveCount(0);
+};
+
+const completeProviderLogin = async (page: Page, clientId: string, username: string) => {
+  const loginPattern = /\/r\/.*\/oidc\/login/;
+  const redirectPattern = new RegExp(`/admin/clients/${clientId}/test/redirect`);
+
+  const initialUrl = page.url();
+
+  const waitForNextNavigation = async (fromUrl: string) => {
+    await page.waitForURL((url) => {
+      const href = url.toString();
+      if (href === fromUrl) {
+        return false;
+      }
+      return loginPattern.test(href) || redirectPattern.test(href);
+    });
+  };
+
+  let currentUrl = page.url();
+  if (!loginPattern.test(currentUrl) && !redirectPattern.test(currentUrl)) {
+    await waitForNextNavigation(initialUrl);
+    currentUrl = page.url();
+  }
+
+  if (loginPattern.test(currentUrl)) {
+    await page.getByRole("textbox", { name: /^Username/ }).fill(username);
+    await Promise.all([
+      page.waitForURL((url) => redirectPattern.test(url.toString())),
+      page.getByRole("button", { name: "Continue" }).click(),
+    ]);
+    currentUrl = page.url();
+  }
+
+  const waitForTestResult = () =>
+    Promise.race([
+      page.getByTestId("test-oauth-id-token").waitFor({ state: "visible", timeout: 60000 }),
+      page.getByTestId("test-oauth-error").waitFor({ state: "visible", timeout: 60000 }),
+    ]);
+
+  if (!redirectPattern.test(currentUrl)) {
+    await page.waitForURL((url) => redirectPattern.test(url.toString()));
+  }
+
+  await waitForTestResult();
+};
+
+const runStandardTestOauth = async (page: Page, params: { clientId: string; clientSecret: string; username: string }) => {
+  await page.goto(`/admin/clients/${params.clientId}/test`, { waitUntil: "domcontentloaded" });
+  const startButton = page.getByTestId("test-oauth-start");
+  await expect(startButton).toBeVisible();
+  await addTestRedirectIfNeeded(page);
+  const secretInput = page.getByTestId("test-oauth-secret-input");
+  await expect(secretInput).toBeVisible();
+  await secretInput.fill(params.clientSecret);
+  await startButton.click();
+
+  const textarea = page.getByTestId("test-oauth-authorization-textarea");
+  await expect(textarea).toBeVisible();
+  await page.getByTestId("test-oauth-authorization-open").click();
+  await completeProviderLogin(page, params.clientId, params.username);
+};
+
 test.describe("proxy mockauth upstream", () => {
   test.beforeEach(async ({ page }) => {
     const sessionToken = await createTestSession(page);
@@ -599,6 +669,72 @@ test.describe("proxy mockauth upstream", () => {
         redirectUri: APP_REDIRECT_URI,
       });
       expect(tokenResponse.response.ok).toBeTruthy();
+    } finally {
+      if (proxy) {
+        await deleteClient(page, proxy.detailUrl);
+      }
+      if (upstream) {
+        await deleteClient(page, upstream.detailUrl);
+      }
+    }
+  });
+
+  test("standard test OAuth flow recovers after upstream secret fix", async ({ page, request }, testInfo) => {
+    const suffix = buildNameSuffix(testInfo);
+    const upstreamName = `Proxy Test Upstream ${suffix}`;
+    const proxyName = `Proxy Test Client ${suffix}`;
+    let upstream: CreatedClient | null = null;
+    let proxy: CreatedClient | null = null;
+
+    try {
+      upstream = await createRegularClient(page, upstreamName, [PROXY_CALLBACK_URI]);
+      proxy = await createProxyClient(page, {
+        name: proxyName,
+        redirectUris: [APP_REDIRECT_URI],
+        upstreamClientId: upstream.clientId,
+        upstreamClientSecret: upstream.clientSecret,
+      });
+
+      await runStandardTestOauth(page, {
+        clientId: proxy.internalId,
+        clientSecret: proxy.clientSecret,
+        username: "proxy-user",
+      });
+      await expect(page.getByTestId("test-oauth-id-token")).toBeVisible();
+      await expect(page.getByTestId("test-oauth-access-token")).toBeVisible();
+
+      const successLogs = await fetchAuditLogs(request, {
+        clientId: proxy.internalId,
+        eventType: "TOKEN_AUTHCODE_COMPLETED",
+      });
+      const successEvent = findAuditEvent(successLogs, "TOKEN_AUTHCODE_COMPLETED", "INFO");
+      const successDetails = successEvent.details as Record<string, unknown>;
+      expect(successDetails?.upstreamCall).toBe(false);
+
+      await updateProxyClientSecret(page, proxy.detailUrl, "bad-secret");
+      await runStandardTestOauth(page, {
+        clientId: proxy.internalId,
+        clientSecret: proxy.clientSecret,
+        username: "proxy-user",
+      });
+      await expect(page.getByTestId("test-oauth-error")).toContainText("invalid_client");
+
+      const errorLogs = await fetchAuditLogs(request, {
+        clientId: proxy.internalId,
+        eventType: "PROXY_CALLBACK_ERROR",
+      });
+      const errorEvent = findAuditEvent(errorLogs, "PROXY_CALLBACK_ERROR", "ERROR");
+      const errorDetails = errorEvent.details as Record<string, unknown>;
+      expect(errorDetails?.error).toBe("invalid_client");
+
+      await updateProxyClientSecret(page, proxy.detailUrl, upstream.clientSecret);
+      await runStandardTestOauth(page, {
+        clientId: proxy.internalId,
+        clientSecret: proxy.clientSecret,
+        username: "proxy-user",
+      });
+      await expect(page.getByTestId("test-oauth-id-token")).toBeVisible();
+      await expect(page.getByTestId("test-oauth-access-token")).toBeVisible();
     } finally {
       if (proxy) {
         await deleteClient(page, proxy.detailUrl);


### PR DESCRIPTION
## Summary
- set Test OAuth secret cookies to SameSite=Lax on set/clear
- emit audit logs for Test OAuth precheck failures, always log proxy auth code errors, and await proxy authorize audits
- add Playwright coverage for proxy Standard Test OAuth flow (success + upstream-secret failure recovery)

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm test:prepare
- PLAYWRIGHT_BROWSERS_PATH=0 pnpm exec dotenv -e .env.test -o -- playwright test --workers=1

Refs #138

cc @noa