### PR TITLE
fix(admin): render proxy provider card

### DIFF
--- a/src/app/admin/clients/[clientId]/client-forms.tsx
+++ b/src/app/admin/clients/[clientId]/client-forms.tsx
@@ -1,6 +1,15 @@
 "use client";
 
-import { useEffect, useMemo, useReducer, useState, useTransition, type FormEvent, type KeyboardEvent } from "react";
+import {
+  useEffect,
+  useMemo,
+  useReducer,
+  useState,
+  useSyncExternalStore,
+  useTransition,
+  type FormEvent,
+  type KeyboardEvent,
+} from "react";
 import { useRouter } from "next/navigation";
 import { z } from "zod";
 import { Check, Copy, Eye, EyeOff, Loader2, Trash2, X } from "lucide-react";
@@ -31,6 +40,7 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Skeleton } from "@/components/ui/skeleton";
 import { Textarea } from "@/components/ui/textarea";
 import { useToast } from "@/components/ui/use-toast";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
@@ -1413,6 +1423,11 @@ export function UpdateProxyAuthStrategyForm({
   const { toast } = useToast();
   const [pending, startTransition] = useTransition();
   const disableForm = !canEdit || pending;
+  const isHydrated = useSyncExternalStore(
+    () => () => undefined,
+    () => true,
+    () => false,
+  );
 
   const form = useForm<z.infer<typeof proxyAuthStrategySchema>>({
     resolver: zodResolver(proxyAuthStrategySchema),
@@ -1422,6 +1437,19 @@ export function UpdateProxyAuthStrategyForm({
   useEffect(() => {
     form.reset({ proxyAuthStrategy: initialStrategy });
   }, [form, initialStrategy]);
+
+  if (!isHydrated) {
+    return (
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-end" aria-hidden>
+        <div className="flex-1 space-y-2">
+          <Skeleton className="h-4 w-40" />
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-4 w-64" />
+        </div>
+        <Skeleton className="h-10 w-full sm:w-36" />
+      </div>
+    );
+  }
 
   const onSubmit = form.handleSubmit((values) => {
     startTransition(async () => {

--- a/src/app/admin/clients/[clientId]/page.tsx
+++ b/src/app/admin/clients/[clientId]/page.tsx
@@ -169,6 +169,8 @@ export default async function ClientDetailPage({ params }: { params: PageParams 
         : buildProxyCallbackUrl(origin, currentResourceId)
       : null;
   const showLocalClientSettings = client.oauthClientMode === "regular";
+  const showProxyProviderSection = client.oauthClientMode !== "regular";
+  const proxyConfigMissing = showProxyProviderSection && !proxyConfigInitial;
   const modeLabel =
     client.oauthClientMode === "proxy"
       ? `proxy mode (${resolvedProxyAuthStrategy === "preauthorized" ? "preauthorized" : "redirect"})`
@@ -326,7 +328,7 @@ export default async function ClientDetailPage({ params }: { params: PageParams 
         </CardContent>
       </Card>
 
-      {client.oauthClientMode !== "regular" && proxyConfigInitial ? (
+      {showProxyProviderSection ? (
         <Card>
           <CardHeader>
             <CardTitle>{providerHeading}</CardTitle>
@@ -343,6 +345,15 @@ export default async function ClientDetailPage({ params }: { params: PageParams 
               canEdit={canManageClients}
               initialStrategy={resolvedProxyAuthStrategy ?? "redirect"}
             />
+            {proxyConfigMissing ? (
+              <Alert variant="warning" data-testid="proxy-config-missing">
+                <AlertTitle>Missing upstream configuration</AlertTitle>
+                <AlertDescription>
+                  This proxy-mode client does not have an upstream provider configuration recorded. Re-run the proxy setup
+                  flow or verify the ProxyProviderConfig record for this client.
+                </AlertDescription>
+              </Alert>
+            ) : null}
             <Alert data-testid="proxy-mode-note">
               <AlertTitle>Scopes and claims come from upstream</AlertTitle>
               <AlertDescription>
@@ -350,12 +361,14 @@ export default async function ClientDetailPage({ params }: { params: PageParams 
                 proxy mode.
               </AlertDescription>
             </Alert>
-            <UpdateProxyProviderConfigForm
-              clientId={client.id}
-              canEdit={canManageClients}
-              initialConfig={proxyConfigInitial}
-              storedSecret={upstreamClientSecretValue}
-            />
+            {proxyConfigInitial ? (
+              <UpdateProxyProviderConfigForm
+                clientId={client.id}
+                canEdit={canManageClients}
+                initialConfig={proxyConfigInitial}
+                storedSecret={upstreamClientSecretValue}
+              />
+            ) : null}
           </CardContent>
         </Card>
       ) : null}

--- a/src/app/admin/clients/__tests__/client-detail.proxy.test.tsx
+++ b/src/app/admin/clients/__tests__/client-detail.proxy.test.tsx
@@ -7,6 +7,47 @@ import { DEFAULT_CLIENT_AUTH_STRATEGIES } from "@/server/oidc/auth-strategy";
 
 import ClientDetailPage from "../[clientId]/page";
 
+const proxyClientBase = {
+  id: "client_internal",
+  tenantId: "tenant_1",
+  name: "Proxy Client",
+  clientId: "client_proxy",
+  clientSecretEncrypted: null,
+  tokenEndpointAuthMethods: ["none"],
+  pkceRequired: true,
+  oauthClientMode: "proxy",
+  proxyAuthStrategy: "redirect",
+  allowedScopes: ["openid", "profile"],
+  allowedGrantTypes: ["authorization_code", "refresh_token"],
+  allowedResponseTypes: ["code"],
+  authStrategies: DEFAULT_CLIENT_AUTH_STRATEGIES,
+  redirectUris: [{ id: "redirect_1", uri: "https://app.example.test/callback", type: "EXACT" }],
+  tenant: { id: "tenant_1", defaultApiResourceId: "api-default", defaultApiResource: { id: "api-default", name: "Default" } },
+  apiResource: null,
+  proxyConfig: {
+    providerType: "oidc",
+    authorizationEndpoint: "https://upstream.example.com/oauth2/authorize",
+    tokenEndpoint: "https://upstream.example.com/oauth2/token",
+    userinfoEndpoint: null,
+    jwksUri: null,
+    upstreamClientId: "up-client",
+    upstreamClientSecretEncrypted: null,
+    defaultScopes: ["openid"],
+    scopeMapping: { profile: ["profile.read"] },
+    pkceSupported: true,
+    oidcEnabled: true,
+    promptPassthroughEnabled: true,
+    loginHintPassthroughEnabled: false,
+    passthroughTokenResponse: false,
+    upstreamTokenEndpointAuthMethod: "client_secret_post",
+  },
+  reauthTtlSeconds: 0,
+  idTokenSignedResponseAlg: null,
+  accessTokenSigningAlg: null,
+  createdAt: new Date("2024-01-01T00:00:00.000Z"),
+  updatedAt: new Date("2024-01-02T00:00:00.000Z"),
+};
+
 const mockGetServerSession = vi.hoisted(() => vi.fn());
 const mockGetAdminTenantContext = vi.hoisted(() => vi.fn());
 const mockGetClientByIdForTenant = vi.hoisted(() => vi.fn());
@@ -84,46 +125,7 @@ describe("ClientDetailPage proxy mode", () => {
     ]);
     mockGetRequestOrigin.mockResolvedValue("https://mockauth.test");
 
-    mockGetClientByIdForTenant.mockResolvedValue({
-      id: "client_internal",
-      tenantId: "tenant_1",
-      name: "Proxy Client",
-      clientId: "client_proxy",
-      clientSecretEncrypted: null,
-      tokenEndpointAuthMethods: ["none"],
-      pkceRequired: true,
-      oauthClientMode: "proxy",
-      proxyAuthStrategy: "redirect",
-      allowedScopes: ["openid", "profile"],
-      allowedGrantTypes: ["authorization_code", "refresh_token"],
-      allowedResponseTypes: ["code"],
-      authStrategies: DEFAULT_CLIENT_AUTH_STRATEGIES,
-      redirectUris: [{ id: "redirect_1", uri: "https://app.example.test/callback", type: "EXACT" }],
-      tenant: { id: "tenant_1", defaultApiResourceId: "api-default", defaultApiResource: { id: "api-default", name: "Default" } },
-      apiResource: null,
-      proxyConfig: {
-        providerType: "oidc",
-        authorizationEndpoint: "https://upstream.example.com/oauth2/authorize",
-        tokenEndpoint: "https://upstream.example.com/oauth2/token",
-        userinfoEndpoint: null,
-        jwksUri: null,
-        upstreamClientId: "up-client",
-        upstreamClientSecretEncrypted: null,
-        defaultScopes: ["openid"],
-        scopeMapping: { profile: ["profile.read"] },
-        pkceSupported: true,
-        oidcEnabled: true,
-        promptPassthroughEnabled: true,
-        loginHintPassthroughEnabled: false,
-        passthroughTokenResponse: false,
-        upstreamTokenEndpointAuthMethod: "client_secret_post",
-      },
-      reauthTtlSeconds: 0,
-      idTokenSignedResponseAlg: null,
-      accessTokenSigningAlg: null,
-      createdAt: new Date("2024-01-01T00:00:00.000Z"),
-      updatedAt: new Date("2024-01-02T00:00:00.000Z"),
-    });
+    mockGetClientByIdForTenant.mockResolvedValue({ ...proxyClientBase });
   });
 
   it("shows upstream configuration details and hides local settings", async () => {
@@ -138,5 +140,18 @@ describe("ClientDetailPage proxy mode", () => {
     expect(screen.queryByTestId("client-auth-strategies-card")).not.toBeInTheDocument();
     expect(screen.queryByTestId("client-signing-card")).not.toBeInTheDocument();
     expect(screen.queryByTestId("client-reauth-card")).not.toBeInTheDocument();
+  });
+
+  it("shows a diagnostic warning when proxy config is missing", async () => {
+    mockGetClientByIdForTenant.mockResolvedValueOnce({
+      ...proxyClientBase,
+      proxyConfig: null,
+    });
+
+    const page = await ClientDetailPage({ params: Promise.resolve({ clientId: "client_proxy" }) });
+    render(page);
+
+    expect(screen.getByTestId("proxy-config-missing")).toBeInTheDocument();
+    expect(screen.queryByTestId("proxy-config-form")).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- render the upstream provider card for all proxy-mode clients and show a warning when config is missing
- defer proxy auth strategy form rendering until hydration to avoid client-side mismatches
- cover missing proxy config behavior in client detail tests

## Testing
- pnpm typecheck
- pnpm lint
- pnpm test

Fixes #144