### PR TITLE
feat(oidc): add RP-initiated logout

### DIFF
--- a/src/app/admin/__tests__/prepare-client-oauth-test-action.test.ts
+++ b/src/app/admin/__tests__/prepare-client-oauth-test-action.test.ts
@@ -127,6 +127,7 @@ describe("prepareClientOauthTestAction", () => {
       discovery: "https://issuer.example/.well-known/openid-configuration",
       jwks: "https://issuer.example/jwks.json",
       authorize: "https://issuer.example/authorize",
+      endSession: "https://issuer.example/end-session",
       token: "https://issuer.example/token",
       userinfo: "https://issuer.example/userinfo",
     });

--- a/src/app/r/[apiResourceId]/oidc/end-session/route.ts
+++ b/src/app/r/[apiResourceId]/oidc/end-session/route.ts
@@ -1,0 +1,94 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import { toResponse } from "@/server/errors";
+import { resolveUrl } from "@/server/http/origin";
+import { handleEndSession } from "@/server/services/end-session-service";
+import { MOCK_SESSION_COOKIE } from "@/server/services/mock-session-service";
+import type { ApiResourceRouteContext } from "@/types/api-resource-route";
+
+const endSessionSchema = z.object({
+  id_token_hint: z.string().min(1).optional(),
+  post_logout_redirect_uri: z.string().min(1).optional(),
+  client_id: z.string().min(1).optional(),
+  state: z.string().min(1).optional(),
+});
+
+const buildResponse = (result: Awaited<ReturnType<typeof handleEndSession>>, normalizedUrl: URL) => {
+  const response =
+    result.type === "redirect"
+      ? NextResponse.redirect(result.redirectTo, { status: 302 })
+      : new NextResponse(result.html, {
+          status: 200,
+          headers: {
+            "content-type": "text/html; charset=utf-8",
+          },
+        });
+
+  if (result.clearSessionCookie) {
+    response.cookies.set({
+      name: MOCK_SESSION_COOKIE,
+      value: "",
+      path: "/r",
+      httpOnly: true,
+      sameSite: "lax",
+      secure: normalizedUrl.protocol === "https:",
+      maxAge: 0,
+    });
+  }
+
+  return response;
+};
+
+const handleRequest = async (
+  request: NextRequest,
+  context: ApiResourceRouteContext,
+  data: z.infer<typeof endSessionSchema>,
+) => {
+  const normalizedUrl = resolveUrl(request);
+
+  try {
+    const { apiResourceId } = await context.params;
+    const sessionToken = request.cookies.get(MOCK_SESSION_COOKIE)?.value;
+    const result = await handleEndSession(
+      {
+        apiResourceId,
+        idTokenHint: data.id_token_hint,
+        postLogoutRedirectUri: data.post_logout_redirect_uri,
+        clientId: data.client_id,
+        state: data.state,
+        sessionToken,
+      },
+      normalizedUrl.origin,
+    );
+
+    return buildResponse(result, normalizedUrl);
+  } catch (error) {
+    return toResponse(error);
+  }
+};
+
+export async function GET(request: NextRequest, context: ApiResourceRouteContext) {
+  const normalizedUrl = resolveUrl(request);
+  const validation = endSessionSchema.safeParse(Object.fromEntries(normalizedUrl.searchParams.entries()));
+
+  if (!validation.success) {
+    return Response.json({ error: "invalid_request", details: validation.error.flatten() }, { status: 400 });
+  }
+
+  return handleRequest(request, context, validation.data);
+}
+
+export async function POST(request: NextRequest, context: ApiResourceRouteContext) {
+  const formEntries = Array.from((await request.clone().formData()).entries(), ([key, value]) => [
+    key,
+    typeof value === "string" ? value : value.name,
+  ]) as Array<[string, string]>;
+  const validation = endSessionSchema.safeParse(Object.fromEntries(formEntries));
+
+  if (!validation.success) {
+    return Response.json({ error: "invalid_request", details: validation.error.flatten() }, { status: 400 });
+  }
+
+  return handleRequest(request, context, validation.data);
+}

--- a/src/app/r/[apiResourceId]/oidc/end-session/route.ts
+++ b/src/app/r/[apiResourceId]/oidc/end-session/route.ts
@@ -44,9 +44,8 @@ const handleRequest = async (
   request: NextRequest,
   context: ApiResourceRouteContext,
   data: z.infer<typeof endSessionSchema>,
+  normalizedUrl: URL,
 ) => {
-  const normalizedUrl = resolveUrl(request);
-
   try {
     const { apiResourceId } = await context.params;
     const sessionToken = request.cookies.get(MOCK_SESSION_COOKIE)?.value;
@@ -76,7 +75,7 @@ export async function GET(request: NextRequest, context: ApiResourceRouteContext
     return Response.json({ error: "invalid_request", details: validation.error.flatten() }, { status: 400 });
   }
 
-  return handleRequest(request, context, validation.data);
+  return handleRequest(request, context, validation.data, normalizedUrl);
 }
 
 export async function POST(request: NextRequest, context: ApiResourceRouteContext) {
@@ -90,5 +89,6 @@ export async function POST(request: NextRequest, context: ApiResourceRouteContex
     return Response.json({ error: "invalid_request", details: validation.error.flatten() }, { status: 400 });
   }
 
-  return handleRequest(request, context, validation.data);
+  const normalizedUrl = resolveUrl(request);
+  return handleRequest(request, context, validation.data, normalizedUrl);
 }

--- a/src/server/oidc/url-builder.ts
+++ b/src/server/oidc/url-builder.ts
@@ -5,6 +5,7 @@ export const buildOidcUrls = (origin: string, apiResourceId: string) => {
     discovery: `${base}/.well-known/openid-configuration`,
     jwks: `${base}/jwks.json`,
     authorize: `${base}/authorize`,
+    endSession: `${base}/end-session`,
     token: `${base}/token`,
     userinfo: `${base}/userinfo`,
   } as const;

--- a/src/server/services/__tests__/discovery-service.test.ts
+++ b/src/server/services/__tests__/discovery-service.test.ts
@@ -7,6 +7,7 @@ describe("discovery document", () => {
     const doc = buildDiscoveryDocument("https://mockauth.test", "resource_999");
     expect(doc.issuer).toBe("https://mockauth.test/r/resource_999/oidc");
     expect(doc.authorization_endpoint).toBe("https://mockauth.test/r/resource_999/oidc/authorize");
+    expect(doc.end_session_endpoint).toBe("https://mockauth.test/r/resource_999/oidc/end-session");
     expect(doc.jwks_uri).toBe("https://mockauth.test/r/resource_999/oidc/jwks.json");
     expect(doc.id_token_signing_alg_values_supported).toEqual(["RS256", "PS256", "ES256", "ES384"]);
   });

--- a/src/server/services/__tests__/end-session-service.test.ts
+++ b/src/server/services/__tests__/end-session-service.test.ts
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetApiResourceWithTenant = vi.hoisted(() => vi.fn());
+const mockGetClientForTenant = vi.hoisted(() => vi.fn());
+const mockResolveRedirectUri = vi.hoisted(() => vi.fn());
+const mockClearSession = vi.hoisted(() => vi.fn());
+
+vi.mock("@/server/services/api-resource-service", () => ({
+  getApiResourceWithTenant: mockGetApiResourceWithTenant,
+}));
+
+vi.mock("@/server/services/client-service", () => ({
+  getClientForTenant: mockGetClientForTenant,
+}));
+
+vi.mock("@/server/oidc/redirect-uri", () => ({
+  resolveRedirectUri: mockResolveRedirectUri,
+}));
+
+vi.mock("@/server/services/mock-session-service", () => ({
+  clearSession: mockClearSession,
+}));
+
+import { handleEndSession } from "@/server/services/end-session-service";
+
+const ORIGIN = "https://mockauth.test";
+const API_RESOURCE_ID = "resource_123";
+const ISSUER = `${ORIGIN}/r/${API_RESOURCE_ID}/oidc`;
+const TENANT_ID = "tenant_123";
+const REDIRECT_URI = "https://client.example/logout";
+const REDIRECT_URIS = [{ uri: REDIRECT_URI }];
+
+const buildIdToken = (payload: Record<string, unknown>) => {
+  const header = Buffer.from(JSON.stringify({ alg: "none" })).toString("base64url");
+  const encodedPayload = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  return `${header}.${encodedPayload}.signature`;
+};
+
+describe("handleEndSession", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetApiResourceWithTenant.mockResolvedValue({
+      tenant: { id: TENANT_ID },
+      resource: { id: API_RESOURCE_ID },
+    } as never);
+    mockGetClientForTenant.mockResolvedValue({ redirectUris: REDIRECT_URIS } as never);
+    mockResolveRedirectUri.mockReturnValue(REDIRECT_URI);
+    mockClearSession.mockResolvedValue(undefined);
+  });
+
+  it("redirects when id_token_hint matches issuer", async () => {
+    const idTokenHint = buildIdToken({ iss: ISSUER, aud: "client_123" });
+
+    const result = await handleEndSession(
+      {
+        apiResourceId: API_RESOURCE_ID,
+        idTokenHint,
+        clientId: "client_123",
+        postLogoutRedirectUri: REDIRECT_URI,
+        state: "state-1",
+      },
+      ORIGIN,
+    );
+
+    expect(result.type).toBe("redirect");
+    if (result.type === "redirect") {
+      expect(result.redirectTo).toBe(`${REDIRECT_URI}?state=state-1`);
+    }
+    expect(result.clearSessionCookie).toBe(false);
+    expect(mockGetClientForTenant).toHaveBeenCalledWith(TENANT_ID, "client_123");
+    expect(mockResolveRedirectUri).toHaveBeenCalledWith(REDIRECT_URI, REDIRECT_URIS);
+    expect(mockClearSession).not.toHaveBeenCalled();
+  });
+
+  it("returns HTML when no id_token_hint or redirect", async () => {
+    const result = await handleEndSession({ apiResourceId: API_RESOURCE_ID }, ORIGIN);
+
+    expect(result.type).toBe("html");
+    if (result.type === "html") {
+      expect(result.html).toContain("You have been logged out.");
+    }
+    expect(result.clearSessionCookie).toBe(false);
+    expect(mockGetClientForTenant).not.toHaveBeenCalled();
+    expect(mockResolveRedirectUri).not.toHaveBeenCalled();
+    expect(mockClearSession).not.toHaveBeenCalled();
+  });
+
+  it("rejects id_token_hint with mismatched issuer", async () => {
+    const idTokenHint = buildIdToken({ iss: "https://issuer.example", aud: "client_123" });
+
+    await expect(
+      handleEndSession(
+        {
+          apiResourceId: API_RESOURCE_ID,
+          idTokenHint,
+        },
+        ORIGIN,
+      ),
+    ).rejects.toThrow("id_token_hint issuer mismatch");
+  });
+
+  it("rejects when client_id is not in aud", async () => {
+    const idTokenHint = buildIdToken({ iss: ISSUER, aud: ["client_a"] });
+
+    await expect(
+      handleEndSession(
+        {
+          apiResourceId: API_RESOURCE_ID,
+          idTokenHint,
+          clientId: "client_b",
+        },
+        ORIGIN,
+      ),
+    ).rejects.toThrow("client_id does not match id_token_hint");
+  });
+
+  it("falls back to HTML when post_logout_redirect_uri has no client", async () => {
+    const result = await handleEndSession(
+      {
+        apiResourceId: API_RESOURCE_ID,
+        postLogoutRedirectUri: REDIRECT_URI,
+      },
+      ORIGIN,
+    );
+
+    expect(result.type).toBe("html");
+    expect(result.clearSessionCookie).toBe(false);
+    expect(mockGetClientForTenant).not.toHaveBeenCalled();
+    expect(mockResolveRedirectUri).not.toHaveBeenCalled();
+  });
+
+  it("clears session when a session token is present", async () => {
+    const result = await handleEndSession(
+      {
+        apiResourceId: API_RESOURCE_ID,
+        sessionToken: "session-1",
+      },
+      ORIGIN,
+    );
+
+    expect(result.type).toBe("html");
+    expect(result.clearSessionCookie).toBe(true);
+    expect(mockClearSession).toHaveBeenCalledWith(TENANT_ID, "session-1");
+  });
+
+  it("rejects malformed JWT payloads", async () => {
+    const header = Buffer.from(JSON.stringify({ alg: "none" })).toString("base64url");
+    const badPayload = Buffer.from("not-json").toString("base64url");
+    const idTokenHint = `${header}.${badPayload}.sig`;
+
+    await expect(
+      handleEndSession(
+        {
+          apiResourceId: API_RESOURCE_ID,
+          idTokenHint,
+        },
+        ORIGIN,
+      ),
+    ).rejects.toThrow("id_token_hint payload is invalid");
+  });
+});

--- a/src/server/services/discovery-service.ts
+++ b/src/server/services/discovery-service.ts
@@ -10,6 +10,7 @@ export const buildDiscoveryDocument = (origin: string, apiResourceId: string) =>
     token_endpoint: `${issuer}/token`,
     userinfo_endpoint: `${issuer}/userinfo`,
     jwks_uri: `${issuer}/jwks.json`,
+    end_session_endpoint: `${issuer}/end-session`,
     response_types_supported: ["code"],
     grant_types_supported: ["authorization_code", "password"],
     scopes_supported: SUPPORTED_SCOPES,

--- a/src/server/services/end-session-service.ts
+++ b/src/server/services/end-session-service.ts
@@ -1,0 +1,106 @@
+import { DomainError } from "@/server/errors";
+import { issuerForResource } from "@/server/oidc/issuer";
+import { resolveRedirectUri } from "@/server/oidc/redirect-uri";
+import { getClientForTenant } from "@/server/services/client-service";
+import { clearSession } from "@/server/services/mock-session-service";
+import { getApiResourceWithTenant } from "@/server/services/api-resource-service";
+
+type EndSessionParams = {
+  apiResourceId: string;
+  idTokenHint?: string;
+  postLogoutRedirectUri?: string;
+  clientId?: string;
+  state?: string;
+  sessionToken?: string;
+};
+
+type EndSessionResult =
+  | { type: "redirect"; redirectTo: string; clearSessionCookie: boolean }
+  | { type: "html"; html: string; clearSessionCookie: boolean };
+
+const LOGGED_OUT_HTML = `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Logged out</title>
+  </head>
+  <body>
+    <p>You have been logged out.</p>
+  </body>
+</html>`;
+
+const parseJwtPayload = (token: string) => {
+  const [header, payload] = token.split(".");
+  if (!header || !payload) {
+    throw new DomainError("id_token_hint is not a valid JWT", { status: 400, code: "invalid_request" });
+  }
+
+  try {
+    const decoded = Buffer.from(payload, "base64url").toString("utf8");
+    const parsed = JSON.parse(decoded) as unknown;
+    if (!parsed || typeof parsed !== "object") {
+      throw new DomainError("id_token_hint payload is invalid", { status: 400, code: "invalid_request" });
+    }
+    return parsed as { iss?: unknown; aud?: unknown };
+  } catch (error) {
+    if (error instanceof DomainError) {
+      throw error;
+    }
+    throw new DomainError("id_token_hint payload is invalid", { status: 400, code: "invalid_request" });
+  }
+};
+
+const parseAudiences = (audience: unknown) => {
+  if (typeof audience === "string") {
+    return [audience];
+  }
+
+  if (Array.isArray(audience) && audience.every((entry) => typeof entry === "string")) {
+    return audience;
+  }
+
+  throw new DomainError("id_token_hint must include aud", { status: 400, code: "invalid_request" });
+};
+
+export const handleEndSession = async (params: EndSessionParams, origin: string): Promise<EndSessionResult> => {
+  const { tenant } = await getApiResourceWithTenant(params.apiResourceId);
+  const issuer = issuerForResource(origin, params.apiResourceId);
+
+  let audiences: string[] | null = null;
+  if (params.idTokenHint) {
+    const payload = parseJwtPayload(params.idTokenHint);
+    if (typeof payload.iss !== "string") {
+      throw new DomainError("id_token_hint must include iss", { status: 400, code: "invalid_request" });
+    }
+    if (payload.iss !== issuer) {
+      throw new DomainError("id_token_hint issuer mismatch", { status: 400, code: "invalid_request" });
+    }
+
+    audiences = parseAudiences(payload.aud);
+    if (params.clientId && !audiences.includes(params.clientId)) {
+      throw new DomainError("client_id does not match id_token_hint", { status: 400, code: "invalid_request" });
+    }
+  }
+
+  const resolvedClientId = params.clientId ?? audiences?.[0];
+  const client = resolvedClientId ? await getClientForTenant(tenant.id, resolvedClientId) : null;
+  const redirectUri =
+    params.postLogoutRedirectUri && client
+      ? resolveRedirectUri(params.postLogoutRedirectUri, client.redirectUris ?? [])
+      : null;
+
+  const clearSessionCookie = Boolean(params.sessionToken);
+  if (params.sessionToken) {
+    await clearSession(tenant.id, params.sessionToken);
+  }
+
+  if (redirectUri) {
+    const redirectUrl = new URL(redirectUri);
+    if (params.state) {
+      redirectUrl.searchParams.set("state", params.state);
+    }
+    return { type: "redirect", redirectTo: redirectUrl.toString(), clearSessionCookie };
+  }
+
+  return { type: "html", html: LOGGED_OUT_HTML, clearSessionCookie };
+};


### PR DESCRIPTION
## Summary
- add end_session_endpoint to discovery and URL helpers
- implement end-session service and route handling logout redirects
- update discovery and URL builder tests for new endpoint

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm test:e2e

Closes #161