### PR TITLE
fix(proxy): persist preauthorized refresh tokens

### DIFF
--- a/src/server/oidc/__tests__/proxy-flow.test.ts
+++ b/src/server/oidc/__tests__/proxy-flow.test.ts
@@ -4,7 +4,7 @@ import type { NextRequest } from "next/server";
 
 import { POST as handleTokenPost } from "@/app/r/[apiResourceId]/oidc/token/route";
 import { prisma } from "@/server/db/client";
-import { encrypt } from "@/server/crypto/key-vault";
+import { decrypt, encrypt } from "@/server/crypto/key-vault";
 import { hashSecret } from "@/server/crypto/hash";
 import { computeS256Challenge } from "@/server/crypto/pkce";
 import { handleAuthorize } from "@/server/services/authorize-service";
@@ -738,6 +738,117 @@ describe("Proxy client OAuth flow", () => {
     const secondParams = new URLSearchParams(secondInit?.body as URLSearchParams);
     expect(secondParams.get("client_id")).toBe("up-client");
     expect(secondParams.has("client_secret")).toBe(false);
+
+    fetchMock.mockRestore();
+  });
+
+  it("persists rotated refresh tokens for preauthorized identities", async () => {
+    const client = await createProxyStrategyClient({
+      ...DEFAULT_PROXY_AUTH_STRATEGIES,
+      preauthorized: { enabled: true },
+    });
+
+    const identity = await prisma.preauthorizedIdentity.create({
+      data: {
+        tenantId,
+        clientId: client.id,
+        label: "Preauthorized",
+        providerSubject: `preauth_${randomUUID()}`,
+        providerEmail: null,
+        providerScope: "openid profile",
+        providerResponseEncrypted: encrypt(JSON.stringify({
+          access_token: "stored-access",
+          refresh_token: "stored-refresh",
+          expires_in: 3600,
+        })),
+        accessTokenExpiresAt: null,
+        refreshTokenExpiresAt: null,
+      },
+    });
+
+    const fetchMock = vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          access_token: "new-access",
+          refresh_token: "rotated-refresh",
+          expires_in: 7200,
+          token_type: "Bearer",
+        }),
+        { status: 200 },
+      ),
+    );
+
+    await completeProxyRefreshGrant({
+      apiResourceId,
+      clientId: client.clientId,
+      refreshToken: "stored-refresh",
+      scope: "openid profile",
+      authMethod: "none",
+      clientSecret: null,
+    });
+
+    const stored = await prisma.preauthorizedIdentity.findUnique({ where: { id: identity.id } });
+    expect(stored).not.toBeNull();
+    const decrypted = JSON.parse(decrypt(stored!.providerResponseEncrypted)) as Record<string, unknown>;
+    expect(decrypted).toMatchObject({
+      access_token: "new-access",
+      refresh_token: "rotated-refresh",
+    });
+
+    fetchMock.mockRestore();
+  });
+
+  it("preserves refresh tokens when providers omit them", async () => {
+    const client = await createProxyStrategyClient({
+      ...DEFAULT_PROXY_AUTH_STRATEGIES,
+      preauthorized: { enabled: true },
+    });
+
+    const identity = await prisma.preauthorizedIdentity.create({
+      data: {
+        tenantId,
+        clientId: client.id,
+        label: "Preauthorized",
+        providerSubject: `preauth_${randomUUID()}`,
+        providerEmail: null,
+        providerScope: "openid profile",
+        providerResponseEncrypted: encrypt(JSON.stringify({
+          access_token: "stored-access",
+          refresh_token: "stored-refresh",
+          expires_in: 3600,
+        })),
+        accessTokenExpiresAt: null,
+        refreshTokenExpiresAt: null,
+      },
+    });
+
+    const fetchMock = vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          access_token: "new-access",
+          expires_in: 7200,
+          token_type: "Bearer",
+        }),
+        { status: 200 },
+      ),
+    );
+
+    await completeProxyRefreshGrant({
+      apiResourceId,
+      clientId: client.clientId,
+      refreshToken: "stored-refresh",
+      scope: "openid profile",
+      authMethod: "none",
+      clientSecret: null,
+    });
+
+    const stored = await prisma.preauthorizedIdentity.findUnique({ where: { id: identity.id } });
+    expect(stored).not.toBeNull();
+    const decrypted = JSON.parse(decrypt(stored!.providerResponseEncrypted)) as Record<string, unknown>;
+    expect(decrypted).toMatchObject({
+      access_token: "new-access",
+      refresh_token: "stored-refresh",
+    });
 
     fetchMock.mockRestore();
   });

--- a/src/server/services/preauthorized-identity-service.ts
+++ b/src/server/services/preauthorized-identity-service.ts
@@ -420,6 +420,84 @@ export const refreshPreauthorizedIdentity = async (params: {
   return { identity: updated, providerResponse: mergedResponse };
 };
 
+export const persistPreauthorizedIdentityRefreshResponse = async (params: {
+  tenantId: string;
+  clientId: string;
+  refreshToken: string;
+  providerResponse: ProviderTokenResponse;
+  now?: Date;
+}) => {
+  const now = params.now ?? new Date();
+  const identities = await prisma.preauthorizedIdentity.findMany({
+    where: { tenantId: params.tenantId, clientId: params.clientId },
+    orderBy: { createdAt: "desc" },
+    select: {
+      id: true,
+      providerResponseEncrypted: true,
+      providerSubject: true,
+      providerEmail: true,
+    },
+  });
+
+  let matched: {
+    id: string;
+    providerSubject: string;
+    providerEmail: string | null;
+    storedRefreshToken: string;
+  } | null = null;
+
+  for (const identity of identities) {
+    let storedResponse: ProviderTokenResponse;
+    try {
+      storedResponse = JSON.parse(decrypt(identity.providerResponseEncrypted)) as ProviderTokenResponse;
+    } catch {
+      continue;
+    }
+    const storedRefreshToken = extractRefreshToken(storedResponse);
+    if (storedRefreshToken && storedRefreshToken === params.refreshToken) {
+      matched = {
+        id: identity.id,
+        providerSubject: identity.providerSubject,
+        providerEmail: identity.providerEmail,
+        storedRefreshToken,
+      };
+      break;
+    }
+  }
+
+  if (!matched) {
+    return null;
+  }
+
+  const incomingRefreshToken = extractRefreshToken(params.providerResponse);
+  const mergedResponse: ProviderTokenResponse = {
+    ...params.providerResponse,
+    refresh_token:
+      incomingRefreshToken && incomingRefreshToken.trim().length > 0
+        ? incomingRefreshToken
+        : matched.storedRefreshToken,
+  };
+  const { subject, email } = resolveProviderMetadata(mergedResponse, {
+    subject: matched.providerSubject,
+    email: matched.providerEmail,
+  });
+  const providerSubject = requireProviderSubject(subject);
+  const accessTokenExpiresAt = extractAccessTokenExpiresAt(mergedResponse, now);
+  const refreshTokenExpiresAt = extractRefreshTokenExpiresAt(mergedResponse, now);
+  const encrypted = encrypt(JSON.stringify(mergedResponse));
+
+  return prisma.preauthorizedIdentity.update({
+    where: { id: matched.id },
+    data: {
+      providerResponseEncrypted: encrypted,
+      providerSubject,
+      providerEmail: email,
+      accessTokenExpiresAt,
+      refreshTokenExpiresAt,
+    },
+  });
+};
+
 export const resolvePreauthorizedIdentityTokens = async (params: {
   tenantId: string;
   clientId: string;

--- a/src/server/services/preauthorized-identity-service.ts
+++ b/src/server/services/preauthorized-identity-service.ts
@@ -450,7 +450,17 @@ export const persistPreauthorizedIdentityRefreshResponse = async (params: {
     let storedResponse: ProviderTokenResponse;
     try {
       storedResponse = JSON.parse(decrypt(identity.providerResponseEncrypted)) as ProviderTokenResponse;
-    } catch {
+    } catch (error) {
+      const errorPayload =
+        error instanceof Error
+          ? { name: error.name, message: error.message, stack: error.stack }
+          : { error: String(error) };
+      console.warn("Failed to decode preauthorized provider response", {
+        ...errorPayload,
+        tenantId: params.tenantId,
+        clientId: params.clientId,
+        identityId: identity.id,
+      });
       continue;
     }
     const storedRefreshToken = extractRefreshToken(storedResponse);

--- a/src/server/services/proxy-token-service.ts
+++ b/src/server/services/proxy-token-service.ts
@@ -543,7 +543,7 @@ export const completeProxyRefreshGrant = async (
       clientId: client.id,
       refreshToken: params.refreshToken,
       providerResponse: response.json,
-    }).catch(() => undefined);
+    });
   }
 
   return refreshResponse;

--- a/src/server/services/proxy-token-service.ts
+++ b/src/server/services/proxy-token-service.ts
@@ -1,6 +1,7 @@
 import { URLSearchParams } from "node:url";
 
 import { DomainError } from "@/server/errors";
+import { parseProxyAuthStrategies } from "@/server/oidc/proxy-auth-strategy";
 import { resolveRedirectUri } from "@/server/oidc/redirect-uri";
 import { buildProxyCallbackUrl } from "@/server/oidc/proxy/constants";
 import { resolveUpstreamAuthMethod } from "@/server/oidc/token-auth-method";
@@ -16,6 +17,7 @@ import { assertClientAuth, verifyPkce } from "@/server/services/token-service";
 import { getApiResourceWithTenant } from "@/server/services/api-resource-service";
 import { getClientForTenant } from "@/server/services/client-service";
 import { emitAuditEvent } from "@/server/services/audit-service";
+import { persistPreauthorizedIdentityRefreshResponse } from "@/server/services/preauthorized-identity-service";
 import {
   buildProxyCallbackErrorDetails,
   buildProxyFlowDiagnostics,
@@ -533,6 +535,16 @@ export const completeProxyRefreshGrant = async (
     details: toTokenResponsePayload(refreshResponse, exchangeDiagnostics),
     requestContext: params.auditContext?.requestContext ?? null,
   });
+
+  const proxyAuthStrategies = parseProxyAuthStrategies(client.proxyAuthStrategies);
+  if (proxyAuthStrategies.preauthorized.enabled) {
+    await persistPreauthorizedIdentityRefreshResponse({
+      tenantId: tenant.id,
+      clientId: client.id,
+      refreshToken: params.refreshToken,
+      providerResponse: response.json,
+    }).catch(() => undefined);
+  }
 
   return refreshResponse;
 };


### PR DESCRIPTION
## Summary
- persist proxy refresh responses back to matching preauthorized identities
- add helper to merge refresh responses while preserving existing refresh tokens
- cover refresh token rotation/omission in proxy flow tests

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test

Closes #165