### PR TITLE
feat(token): support email password grant

### DIFF
--- a/src/server/services/__tests__/token-service.test.ts
+++ b/src/server/services/__tests__/token-service.test.ts
@@ -38,6 +38,15 @@ const buildAuthStrategies = (overrides: StrategyOverrides = {}): ClientAuthStrat
   email: { ...DEFAULT_CLIENT_AUTH_STRATEGIES.email, ...overrides.email },
 });
 
+const updateAuthStrategies = async (clientId: string, overrides: StrategyOverrides) => {
+  await prisma.client.update({
+    where: { id: clientId },
+    data: {
+      authStrategies: buildAuthStrategies(overrides),
+    },
+  });
+};
+
 const createPasswordClient = async (input: {
   tenantId: string;
   allowedGrantTypes?: string[];
@@ -70,19 +79,175 @@ const createPasswordClient = async (input: {
 };
 
 describe("token service password grant", () => {
-  it("issues tokens when subject is entered", async () => {
+  it("issues tokens for email strategy", async () => {
     const { tenant, apiResource } = await createTenant();
     const { client, clientSecret } = await createPasswordClient({
       tenantId: tenant.id,
       allowedGrantTypes: ["password"],
-      allowedScopes: ["openid", "profile"],
+      allowedScopes: ["openid", "email", "profile"],
+    });
+
+    await updateAuthStrategies(client.id, {
+      username: { enabled: false },
+      email: { enabled: true },
+    });
+
+    const response = await issueTokensFromPassword({
+      apiResourceId: apiResource.id,
+      clientId: client.clientId,
+      username: "user@example.com",
+      scope: "openid email profile",
+      origin: ORIGIN,
+      authMethod: "client_secret_post",
+      clientSecret,
+    });
+
+    expect(response.access_token).toBeTruthy();
+    expect(response.id_token).toBeTruthy();
+
+    const idToken = decodeJwt(response.id_token!);
+    expect(idToken.sub).toBe("user@example.com");
+    expect(idToken.email).toBe("user@example.com");
+    expect(idToken.email_verified).toBe(false);
+    expect(idToken.preferred_username).toBeUndefined();
+  });
+
+  it("issues tokens when email subject is generated", async () => {
+    const { tenant, apiResource } = await createTenant();
+    const { client, clientSecret } = await createPasswordClient({
+      tenantId: tenant.id,
+      allowedGrantTypes: ["password"],
+      allowedScopes: ["openid", "email"],
+    });
+
+    await updateAuthStrategies(client.id, {
+      username: { enabled: false },
+      email: { enabled: true, subSource: "generated_uuid" },
+    });
+
+    const response = await issueTokensFromPassword({
+      apiResourceId: apiResource.id,
+      clientId: client.clientId,
+      username: "user@example.com",
+      scope: "openid email",
+      origin: ORIGIN,
+      authMethod: "client_secret_post",
+      clientSecret,
+    });
+
+    const idToken = decodeJwt(response.id_token!);
+    const identity = await prisma.mockIdentity.findFirstOrThrow({
+      where: {
+        tenantId: tenant.id,
+        strategy: $Enums.LoginStrategy.EMAIL,
+        identifier: "user@example.com",
+      },
+    });
+
+    expect(idToken.sub).toBe(identity.sub);
+    expect(idToken.sub).not.toBe("user@example.com");
+  });
+
+  it("marks email as verified when configured", async () => {
+    const { tenant, apiResource } = await createTenant();
+    const { client, clientSecret } = await createPasswordClient({
+      tenantId: tenant.id,
+      allowedGrantTypes: ["password"],
+      allowedScopes: ["openid", "email"],
+    });
+
+    await updateAuthStrategies(client.id, {
+      username: { enabled: false },
+      email: { enabled: true, emailVerifiedMode: "true" },
+    });
+
+    const response = await issueTokensFromPassword({
+      apiResourceId: apiResource.id,
+      clientId: client.clientId,
+      username: "user@example.com",
+      scope: "openid email",
+      origin: ORIGIN,
+      authMethod: "client_secret_post",
+      clientSecret,
+    });
+
+    const idToken = decodeJwt(response.id_token!);
+    expect(idToken.email_verified).toBe(true);
+  });
+
+  it("defaults email verification to false for user choice", async () => {
+    const { tenant, apiResource } = await createTenant();
+    const { client, clientSecret } = await createPasswordClient({
+      tenantId: tenant.id,
+      allowedGrantTypes: ["password"],
+      allowedScopes: ["openid", "email"],
+    });
+
+    await updateAuthStrategies(client.id, {
+      username: { enabled: false },
+      email: { enabled: true, emailVerifiedMode: "user_choice" },
+    });
+
+    const response = await issueTokensFromPassword({
+      apiResourceId: apiResource.id,
+      clientId: client.clientId,
+      username: "user@example.com",
+      scope: "openid email",
+      origin: ORIGIN,
+      authMethod: "client_secret_post",
+      clientSecret,
+    });
+
+    const idToken = decodeJwt(response.id_token!);
+    expect(idToken.email_verified).toBe(false);
+  });
+
+  it("prefers email strategy when identifier includes @", async () => {
+    const { tenant, apiResource } = await createTenant();
+    const { client, clientSecret } = await createPasswordClient({
+      tenantId: tenant.id,
+      allowedGrantTypes: ["password"],
+      allowedScopes: ["openid", "email", "profile"],
+    });
+
+    await updateAuthStrategies(client.id, {
+      username: { enabled: true },
+      email: { enabled: true },
+    });
+
+    const response = await issueTokensFromPassword({
+      apiResourceId: apiResource.id,
+      clientId: client.clientId,
+      username: "user@example.com",
+      scope: "openid email profile",
+      origin: ORIGIN,
+      authMethod: "client_secret_post",
+      clientSecret,
+    });
+
+    const idToken = decodeJwt(response.id_token!);
+    expect(idToken.email).toBe("user@example.com");
+    expect(idToken.preferred_username).toBeUndefined();
+  });
+
+  it("selects username strategy when identifier is not an email", async () => {
+    const { tenant, apiResource } = await createTenant();
+    const { client, clientSecret } = await createPasswordClient({
+      tenantId: tenant.id,
+      allowedGrantTypes: ["password"],
+      allowedScopes: ["openid", "email", "profile"],
+    });
+
+    await updateAuthStrategies(client.id, {
+      username: { enabled: true },
+      email: { enabled: true },
     });
 
     const response = await issueTokensFromPassword({
       apiResourceId: apiResource.id,
       clientId: client.clientId,
       username: "demo-user",
-      scope: "openid profile",
+      scope: "openid email profile",
       origin: ORIGIN,
       authMethod: "client_secret_post",
       clientSecret,
@@ -94,46 +259,61 @@ describe("token service password grant", () => {
     const idToken = decodeJwt(response.id_token!);
     expect(idToken.sub).toBe("demo-user");
     expect(idToken.preferred_username).toBe("demo-user");
+    expect(idToken.email).toBeUndefined();
   });
 
-  it("issues tokens when subject is generated", async () => {
+  it("treats email-like identifiers as username when only username is enabled", async () => {
     const { tenant, apiResource } = await createTenant();
     const { client, clientSecret } = await createPasswordClient({
       tenantId: tenant.id,
       allowedGrantTypes: ["password"],
-      allowedScopes: ["openid", "profile"],
+      allowedScopes: ["openid", "email", "profile"],
     });
 
-    await prisma.client.update({
-      where: { id: client.id },
-      data: {
-        authStrategies: buildAuthStrategies({
-          username: { subSource: "generated_uuid" },
-        }),
-      },
+    await updateAuthStrategies(client.id, {
+      username: { enabled: true },
+      email: { enabled: false },
     });
 
     const response = await issueTokensFromPassword({
       apiResourceId: apiResource.id,
       clientId: client.clientId,
-      username: "demo-user",
-      scope: "openid profile",
+      username: "user@example.com",
+      scope: "openid email profile",
       origin: ORIGIN,
       authMethod: "client_secret_post",
       clientSecret,
     });
 
     const idToken = decodeJwt(response.id_token!);
-    const identity = await prisma.mockIdentity.findFirstOrThrow({
-      where: {
-        tenantId: tenant.id,
-        strategy: $Enums.LoginStrategy.USERNAME,
-        identifier: "demo-user",
-      },
+    expect(idToken.preferred_username).toBe("user@example.com");
+    expect(idToken.email).toBeUndefined();
+  });
+
+  it("rejects password grants when only email is enabled and identifier is not an email", async () => {
+    const { tenant, apiResource } = await createTenant();
+    const { client, clientSecret } = await createPasswordClient({
+      tenantId: tenant.id,
+      allowedGrantTypes: ["password"],
+      allowedScopes: ["openid", "email"],
     });
 
-    expect(idToken.sub).toBe(identity.sub);
-    expect(idToken.sub).not.toBe("demo-user");
+    await updateAuthStrategies(client.id, {
+      username: { enabled: false },
+      email: { enabled: true },
+    });
+
+    await expect(
+      issueTokensFromPassword({
+        apiResourceId: apiResource.id,
+        clientId: client.clientId,
+        username: "demo-user",
+        scope: "openid email",
+        origin: ORIGIN,
+        authMethod: "client_secret_post",
+        clientSecret,
+      }),
+    ).rejects.toThrowError("Username authentication is disabled");
   });
 
   it("rejects password grants when client disallows the grant type", async () => {
@@ -157,7 +337,7 @@ describe("token service password grant", () => {
     ).rejects.toThrowError("Client does not support password grant");
   });
 
-  it("rejects password grants when username strategy is disabled", async () => {
+  it("rejects password grants when no auth strategy is enabled", async () => {
     const { tenant, apiResource } = await createTenant();
     const { client, clientSecret } = await createPasswordClient({
       tenantId: tenant.id,
@@ -165,13 +345,9 @@ describe("token service password grant", () => {
       allowedScopes: ["openid", "profile"],
     });
 
-    await prisma.client.update({
-      where: { id: client.id },
-      data: {
-        authStrategies: buildAuthStrategies({
-          username: { enabled: false },
-        }),
-      },
+    await updateAuthStrategies(client.id, {
+      username: { enabled: false },
+      email: { enabled: false },
     });
 
     await expect(
@@ -184,7 +360,7 @@ describe("token service password grant", () => {
         authMethod: "client_secret_post",
         clientSecret,
       }),
-    ).rejects.toThrowError("Username authentication is disabled");
+    ).rejects.toThrowError("No authentication strategy is enabled");
   });
 
   it("rejects password grants for proxy clients", async () => {

--- a/src/server/services/token-service.ts
+++ b/src/server/services/token-service.ts
@@ -395,31 +395,42 @@ export const issueTokensFromPassword = async (params: {
   }
 
   const strategies = parseClientAuthStrategies(client.authStrategies);
-  if (!strategies.username.enabled) {
-    throw new DomainError("Username authentication is disabled", { status: 400, code: "invalid_grant" });
-  }
-
   const trimmedIdentifier = username.trim();
   if (!trimmedIdentifier) {
     throw new DomainError("username is required", { status: 400, code: "invalid_request" });
+  }
+
+  const emailEnabled = strategies.email.enabled;
+  const usernameEnabled = strategies.username.enabled;
+  if (!emailEnabled && !usernameEnabled) {
+    throw new DomainError("No authentication strategy is enabled", { status: 400, code: "invalid_grant" });
+  }
+
+  const looksLikeEmail = trimmedIdentifier.includes("@");
+  const strategy: ClientAuthStrategy = emailEnabled && looksLikeEmail ? "email" : "username";
+  if (strategy === "username" && !usernameEnabled) {
+    throw new DomainError("Username authentication is disabled", { status: 400, code: "invalid_grant" });
   }
 
   await withSecurityViolationAudit(() => assertClientAuth(client, authMethod, clientSecret), violationContext);
 
   const requestedScopes = normalizeRequestedScopes(scope, client.allowedScopes);
   const normalizedScope = requestedScopes.join(" ");
+  const selectedConfig = strategy === "email" ? strategies.email : strategies.username;
   const subject =
-    strategies.username.subSource === "entered"
+    selectedConfig.subSource === "entered"
       ? trimmedIdentifier
       : await resolveStableSubject({
           tenantId: tenant.id,
-          strategy: "username",
+          strategy,
           identifier: trimmedIdentifier,
         });
 
+  const emailVerifiedClaim =
+    strategy === "email" && strategies.email.emailVerifiedMode === "true" ? true : undefined;
   const user = await findOrCreateMockUser(tenant.id, trimmedIdentifier, {
     displayName: trimmedIdentifier,
-    email: null,
+    email: strategy === "email" ? trimmedIdentifier : null,
   });
 
   return issueTokens({
@@ -430,6 +441,7 @@ export const issueTokensFromPassword = async (params: {
     subject,
     scope: normalizedScope,
     origin,
-    strategy: "username",
+    strategy,
+    emailVerifiedClaim,
   });
 };


### PR DESCRIPTION
## Summary
- support email strategy selection for password grant token issuance
- apply strategy-specific subject/email verified claims
- expand token-service coverage for email/username scenarios

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm test:prepare && pnpm exec dotenv -e .env.test -o -- playwright test --workers=1

## Issue
- #155