### PR TITLE
fix(oidc): absolute picker redirect

### DIFF
--- a/src/server/oidc/__tests__/proxy-flow.test.ts
+++ b/src/server/oidc/__tests__/proxy-flow.test.ts
@@ -233,7 +233,7 @@ describe("Proxy client OAuth flow", () => {
         state: "strategy-preauthorized",
       });
 
-      expect(authorize.redirectTo).toBe(`/r/${apiResourceId}/oidc/preauthorized/picker`);
+      expect(authorize.redirectTo).toBe(`https://mockauth.test/r/${apiResourceId}/oidc/preauthorized/picker`);
       const pickerCookie = authorize.cookies?.find((cookie) => cookie.name === PREAUTHORIZED_PICKER_COOKIE);
       expect(pickerCookie).toBeDefined();
     });
@@ -263,7 +263,7 @@ describe("Proxy client OAuth flow", () => {
         state: "strategy-preauth-exists",
       });
 
-      expect(authorize.redirectTo).toBe(`/r/${apiResourceId}/oidc/preauthorized/picker`);
+      expect(authorize.redirectTo).toBe(`https://mockauth.test/r/${apiResourceId}/oidc/preauthorized/picker`);
       const pickerCookie = authorize.cookies?.find((cookie) => cookie.name === PREAUTHORIZED_PICKER_COOKIE);
       expect(pickerCookie).toBeDefined();
     });

--- a/src/server/services/authorize-service.ts
+++ b/src/server/services/authorize-service.ts
@@ -492,5 +492,9 @@ const handlePreauthorizedAuthorize = async (args: {
     },
   ];
 
-  return { type: "redirect", redirectTo: `/r/${resourceId}/oidc/preauthorized/picker`, cookies };
+  return {
+    type: "redirect",
+    redirectTo: new URL(`/r/${resourceId}/oidc/preauthorized/picker`, origin).toString(),
+    cookies,
+  };
 };


### PR DESCRIPTION
## Summary
- return absolute preauthorized picker redirect URLs in authorize service
- update proxy auth strategy tests to expect absolute picker redirects

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test

Fixes #149