### PR TITLE
feat(clients): add post-logout redirects

### DIFF
--- a/prisma/migrations/20260412042240_post_logout_redirect_uris/migration.sql
+++ b/prisma/migrations/20260412042240_post_logout_redirect_uris/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE "PostLogoutRedirectUri" (
+    "id" TEXT NOT NULL,
+    "clientId" TEXT NOT NULL,
+    "uri" TEXT NOT NULL,
+    "type" "RedirectUriType" NOT NULL DEFAULT 'EXACT',
+    "enabled" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "PostLogoutRedirectUri_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PostLogoutRedirectUri_clientId_uri_key" ON "PostLogoutRedirectUri"("clientId", "uri");
+
+-- AddForeignKey
+ALTER TABLE "PostLogoutRedirectUri" ADD CONSTRAINT "PostLogoutRedirectUri_clientId_fkey" FOREIGN KEY ("clientId") REFERENCES "Client"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -198,6 +198,7 @@ model Client {
   authStrategies           Json                     @default("{\"username\":{\"enabled\":true,\"subSource\":\"entered\"},\"email\":{\"enabled\":false,\"subSource\":\"entered\",\"emailVerifiedMode\":\"false\"}}")
   reauthTtlSeconds         Int                      @default(0)
   redirectUris             RedirectUri[]
+  postLogoutRedirectUris   PostLogoutRedirectUri[]
   oauthTestSessions        OAuthTestSession[]
   authorizationCodes       AuthorizationCode[]
   accessTokens             AccessToken[]
@@ -215,6 +216,17 @@ model Client {
 }
 
 model RedirectUri {
+  id        String          @id @default(uuid())
+  client    Client          @relation(fields: [clientId], references: [id], onDelete: Cascade)
+  clientId  String
+  uri       String
+  type      RedirectUriType @default(EXACT)
+  enabled   Boolean         @default(true)
+  createdAt DateTime        @default(now())
+  @@unique([clientId, uri])
+}
+
+model PostLogoutRedirectUri {
   id        String          @id @default(uuid())
   client    Client          @relation(fields: [clientId], references: [id], onDelete: Cascade)
   clientId  String

--- a/src/app/admin/actions.ts
+++ b/src/app/admin/actions.ts
@@ -268,7 +268,6 @@ const keySchema = z.object({ tenantId: z.string().min(1), alg: z.enum(SUPPORTED_
 const setTenantSchema = z.object({ tenantId: z.string().min(1) });
 const rotateSecretSchema = z.object({ clientId: z.string().min(1) });
 const redirectSchema = z.object({ clientId: z.string().min(1), uri: z.string().min(1) });
-const postLogoutRedirectSchema = z.object({ clientId: z.string().min(1), uri: z.string().min(1) });
 const oauthTestSchema = z.object({
   clientId: z.string().min(1),
   redirectUri: z.string().min(1),
@@ -278,7 +277,6 @@ const oauthTestSchema = z.object({
 });
 const updateClientSchema = z.object({ clientId: z.string().min(1), name: z.string().min(2) });
 const deleteRedirectSchema = z.object({ redirectId: z.string().min(1) });
-const deletePostLogoutRedirectSchema = z.object({ redirectId: z.string().min(1) });
 const membershipRoleSchema = z.enum(["OWNER", "WRITER", "READER"]);
 const inviteRoleSchema = z.enum(["WRITER", "READER"]);
 const deleteTenantSchema = z.object({ tenantId: z.string().min(1) });
@@ -1018,11 +1016,11 @@ export const addRedirectUriAction = async (input: z.infer<typeof redirectSchema>
 };
 
 export const addPostLogoutRedirectUriAction = async (
-  input: z.infer<typeof postLogoutRedirectSchema>,
+  input: z.infer<typeof redirectSchema>,
 ): Promise<ActionState> => {
   try {
     const adminId = await requireSession();
-    const parsed = postLogoutRedirectSchema.parse(input);
+    const parsed = redirectSchema.parse(input);
     const client = await getClientForAdmin(parsed.clientId, adminId, ["OWNER", "WRITER"]);
     if (!client) {
       return { error: "Client not found" };
@@ -1382,11 +1380,11 @@ export const deleteRedirectUriAction = async (input: z.infer<typeof deleteRedire
 };
 
 export const deletePostLogoutRedirectUriAction = async (
-  input: z.infer<typeof deletePostLogoutRedirectSchema>,
+  input: z.infer<typeof deleteRedirectSchema>,
 ): Promise<ActionState> => {
   try {
     const adminId = await requireSession();
-    const parsed = deletePostLogoutRedirectSchema.parse(input);
+    const parsed = deleteRedirectSchema.parse(input);
     const redirect = await prisma.postLogoutRedirectUri.findUnique({
       where: { id: parsed.redirectId },
       select: { id: true, uri: true, clientId: true, client: { select: { tenantId: true } } },

--- a/src/app/admin/actions.ts
+++ b/src/app/admin/actions.ts
@@ -19,6 +19,7 @@ import {
   buildPreauthorizedAdminTransactionCookiePath,
 } from "@/server/oidc/preauthorized/constants";
 import {
+  addPostLogoutRedirectUri,
   addRedirectUri,
   createClient,
   deleteClient,
@@ -102,6 +103,7 @@ const clientSchema = z.object({
   pkceRequired: z.boolean().default(true),
   allowedGrantTypes: z.array(z.enum(grantTypeOptions)).min(1).default(["authorization_code"]),
   redirects: z.array(z.string().min(1)).optional(),
+  postLogoutRedirects: z.array(z.string().min(1)).optional(),
   scopes: z.array(z.string().min(1)).optional(),
   mode: z.enum(["regular", "proxy"]).default("regular"),
   proxyAuthStrategies: proxyAuthStrategiesSchema.optional(),
@@ -266,6 +268,7 @@ const keySchema = z.object({ tenantId: z.string().min(1), alg: z.enum(SUPPORTED_
 const setTenantSchema = z.object({ tenantId: z.string().min(1) });
 const rotateSecretSchema = z.object({ clientId: z.string().min(1) });
 const redirectSchema = z.object({ clientId: z.string().min(1), uri: z.string().min(1) });
+const postLogoutRedirectSchema = z.object({ clientId: z.string().min(1), uri: z.string().min(1) });
 const oauthTestSchema = z.object({
   clientId: z.string().min(1),
   redirectUri: z.string().min(1),
@@ -275,6 +278,7 @@ const oauthTestSchema = z.object({
 });
 const updateClientSchema = z.object({ clientId: z.string().min(1), name: z.string().min(2) });
 const deleteRedirectSchema = z.object({ redirectId: z.string().min(1) });
+const deletePostLogoutRedirectSchema = z.object({ redirectId: z.string().min(1) });
 const membershipRoleSchema = z.enum(["OWNER", "WRITER", "READER"]);
 const inviteRoleSchema = z.enum(["WRITER", "READER"]);
 const deleteTenantSchema = z.object({ tenantId: z.string().min(1) });
@@ -488,6 +492,7 @@ export const createClientAction = async (
       }
     }
     const redirectEntries = parsed.redirects?.filter(Boolean);
+    const postLogoutRedirectEntries = parsed.postLogoutRedirects?.filter(Boolean);
     const normalizedScopes = parsed.scopes ? normalizeScopes(parsed.scopes) : Array.from(SUPPORTED_SCOPES);
     if (!normalizedScopes.includes("openid")) {
       return { error: "Scopes must include openid" };
@@ -508,6 +513,7 @@ export const createClientAction = async (
       pkceRequired: parsed.pkceRequired,
       allowedGrantTypes: parsed.allowedGrantTypes,
       redirectUris: redirectEntries,
+      postLogoutRedirectUris: postLogoutRedirectEntries,
       allowedScopes: canonicalScopes,
       oauthClientMode: parsed.mode,
       proxyAuthStrategies,
@@ -1011,6 +1017,35 @@ export const addRedirectUriAction = async (input: z.infer<typeof redirectSchema>
   }
 };
 
+export const addPostLogoutRedirectUriAction = async (
+  input: z.infer<typeof postLogoutRedirectSchema>,
+): Promise<ActionState> => {
+  try {
+    const adminId = await requireSession();
+    const parsed = postLogoutRedirectSchema.parse(input);
+    const client = await getClientForAdmin(parsed.clientId, adminId, ["OWNER", "WRITER"]);
+    if (!client) {
+      return { error: "Client not found" };
+    }
+    const redirect = await addPostLogoutRedirectUri(client.id, parsed.uri);
+    revalidatePath(clientPath(client.id));
+    void emitConfigChange({
+      tenantId: client.tenantId,
+      actorId: adminId,
+      action: "create",
+      resource: "post_logout_redirect_uri",
+      resourceId: redirect.id,
+      resourceName: redirect.uri,
+      clientId: client.id,
+      message: "Post-logout redirect URI added",
+    });
+    return { success: "Post-logout redirect URI saved" };
+  } catch (error) {
+    console.error(error);
+    return { error: "Failed to add post-logout redirect" };
+  }
+};
+
 export const prepareClientOauthTestAction = async (
   input: z.infer<typeof oauthTestSchema>,
 ): Promise<ActionState<{ authorizationUrl: string }>> => {
@@ -1343,6 +1378,40 @@ export const deleteRedirectUriAction = async (input: z.infer<typeof deleteRedire
   } catch (error) {
     console.error(error);
     return { error: "Unable to remove redirect" };
+  }
+};
+
+export const deletePostLogoutRedirectUriAction = async (
+  input: z.infer<typeof deletePostLogoutRedirectSchema>,
+): Promise<ActionState> => {
+  try {
+    const adminId = await requireSession();
+    const parsed = deletePostLogoutRedirectSchema.parse(input);
+    const redirect = await prisma.postLogoutRedirectUri.findUnique({
+      where: { id: parsed.redirectId },
+      select: { id: true, uri: true, clientId: true, client: { select: { tenantId: true } } },
+    });
+    if (!redirect) {
+      return { error: "Post-logout redirect not found" };
+    }
+    const membership = await assertTenantMembership(adminId, redirect.client.tenantId);
+    ensureMembershipRole(membership.role, ["OWNER", "WRITER"]);
+    await prisma.postLogoutRedirectUri.delete({ where: { id: redirect.id } });
+    revalidatePath(clientPath(redirect.clientId));
+    void emitConfigChange({
+      tenantId: redirect.client.tenantId,
+      actorId: adminId,
+      action: "delete",
+      resource: "post_logout_redirect_uri",
+      resourceId: redirect.id,
+      resourceName: redirect.uri,
+      clientId: redirect.clientId,
+      message: "Post-logout redirect URI removed",
+    });
+    return { success: "Post-logout redirect removed" };
+  } catch (error) {
+    console.error(error);
+    return { error: "Unable to remove post-logout redirect" };
   }
 };
 

--- a/src/app/admin/clients/[clientId]/client-forms.tsx
+++ b/src/app/admin/clients/[clientId]/client-forms.tsx
@@ -16,7 +16,9 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useFieldArray, useForm, useWatch } from "react-hook-form";
 
 import {
+  addPostLogoutRedirectUriAction,
   addRedirectUriAction,
+  deletePostLogoutRedirectUriAction,
   deleteRedirectUriAction,
   rotateClientSecretAction,
   updateClientAuthStrategiesAction,
@@ -63,25 +65,28 @@ import { DEFAULT_JWT_SIGNING_ALG, SUPPORTED_JWT_SIGNING_ALGS } from "@/server/oi
 import type { JwtSigningAlg } from "@/generated/prisma/client";
 
 const nameSchema = z.object({ name: z.string().min(2, "Name must be at least 2 characters") });
-const redirectSchema = z.object({
-  uri: z
-    .string()
-    .min(1, "Enter a redirect URI")
-    .superRefine((value, ctx) => {
-      const trimmed = value.trim();
-      if (trimmed === "*") {
-        return;
-      }
-      try {
-        const url = new URL(trimmed);
-        if (!url.protocol.startsWith("http")) {
-          throw new Error("invalid");
+const buildRedirectSchema = (message: string) =>
+  z.object({
+    uri: z
+      .string()
+      .min(1, message)
+      .superRefine((value, ctx) => {
+        const trimmed = value.trim();
+        if (trimmed === "*") {
+          return;
         }
-      } catch {
-        ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Enter an absolute URL or *" });
-      }
-    }),
-});
+        try {
+          const url = new URL(trimmed);
+          if (!url.protocol.startsWith("http")) {
+            throw new Error("invalid");
+          }
+        } catch {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Enter an absolute URL or *" });
+        }
+      }),
+  });
+const redirectSchema = buildRedirectSchema("Enter a redirect URI");
+const postLogoutRedirectSchema = buildRedirectSchema("Enter a post-logout redirect URI");
 const issuerSchema = z.object({ resourceId: z.union([z.literal("default"), z.string().min(1)]) });
 const strategyConfigSchema = z.object({ enabled: z.boolean(), subSource: z.enum(["entered", "generated_uuid"]) });
 const emailStrategyConfigSchema = strategyConfigSchema.extend({ emailVerifiedMode: z.enum(["true", "false", "user_choice"]) });
@@ -860,6 +865,76 @@ export function AddRedirectForm({ clientId, canEdit }: { clientId: string; canEd
   );
 }
 
+export function AddPostLogoutRedirectForm({ clientId, canEdit }: { clientId: string; canEdit: boolean }) {
+  const router = useRouter();
+  const form = useForm<z.infer<typeof postLogoutRedirectSchema>>({
+    resolver: zodResolver(postLogoutRedirectSchema),
+    defaultValues: { uri: "" },
+  });
+  const [pending, startTransition] = useTransition();
+  const { toast } = useToast();
+  const watchedField = useWatch({ control: form.control, name: "uri" }) ?? "";
+  const watchedUri = watchedField.trim();
+  const normalized = watchedUri.toLowerCase();
+  const isAnyWildcard = watchedUri === "*";
+  const isHostWildcard = !isAnyWildcard && normalized.startsWith("https://*.");
+  const isPathWildcard =
+    !isAnyWildcard && !isHostWildcard && watchedUri.endsWith("/*") && normalized.startsWith("http");
+
+  const onSubmit = (values: z.infer<typeof postLogoutRedirectSchema>) => {
+    startTransition(async () => {
+      const result = await addPostLogoutRedirectUriAction({ clientId, uri: values.uri });
+      if (result.error) {
+        toast({ variant: "destructive", title: "Unable to save post-logout redirect", description: result.error });
+        return;
+      }
+      toast({ title: "Post-logout redirect saved" });
+      form.reset();
+      router.refresh();
+    });
+  };
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="grid gap-3 sm:grid-cols-[1fr_auto]">
+        <FormField
+          control={form.control}
+          name="uri"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Post-logout redirect URI</FormLabel>
+              <FormControl>
+                <Input placeholder="https://app.example.com/logout or *" {...field} disabled={!canEdit || pending} />
+              </FormControl>
+              <FormMessage />
+              {isAnyWildcard ? (
+                <Alert variant="destructive" data-testid="redirect-any-warning" className="mt-3">
+                  <AlertTitle>QA-only wildcard</AlertTitle>
+                  <AlertDescription>
+                    Allowing <span className="font-mono">*</span> matches every redirect URI and only works when
+                    MOCKAUTH_ALLOW_ANY_REDIRECT=true. Never enable this in production.
+                  </AlertDescription>
+                </Alert>
+              ) : null}
+              {!isAnyWildcard && (isHostWildcard || isPathWildcard) ? (
+                <Alert variant="warning" data-testid="redirect-wildcard-warning" className="mt-3">
+                  <AlertTitle>Wildcard redirects are for QA</AlertTitle>
+                  <AlertDescription>
+                    Host and path wildcards are intended for QA environments only and must not be used for production tenants.
+                  </AlertDescription>
+                </Alert>
+              ) : null}
+            </FormItem>
+          )}
+        />
+        <Button type="submit" disabled={!canEdit || pending} className="self-end">
+          {pending ? <Loader2 className="h-4 w-4 animate-spin" /> : "Add"}
+        </Button>
+      </form>
+    </Form>
+  );
+}
+
 export function UpdateClientScopesForm({
   clientId,
   initialScopes,
@@ -1228,6 +1303,38 @@ export function DeleteRedirectButton({ redirectId, canEdit }: { redirectId: stri
         return;
       }
       toast({ title: "Redirect removed" });
+      router.refresh();
+    });
+  };
+
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="sm"
+      className="text-destructive"
+      onClick={handleDelete}
+      disabled={pending || !canEdit}
+    >
+      {pending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Trash2 className="h-4 w-4" />}
+      {!pending && <span className="ml-1 text-sm">Remove</span>}
+    </Button>
+  );
+}
+
+export function DeletePostLogoutRedirectButton({ redirectId, canEdit }: { redirectId: string; canEdit: boolean }) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const { toast } = useToast();
+
+  const handleDelete = () => {
+    startTransition(async () => {
+      const result = await deletePostLogoutRedirectUriAction({ redirectId });
+      if (result.error) {
+        toast({ variant: "destructive", title: "Unable to remove", description: result.error });
+        return;
+      }
+      toast({ title: "Post-logout redirect removed" });
       router.refresh();
     });
   };

--- a/src/app/admin/clients/[clientId]/client-forms.tsx
+++ b/src/app/admin/clients/[clientId]/client-forms.tsx
@@ -20,6 +20,7 @@ import {
   addRedirectUriAction,
   deletePostLogoutRedirectUriAction,
   deleteRedirectUriAction,
+  type ActionState,
   rotateClientSecretAction,
   updateClientAuthStrategiesAction,
   updateClientTokenConfigAction,
@@ -87,6 +88,46 @@ const buildRedirectSchema = (message: string) =>
   });
 const redirectSchema = buildRedirectSchema("Enter a redirect URI");
 const postLogoutRedirectSchema = buildRedirectSchema("Enter a post-logout redirect URI");
+type RedirectFormValues = z.infer<typeof redirectSchema>;
+type RedirectFormConfig = {
+  label: string;
+  placeholder: string;
+  addAction: (input: { clientId: string; uri: string }) => Promise<ActionState>;
+  toastSuccess: string;
+  toastError: string;
+  schema: z.ZodType<RedirectFormValues>;
+};
+type RedirectDeleteConfig = {
+  deleteAction: (input: { redirectId: string }) => Promise<ActionState>;
+  toastSuccess: string;
+  toastError: string;
+};
+const redirectFormConfig: RedirectFormConfig = {
+  label: "Redirect URI",
+  placeholder: "https://app.example.com/callback or *",
+  addAction: addRedirectUriAction,
+  toastSuccess: "Redirect saved",
+  toastError: "Unable to save redirect",
+  schema: redirectSchema,
+};
+const postLogoutRedirectFormConfig: RedirectFormConfig = {
+  label: "Post-logout redirect URI",
+  placeholder: "https://app.example.com/logout or *",
+  addAction: addPostLogoutRedirectUriAction,
+  toastSuccess: "Post-logout redirect saved",
+  toastError: "Unable to save post-logout redirect",
+  schema: postLogoutRedirectSchema,
+};
+const redirectDeleteConfig: RedirectDeleteConfig = {
+  deleteAction: deleteRedirectUriAction,
+  toastSuccess: "Redirect removed",
+  toastError: "Unable to remove",
+};
+const postLogoutRedirectDeleteConfig: RedirectDeleteConfig = {
+  deleteAction: deletePostLogoutRedirectUriAction,
+  toastSuccess: "Post-logout redirect removed",
+  toastError: "Unable to remove",
+};
 const issuerSchema = z.object({ resourceId: z.union([z.literal("default"), z.string().min(1)]) });
 const strategyConfigSchema = z.object({ enabled: z.boolean(), subSource: z.enum(["entered", "generated_uuid"]) });
 const emailStrategyConfigSchema = strategyConfigSchema.extend({ emailVerifiedMode: z.enum(["true", "false", "user_choice"]) });
@@ -798,9 +839,20 @@ export function UpdateTokenConfigForm({
   );
 }
 
-export function AddRedirectForm({ clientId, canEdit }: { clientId: string; canEdit: boolean }) {
+function AddRedirectUriForm({
+  clientId,
+  canEdit,
+  config,
+}: {
+  clientId: string;
+  canEdit: boolean;
+  config: RedirectFormConfig;
+}) {
   const router = useRouter();
-  const form = useForm<z.infer<typeof redirectSchema>>({ resolver: zodResolver(redirectSchema), defaultValues: { uri: "" } });
+  const form = useForm<RedirectFormValues>({
+    resolver: zodResolver(config.schema),
+    defaultValues: { uri: "" },
+  });
   const [pending, startTransition] = useTransition();
   const { toast } = useToast();
   const watchedField = useWatch({ control: form.control, name: "uri" }) ?? "";
@@ -811,14 +863,14 @@ export function AddRedirectForm({ clientId, canEdit }: { clientId: string; canEd
   const isPathWildcard =
     !isAnyWildcard && !isHostWildcard && watchedUri.endsWith("/*") && normalized.startsWith("http");
 
-  const onSubmit = (values: z.infer<typeof redirectSchema>) => {
+  const onSubmit = (values: RedirectFormValues) => {
     startTransition(async () => {
-      const result = await addRedirectUriAction({ clientId, uri: values.uri });
+      const result = await config.addAction({ clientId, uri: values.uri });
       if (result.error) {
-        toast({ variant: "destructive", title: "Unable to save redirect", description: result.error });
+        toast({ variant: "destructive", title: config.toastError, description: result.error });
         return;
       }
-      toast({ title: "Redirect saved" });
+      toast({ title: config.toastSuccess });
       form.reset();
       router.refresh();
     });
@@ -832,9 +884,9 @@ export function AddRedirectForm({ clientId, canEdit }: { clientId: string; canEd
           name="uri"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Redirect URI</FormLabel>
+              <FormLabel>{config.label}</FormLabel>
               <FormControl>
-                <Input placeholder="https://app.example.com/callback or *" {...field} disabled={!canEdit || pending} />
+                <Input placeholder={config.placeholder} {...field} disabled={!canEdit || pending} />
               </FormControl>
               <FormMessage />
               {isAnyWildcard ? (
@@ -865,73 +917,13 @@ export function AddRedirectForm({ clientId, canEdit }: { clientId: string; canEd
   );
 }
 
+export function AddRedirectForm({ clientId, canEdit }: { clientId: string; canEdit: boolean }) {
+  return <AddRedirectUriForm clientId={clientId} canEdit={canEdit} config={redirectFormConfig} />;
+}
+
 export function AddPostLogoutRedirectForm({ clientId, canEdit }: { clientId: string; canEdit: boolean }) {
-  const router = useRouter();
-  const form = useForm<z.infer<typeof postLogoutRedirectSchema>>({
-    resolver: zodResolver(postLogoutRedirectSchema),
-    defaultValues: { uri: "" },
-  });
-  const [pending, startTransition] = useTransition();
-  const { toast } = useToast();
-  const watchedField = useWatch({ control: form.control, name: "uri" }) ?? "";
-  const watchedUri = watchedField.trim();
-  const normalized = watchedUri.toLowerCase();
-  const isAnyWildcard = watchedUri === "*";
-  const isHostWildcard = !isAnyWildcard && normalized.startsWith("https://*.");
-  const isPathWildcard =
-    !isAnyWildcard && !isHostWildcard && watchedUri.endsWith("/*") && normalized.startsWith("http");
-
-  const onSubmit = (values: z.infer<typeof postLogoutRedirectSchema>) => {
-    startTransition(async () => {
-      const result = await addPostLogoutRedirectUriAction({ clientId, uri: values.uri });
-      if (result.error) {
-        toast({ variant: "destructive", title: "Unable to save post-logout redirect", description: result.error });
-        return;
-      }
-      toast({ title: "Post-logout redirect saved" });
-      form.reset();
-      router.refresh();
-    });
-  };
-
   return (
-    <Form {...form}>
-      <form onSubmit={form.handleSubmit(onSubmit)} className="grid gap-3 sm:grid-cols-[1fr_auto]">
-        <FormField
-          control={form.control}
-          name="uri"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Post-logout redirect URI</FormLabel>
-              <FormControl>
-                <Input placeholder="https://app.example.com/logout or *" {...field} disabled={!canEdit || pending} />
-              </FormControl>
-              <FormMessage />
-              {isAnyWildcard ? (
-                <Alert variant="destructive" data-testid="redirect-any-warning" className="mt-3">
-                  <AlertTitle>QA-only wildcard</AlertTitle>
-                  <AlertDescription>
-                    Allowing <span className="font-mono">*</span> matches every redirect URI and only works when
-                    MOCKAUTH_ALLOW_ANY_REDIRECT=true. Never enable this in production.
-                  </AlertDescription>
-                </Alert>
-              ) : null}
-              {!isAnyWildcard && (isHostWildcard || isPathWildcard) ? (
-                <Alert variant="warning" data-testid="redirect-wildcard-warning" className="mt-3">
-                  <AlertTitle>Wildcard redirects are for QA</AlertTitle>
-                  <AlertDescription>
-                    Host and path wildcards are intended for QA environments only and must not be used for production tenants.
-                  </AlertDescription>
-                </Alert>
-              ) : null}
-            </FormItem>
-          )}
-        />
-        <Button type="submit" disabled={!canEdit || pending} className="self-end">
-          {pending ? <Loader2 className="h-4 w-4 animate-spin" /> : "Add"}
-        </Button>
-      </form>
-    </Form>
+    <AddRedirectUriForm clientId={clientId} canEdit={canEdit} config={postLogoutRedirectFormConfig} />
   );
 }
 
@@ -1290,19 +1282,27 @@ export function UpdateAuthStrategiesForm({
   );
 }
 
-export function DeleteRedirectButton({ redirectId, canEdit }: { redirectId: string; canEdit: boolean }) {
+function DeleteRedirectButtonBase({
+  redirectId,
+  canEdit,
+  config,
+}: {
+  redirectId: string;
+  canEdit: boolean;
+  config: RedirectDeleteConfig;
+}) {
   const router = useRouter();
   const [pending, startTransition] = useTransition();
   const { toast } = useToast();
 
   const handleDelete = () => {
     startTransition(async () => {
-      const result = await deleteRedirectUriAction({ redirectId });
+      const result = await config.deleteAction({ redirectId });
       if (result.error) {
-        toast({ variant: "destructive", title: "Unable to remove", description: result.error });
+        toast({ variant: "destructive", title: config.toastError, description: result.error });
         return;
       }
-      toast({ title: "Redirect removed" });
+      toast({ title: config.toastSuccess });
       router.refresh();
     });
   };
@@ -1322,35 +1322,17 @@ export function DeleteRedirectButton({ redirectId, canEdit }: { redirectId: stri
   );
 }
 
+export function DeleteRedirectButton({ redirectId, canEdit }: { redirectId: string; canEdit: boolean }) {
+  return <DeleteRedirectButtonBase redirectId={redirectId} canEdit={canEdit} config={redirectDeleteConfig} />;
+}
+
 export function DeletePostLogoutRedirectButton({ redirectId, canEdit }: { redirectId: string; canEdit: boolean }) {
-  const router = useRouter();
-  const [pending, startTransition] = useTransition();
-  const { toast } = useToast();
-
-  const handleDelete = () => {
-    startTransition(async () => {
-      const result = await deletePostLogoutRedirectUriAction({ redirectId });
-      if (result.error) {
-        toast({ variant: "destructive", title: "Unable to remove", description: result.error });
-        return;
-      }
-      toast({ title: "Post-logout redirect removed" });
-      router.refresh();
-    });
-  };
-
   return (
-    <Button
-      type="button"
-      variant="ghost"
-      size="sm"
-      className="text-destructive"
-      onClick={handleDelete}
-      disabled={pending || !canEdit}
-    >
-      {pending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Trash2 className="h-4 w-4" />}
-      {!pending && <span className="ml-1 text-sm">Remove</span>}
-    </Button>
+    <DeleteRedirectButtonBase
+      redirectId={redirectId}
+      canEdit={canEdit}
+      config={postLogoutRedirectDeleteConfig}
+    />
   );
 }
 

--- a/src/app/admin/clients/[clientId]/page.tsx
+++ b/src/app/admin/clients/[clientId]/page.tsx
@@ -5,7 +5,9 @@ import { format } from "date-fns";
 
 import { CopyBundleButton, CopyField } from "@/app/admin/_components/copy-field";
 import {
+  AddPostLogoutRedirectForm,
   AddRedirectForm,
+  DeletePostLogoutRedirectButton,
   DeleteRedirectButton,
   RotateSecretForm,
   UpdateAuthStrategiesForm,
@@ -541,6 +543,44 @@ export default async function ClientDetailPage({ params }: { params: PageParams 
                     <TableCell className="hidden sm:table-cell text-xs uppercase text-muted-foreground">{uri.type.toLowerCase()}</TableCell>
                     <TableCell className="text-right">
                       <DeleteRedirectButton redirectId={uri.id} canEdit={canManageClients} />
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Post-logout Redirect URIs</CardTitle>
+          <CardDescription>Allow RP-initiated logout redirects to approved destinations.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <AddPostLogoutRedirectForm clientId={client.id} canEdit={canManageClients} />
+          {client.postLogoutRedirectUris.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No post-logout redirect URIs configured yet.</p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>URI</TableHead>
+                  <TableHead className="hidden sm:table-cell">Type</TableHead>
+                  <TableHead className="text-right">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {client.postLogoutRedirectUris.map((uri) => (
+                  <TableRow key={uri.id}>
+                    <TableCell>
+                      <p className="font-mono text-sm">{uri.uri}</p>
+                    </TableCell>
+                    <TableCell className="hidden sm:table-cell text-xs uppercase text-muted-foreground">
+                      {uri.type.toLowerCase()}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <DeletePostLogoutRedirectButton redirectId={uri.id} canEdit={canManageClients} />
                     </TableCell>
                   </TableRow>
                 ))}

--- a/src/app/admin/clients/__tests__/client-detail.proxy.test.tsx
+++ b/src/app/admin/clients/__tests__/client-detail.proxy.test.tsx
@@ -23,6 +23,7 @@ const proxyClientBase = {
   allowedResponseTypes: ["code"],
   authStrategies: DEFAULT_CLIENT_AUTH_STRATEGIES,
   redirectUris: [{ id: "redirect_1", uri: "https://app.example.test/callback", type: "EXACT" }],
+  postLogoutRedirectUris: [],
   tenant: { id: "tenant_1", defaultApiResourceId: "api-default", defaultApiResource: { id: "api-default", name: "Default" } },
   apiResource: null,
   proxyConfig: {
@@ -104,6 +105,8 @@ vi.mock("../[clientId]/client-forms", () => ({
   UpdateClientReauthTtlForm: () => <div data-testid="client-reauth-form" />,
   AddRedirectForm: () => <div data-testid="add-redirect-form" />,
   DeleteRedirectButton: () => <button type="button" data-testid="delete-redirect-btn" />,
+  AddPostLogoutRedirectForm: () => <div data-testid="add-post-logout-redirect-form" />,
+  DeletePostLogoutRedirectButton: () => <button type="button" data-testid="delete-post-logout-redirect-btn" />,
   RotateSecretForm: () => <div data-testid="rotate-secret-form" />,
 }));
 

--- a/src/app/admin/clients/__tests__/new-client-form.proxy.test.tsx
+++ b/src/app/admin/clients/__tests__/new-client-form.proxy.test.tsx
@@ -163,6 +163,7 @@ describe("NewClientForm proxy mode", () => {
       pkceRequired: true,
       allowedGrantTypes: ["authorization_code"],
       redirects: ["https://client.example.test/callback"],
+      postLogoutRedirects: [],
       mode: "proxy",
       proxyAuthStrategies: DEFAULT_PROXY_AUTH_STRATEGIES,
       proxyConfig: {

--- a/src/app/admin/clients/__tests__/update-client-auth-strategies-form.test.tsx
+++ b/src/app/admin/clients/__tests__/update-client-auth-strategies-form.test.tsx
@@ -11,7 +11,9 @@ const mockUpdateClientAuthStrategiesAction = vi.hoisted(() => vi.fn().mockResolv
 
 vi.mock("@/app/admin/actions", () => ({
   addRedirectUriAction: vi.fn(),
+  addPostLogoutRedirectUriAction: vi.fn(),
   deleteRedirectUriAction: vi.fn(),
+  deletePostLogoutRedirectUriAction: vi.fn(),
   rotateClientSecretAction: vi.fn(),
   updateClientAuthStrategiesAction: mockUpdateClientAuthStrategiesAction,
   updateClientIssuerAction: vi.fn(),

--- a/src/app/admin/clients/__tests__/update-client-issuer-form.test.tsx
+++ b/src/app/admin/clients/__tests__/update-client-issuer-form.test.tsx
@@ -10,7 +10,9 @@ const mockUpdateClientIssuerAction = vi.hoisted(() => vi.fn().mockResolvedValue(
 
 vi.mock("@/app/admin/actions", () => ({
   addRedirectUriAction: vi.fn(),
+  addPostLogoutRedirectUriAction: vi.fn(),
   deleteRedirectUriAction: vi.fn(),
+  deletePostLogoutRedirectUriAction: vi.fn(),
   rotateClientSecretAction: vi.fn(),
   updateClientAuthStrategiesAction: vi.fn(),
   updateClientIssuerAction: mockUpdateClientIssuerAction,

--- a/src/app/admin/clients/__tests__/update-client-reauth-form.test.tsx
+++ b/src/app/admin/clients/__tests__/update-client-reauth-form.test.tsx
@@ -10,7 +10,9 @@ const mockUpdateClientReauthTtlAction = vi.hoisted(() => vi.fn().mockResolvedVal
 
 vi.mock("@/app/admin/actions", () => ({
   addRedirectUriAction: vi.fn(),
+  addPostLogoutRedirectUriAction: vi.fn(),
   deleteRedirectUriAction: vi.fn(),
+  deletePostLogoutRedirectUriAction: vi.fn(),
   rotateClientSecretAction: vi.fn(),
   updateClientAuthStrategiesAction: vi.fn(),
   updateClientIssuerAction: vi.fn(),

--- a/src/app/admin/clients/__tests__/update-client-scopes-form.test.tsx
+++ b/src/app/admin/clients/__tests__/update-client-scopes-form.test.tsx
@@ -10,7 +10,9 @@ const mockUpdateClientScopesAction = vi.hoisted(() => vi.fn().mockResolvedValue(
 
 vi.mock("@/app/admin/actions", () => ({
   addRedirectUriAction: vi.fn(),
+  addPostLogoutRedirectUriAction: vi.fn(),
   deleteRedirectUriAction: vi.fn(),
+  deletePostLogoutRedirectUriAction: vi.fn(),
   rotateClientSecretAction: vi.fn(),
   updateClientAuthStrategiesAction: vi.fn(),
   updateClientIssuerAction: vi.fn(),

--- a/src/app/admin/clients/__tests__/update-client-signing-algorithms-form.test.tsx
+++ b/src/app/admin/clients/__tests__/update-client-signing-algorithms-form.test.tsx
@@ -10,7 +10,9 @@ const mockUpdateClientSigningAlgsAction = vi.hoisted(() => vi.fn().mockResolvedV
 
 vi.mock("@/app/admin/actions", () => ({
   addRedirectUriAction: vi.fn(),
+  addPostLogoutRedirectUriAction: vi.fn(),
   deleteRedirectUriAction: vi.fn(),
+  deletePostLogoutRedirectUriAction: vi.fn(),
   rotateClientSecretAction: vi.fn(),
   updateClientAuthStrategiesAction: vi.fn(),
   updateClientScopesAction: vi.fn(),

--- a/src/app/admin/clients/new/client-form.tsx
+++ b/src/app/admin/clients/new/client-form.tsx
@@ -69,6 +69,7 @@ const formSchema = z
       .array(z.enum(grantTypeOptions))
       .min(1, "Select at least one grant type"),
     redirects: z.string().optional(),
+    postLogoutRedirects: z.string().optional(),
     mode: z.enum(["regular", "proxy"] as const),
     proxyAuthStrategies: proxyAuthStrategiesZodSchema,
     proxyConfig: proxyConfigSchema.optional(),
@@ -335,6 +336,7 @@ export function NewClientForm({ tenantId }: { tenantId: string }) {
       pkceRequired: true,
       allowedGrantTypes: ["authorization_code"],
       redirects: "",
+      postLogoutRedirects: "",
       mode: "regular",
       proxyAuthStrategies: createDefaultProxyAuthStrategies(),
       proxyConfig: createDefaultProxyConfig(),
@@ -404,6 +406,10 @@ export function NewClientForm({ tenantId }: { tenantId: string }) {
         ?.split(/\r?\n/)
         .map((entry) => entry.trim())
         .filter((entry) => entry.length > 0);
+      const postLogoutRedirectEntries = values.postLogoutRedirects
+        ?.split(/\r?\n/)
+        .map((entry) => entry.trim())
+        .filter((entry) => entry.length > 0);
 
       const proxyConfigInput = values.mode === "proxy" && values.proxyConfig
         ? {
@@ -432,6 +438,7 @@ export function NewClientForm({ tenantId }: { tenantId: string }) {
         pkceRequired: values.pkceRequired,
         allowedGrantTypes: values.allowedGrantTypes,
         redirects: redirectEntries,
+        postLogoutRedirects: postLogoutRedirectEntries,
         mode: values.mode,
         proxyAuthStrategies: values.mode === "proxy" ? values.proxyAuthStrategies : undefined,
         proxyConfig: proxyConfigInput,
@@ -450,6 +457,7 @@ export function NewClientForm({ tenantId }: { tenantId: string }) {
         pkceRequired: values.pkceRequired,
         allowedGrantTypes: values.allowedGrantTypes,
         redirects: "",
+        postLogoutRedirects: "",
         mode: values.mode,
         proxyAuthStrategies: values.proxyAuthStrategies,
         proxyConfig: createDefaultProxyConfig(),
@@ -918,6 +926,21 @@ export function NewClientForm({ tenantId }: { tenantId: string }) {
                 <Textarea rows={4} placeholder="https://client.example.test/callback" {...field} />
               </FormControl>
               <p className="text-xs text-muted-foreground">Enter one URI per line. Wildcards are normalized automatically.</p>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="postLogoutRedirects"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Post-logout redirect URIs</FormLabel>
+              <FormControl>
+                <Textarea rows={4} placeholder="https://client.example.test/logout" {...field} />
+              </FormControl>
+              <p className="text-xs text-muted-foreground">Enter one URI per line for logout redirects.</p>
               <FormMessage />
             </FormItem>
           )}

--- a/src/app/admin/clients/page.tsx
+++ b/src/app/admin/clients/page.tsx
@@ -105,7 +105,16 @@ export default async function ClientsPage({ searchParams }: { searchParams: Sear
                       <Badge variant="secondary">{client.tokenEndpointAuthMethods.join(", ")}</Badge>
                     </TableCell>
                     <TableCell className="hidden md:table-cell">
-                      {client._count.redirectUris} redirect URI{client._count.redirectUris === 1 ? "" : "s"}
+                      <div className="space-y-1">
+                        <p>
+                          {client._count.redirectUris} redirect URI{client._count.redirectUris === 1 ? "" : "s"}
+                        </p>
+                        {client._count.postLogoutRedirectUris > 0 ? (
+                          <p className="text-xs text-muted-foreground">
+                            {client._count.postLogoutRedirectUris} post-logout
+                          </p>
+                        ) : null}
+                      </div>
                     </TableCell>
                     <TableCell className="hidden md:table-cell">
                       {formatDistanceToNow(client.updatedAt, { addSuffix: true })}

--- a/src/app/api/test/clients/route.ts
+++ b/src/app/api/test/clients/route.ts
@@ -13,6 +13,7 @@ type Body = {
   pkceRequired?: boolean;
   allowedGrantTypes?: string[];
   redirectUris?: string[];
+  postLogoutRedirectUris?: string[];
 };
 
 export async function POST(request: Request) {
@@ -36,6 +37,9 @@ export async function POST(request: Request) {
       ? payload.allowedGrantTypes
       : ["authorization_code"];
   const redirectUris = Array.isArray(payload.redirectUris) ? payload.redirectUris : undefined;
+  const postLogoutRedirectUris = Array.isArray(payload.postLogoutRedirectUris)
+    ? payload.postLogoutRedirectUris
+    : undefined;
 
   const created = [] as { id: string; name: string; clientId: string }[];
   for (const name of names) {
@@ -45,6 +49,7 @@ export async function POST(request: Request) {
       pkceRequired,
       allowedGrantTypes,
       redirectUris,
+      postLogoutRedirectUris,
     });
     created.push({ id: client.id, name: client.name, clientId: client.clientId });
   }

--- a/src/server/services/__tests__/client-service.test.ts
+++ b/src/server/services/__tests__/client-service.test.ts
@@ -5,6 +5,7 @@ import { prisma } from "@/server/db/client";
 import { decrypt } from "@/server/crypto/key-vault";
 import { DEFAULT_PROXY_AUTH_STRATEGIES } from "@/server/oidc/proxy-auth-strategy";
 import {
+  addPostLogoutRedirectUri,
   createClient,
   deleteClient,
   getClientByIdForTenant,
@@ -63,6 +64,39 @@ describe("client service", () => {
     expect(stored?.clientSecretEncrypted).toBeTruthy();
     expect(stored?.allowedScopes).toEqual(["openid", "profile", "email"]);
     expect(decrypt(stored?.clientSecretEncrypted as string)).toEqual(clientSecret);
+  });
+
+  it("creates a client with post-logout redirect URIs", async () => {
+    const tenant = await createTenant();
+    const { client } = await createClient(tenant.id, {
+      name: "Logout App",
+      tokenEndpointAuthMethods: ["none"],
+      postLogoutRedirectUris: ["https://example.com/logout"],
+    });
+
+    const stored = await prisma.client.findUnique({
+      where: { id: client.id },
+      include: { redirectUris: true, postLogoutRedirectUris: true },
+    });
+
+    expect(stored?.redirectUris).toHaveLength(0);
+    expect(stored?.postLogoutRedirectUris).toHaveLength(1);
+    expect(stored?.postLogoutRedirectUris[0].uri).toBe("https://example.com/logout");
+  });
+
+  it("adds post-logout redirect URIs", async () => {
+    const tenant = await createTenant();
+    const { client } = await createClient(tenant.id, {
+      name: "Add Logout",
+      tokenEndpointAuthMethods: ["none"],
+      redirectUris: ["https://example.com/callback"],
+    });
+
+    const added = await addPostLogoutRedirectUri(client.id, "https://example.com/logout");
+    expect(added.uri).toBe("https://example.com/logout");
+
+    const stored = await prisma.postLogoutRedirectUri.findMany({ where: { clientId: client.id } });
+    expect(stored).toHaveLength(1);
   });
 
   it("allows configuring custom scopes", async () => {
@@ -208,6 +242,7 @@ describe("client service", () => {
       name: "Cascade Client",
       tokenEndpointAuthMethods: ["client_secret_basic"],
       redirectUris: ["https://cascade.example/callback"],
+      postLogoutRedirectUris: ["https://cascade.example/logout"],
       oauthClientMode: "proxy",
       proxyAuthStrategies: DEFAULT_PROXY_AUTH_STRATEGIES,
       proxyConfig: {
@@ -326,6 +361,7 @@ describe("client service", () => {
     expect(retainedLog).not.toBeNull();
     expect(retainedLog?.clientId).toBeNull();
     expect(await prisma.redirectUri.count({ where: { clientId: client.id } })).toBe(0);
+    expect(await prisma.postLogoutRedirectUri.count({ where: { clientId: client.id } })).toBe(0);
     expect(await prisma.oAuthTestSession.count({ where: { clientId: client.id } })).toBe(0);
     expect(await prisma.authorizationCode.count({ where: { clientId: client.id } })).toBe(0);
     expect(await prisma.accessToken.count({ where: { clientId: client.id } })).toBe(0);

--- a/src/server/services/__tests__/end-session-service.test.ts
+++ b/src/server/services/__tests__/end-session-service.test.ts
@@ -28,7 +28,8 @@ const API_RESOURCE_ID = "resource_123";
 const ISSUER = `${ORIGIN}/r/${API_RESOURCE_ID}/oidc`;
 const TENANT_ID = "tenant_123";
 const REDIRECT_URI = "https://client.example/logout";
-const REDIRECT_URIS = [{ uri: REDIRECT_URI }];
+const REDIRECT_URIS = [{ uri: "https://client.example/callback" }];
+const POST_LOGOUT_REDIRECT_URIS = [{ uri: REDIRECT_URI }];
 
 const buildIdToken = (payload: Record<string, unknown>) => {
   const header = Buffer.from(JSON.stringify({ alg: "none" })).toString("base64url");
@@ -43,7 +44,10 @@ describe("handleEndSession", () => {
       tenant: { id: TENANT_ID },
       resource: { id: API_RESOURCE_ID },
     } as never);
-    mockGetClientForTenant.mockResolvedValue({ redirectUris: REDIRECT_URIS } as never);
+    mockGetClientForTenant.mockResolvedValue({
+      redirectUris: REDIRECT_URIS,
+      postLogoutRedirectUris: POST_LOGOUT_REDIRECT_URIS,
+    } as never);
     mockResolveRedirectUri.mockReturnValue(REDIRECT_URI);
     mockClearSession.mockResolvedValue(undefined);
   });
@@ -68,7 +72,7 @@ describe("handleEndSession", () => {
     }
     expect(result.clearSessionCookie).toBe(false);
     expect(mockGetClientForTenant).toHaveBeenCalledWith(TENANT_ID, "client_123");
-    expect(mockResolveRedirectUri).toHaveBeenCalledWith(REDIRECT_URI, REDIRECT_URIS);
+    expect(mockResolveRedirectUri).toHaveBeenCalledWith(REDIRECT_URI, POST_LOGOUT_REDIRECT_URIS);
     expect(mockClearSession).not.toHaveBeenCalled();
   });
 

--- a/src/server/services/client-service.ts
+++ b/src/server/services/client-service.ts
@@ -107,7 +107,7 @@ const normalizeScopeMapping = (mapping?: ProxyProviderConfigInput["scopeMapping"
 export const getClientForTenant = async (tenantId: string, clientId: string) => {
   const client = await prisma.client.findFirst({
     where: { tenantId, clientId },
-    include: { redirectUris: true, proxyConfig: true },
+    include: { redirectUris: true, postLogoutRedirectUris: true, proxyConfig: true },
   });
 
   if (!client) {
@@ -125,6 +125,7 @@ export const createClient = async (
     pkceRequired?: boolean;
     allowedGrantTypes?: string[];
     redirectUris?: string[];
+    postLogoutRedirectUris?: string[];
     allowedScopes?: string[];
     oauthClientMode?: "regular" | "proxy";
     proxyAuthStrategies?: ProxyAuthStrategies;
@@ -184,6 +185,13 @@ export const createClient = async (
       }
     }
 
+    if (data.postLogoutRedirectUris?.length) {
+      for (const raw of data.postLogoutRedirectUris) {
+        const { normalized, type } = classifyRedirect(raw);
+        await tx.postLogoutRedirectUri.create({ data: { clientId: created.id, uri: normalized, type } });
+      }
+    }
+
     if (mode === "proxy" && validatedProxyConfig) {
       const trimmedUpstreamClientId = validatedProxyConfig.upstreamClientId.trim();
       const normalizedSecret = validatedProxyConfig.upstreamClientSecret?.trim();
@@ -233,6 +241,22 @@ export const addRedirectUri = async (clientId: string, value: string) => {
   });
 };
 
+export const addPostLogoutRedirectUri = async (clientId: string, value: string) => {
+  const client = await prisma.client.findUnique({ where: { id: clientId } });
+  if (!client) {
+    throw new DomainError("Client not found", { status: 404 });
+  }
+
+  const { normalized, type } = classifyRedirect(value);
+  return prisma.postLogoutRedirectUri.create({
+    data: {
+      clientId,
+      uri: normalized,
+      type,
+    },
+  });
+};
+
 const DEFAULT_PAGE_SIZE = 10;
 
 export const listClients = async (
@@ -257,7 +281,7 @@ export const listClients = async (
   const [clients, total] = await prisma.$transaction([
     prisma.client.findMany({
       where,
-      include: { _count: { select: { redirectUris: true } } },
+      include: { _count: { select: { redirectUris: true, postLogoutRedirectUris: true } } },
       orderBy: { createdAt: "desc" },
       skip: (page - 1) * pageSize,
       take: pageSize,
@@ -281,6 +305,7 @@ export const getClientByIdForTenant = async (tenantId: string, clientInternalId:
     where: { id: clientInternalId, tenantId },
     include: {
       redirectUris: { orderBy: { createdAt: "asc" } },
+      postLogoutRedirectUris: { orderBy: { createdAt: "asc" } },
       tenant: { include: { defaultApiResource: true } },
       apiResource: true,
       proxyConfig: true,

--- a/src/server/services/end-session-service.ts
+++ b/src/server/services/end-session-service.ts
@@ -86,7 +86,7 @@ export const handleEndSession = async (params: EndSessionParams, origin: string)
   const client = resolvedClientId ? await getClientForTenant(tenant.id, resolvedClientId) : null;
   const redirectUri =
     params.postLogoutRedirectUri && client
-      ? resolveRedirectUri(params.postLogoutRedirectUri, client.redirectUris ?? [])
+      ? resolveRedirectUri(params.postLogoutRedirectUri, client.postLogoutRedirectUris ?? [])
       : null;
 
   const clearSessionCookie = Boolean(params.sessionToken);

--- a/tests/e2e/admin.spec.ts
+++ b/tests/e2e/admin.spec.ts
@@ -71,13 +71,13 @@ test.describe("admin console", () => {
 
     await page.getByRole("link", { name: "Add client" }).click();
     await page.getByLabel("Client name").fill(clientName);
-    await page.getByLabel("Redirect URIs").fill("https://pw.example.test/callback");
+    await page.getByLabel("Redirect URIs", { exact: true }).fill("https://pw.example.test/callback");
     await page.getByRole("button", { name: "Create client" }).click();
     await page.getByRole("link", { name: "Back to list" }).click();
 
     const row = page.getByRole("row", { name: new RegExp(clientName, "i") }).last();
     await row.getByRole("link", { name: "Details →" }).click();
-    await expect(page.getByRole("heading", { name: "Redirect URIs" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Redirect URIs", exact: true })).toBeVisible();
 
     const requiredSection = page.getByTestId("oauth-required");
     await expect(requiredSection.locator("[data-field-label]").first()).toBeVisible();
@@ -105,13 +105,14 @@ test.describe("admin console", () => {
     await tenantIdField.getByRole("button", { name: "Copy Tenant ID" }).click();
     await expect(tenantIdField.getByText("Copied")).toBeVisible();
 
-    const redirectInput = page.getByLabel("Redirect URI");
+    const redirectInput = page.getByLabel("Redirect URI", { exact: true });
     await redirectInput.fill("*");
     await expect(page.getByTestId("redirect-any-warning")).toBeVisible();
     await redirectInput.fill("https://*.example.test/callback");
     await expect(page.getByTestId("redirect-wildcard-warning")).toBeVisible();
     await redirectInput.fill("https://pw.example.test/alt");
-    await page.getByRole("button", { name: /^Add$/ }).click();
+    const redirectCard = page.getByRole("heading", { name: "Redirect URIs", exact: true }).locator("..").locator("..");
+    await redirectCard.getByRole("button", { name: "Add" }).click();
     await expect(page.getByText("https://pw.example.test/alt")).toBeVisible();
 
     await page.getByRole("button", { name: "Rotate secret" }).click();

--- a/tests/e2e/collaboration.spec.ts
+++ b/tests/e2e/collaboration.spec.ts
@@ -132,7 +132,9 @@ test.describe("collaboration", () => {
     expect(detailsHref).toBeTruthy();
     await readerPage.goto(detailsHref!, { waitUntil: "domcontentloaded" });
     await expect(readerPage.getByTestId("scope-save-button")).toBeDisabled();
-    await expect(readerPage.getByRole("button", { name: "Add", exact: true })).toBeDisabled();
+    const addButtons = readerPage.getByRole("button", { name: "Add" });
+    await expect(addButtons.first()).toBeDisabled();
+    await expect(addButtons.nth(1)).toBeDisabled();
     await expect(readerPage.getByText("Client secrets can only be rotated by owners or writers.")).toBeVisible();
     await readerContext.close();
   });

--- a/tests/e2e/post-logout-redirect.spec.ts
+++ b/tests/e2e/post-logout-redirect.spec.ts
@@ -1,0 +1,70 @@
+import { expect, test, type APIRequestContext } from "@playwright/test";
+
+type TenantContext = { tenantId: string; resourceId: string };
+
+test.describe("post logout redirect URIs", () => {
+  test("validates post_logout_redirect_uri against post-logout list", async ({ request }) => {
+    const tenant = await createIsolatedTenant(request);
+    const clientId = await seedClient(request, tenant.tenantId, {
+      redirectUris: ["https://client.example.test/callback"],
+      postLogoutRedirectUris: ["https://client.example.test/logout"],
+    });
+
+    const allowed = await endSession(request, tenant, clientId, "https://client.example.test/logout", "logout-state");
+    expect(allowed.status()).toBe(302);
+    expect(allowed.headers()["location"]).toBe("https://client.example.test/logout?state=logout-state");
+
+    const rejected = await endSession(request, tenant, clientId, "https://client.example.test/callback", "bad-state");
+    expect(rejected.status()).toBe(400);
+    const body = (await rejected.json()) as { error: string };
+    expect(body.error).toBe("invalid_redirect_uri");
+  });
+});
+
+const createIsolatedTenant = async (request: APIRequestContext): Promise<TenantContext> => {
+  const uniqueAdminEmail = `pw-admin+${Date.now()}-${Math.random().toString(36).slice(2)}@example.test`;
+  const response = await request.post("/admin/api/test/seed-tenants-clients", { data: { adminEmail: uniqueAdminEmail } });
+  expect(response.ok()).toBeTruthy();
+  const payload = (await response.json()) as { tenantAId: string; tenantAResourceId: string };
+  if (!payload.tenantAId || !payload.tenantAResourceId) {
+    throw new Error("Failed to seed tenant for post-logout redirect tests");
+  }
+  return { tenantId: payload.tenantAId, resourceId: payload.tenantAResourceId };
+};
+
+const seedClient = async (
+  request: APIRequestContext,
+  tenantId: string,
+  options: { redirectUris: string[]; postLogoutRedirectUris: string[] },
+) => {
+  const response = await request.post("/api/test/clients", {
+    data: {
+      names: ["Post-logout QA"],
+      tokenEndpointAuthMethods: ["none"],
+      tenantId,
+      redirectUris: options.redirectUris,
+      postLogoutRedirectUris: options.postLogoutRedirectUris,
+    },
+  });
+  expect(response.ok()).toBeTruthy();
+  const payload = (await response.json()) as { clients: { clientId: string }[] };
+  const [client] = payload.clients;
+  if (!client) {
+    throw new Error("Failed to seed client");
+  }
+  return client.clientId;
+};
+
+const endSession = (
+  request: APIRequestContext,
+  tenant: TenantContext,
+  clientId: string,
+  postLogoutRedirectUri: string,
+  state: string,
+) => {
+  const url = new URL(`http://127.0.0.1:3000/r/${tenant.resourceId}/oidc/end-session`);
+  url.searchParams.set("client_id", clientId);
+  url.searchParams.set("post_logout_redirect_uri", postLogoutRedirectUri);
+  url.searchParams.set("state", state);
+  return request.fetch(url.toString(), { method: "GET", maxRedirects: 0 });
+};

--- a/tests/e2e/proxy-mockauth-upstream.spec.ts
+++ b/tests/e2e/proxy-mockauth-upstream.spec.ts
@@ -102,7 +102,7 @@ const createRegularClient = async (page: Page, name: string, redirectUris: strin
   await expect(page.getByRole("heading", { name: "New client" })).toBeVisible();
 
   await page.getByLabel("Client name").fill(name);
-  await page.getByLabel("Redirect URIs").fill(redirectUris.join("\n"));
+  await page.getByLabel("Redirect URIs", { exact: true }).fill(redirectUris.join("\n"));
   await page.getByRole("button", { name: "Create client" }).click();
 
   await expect(page.getByText("Client created").first()).toBeVisible();
@@ -138,7 +138,7 @@ const createProxyClient = async (
   await page.getByLabel("Userinfo endpoint").fill(`${ISSUER_BASE}/userinfo`);
   await page.getByLabel("JWKS URI").fill(`${ISSUER_BASE}/jwks.json`);
   await page.getByLabel("Default provider scopes").fill(APP_SCOPE);
-  await page.getByLabel("Redirect URIs").fill(params.redirectUris.join("\n"));
+  await page.getByLabel("Redirect URIs", { exact: true }).fill(params.redirectUris.join("\n"));
 
   await page.getByRole("button", { name: "Create client" }).click();
   await expect(page.getByText("Client created").first()).toBeVisible();


### PR DESCRIPTION
## Summary
- add post-logout redirect URI model/service/admin support
- update admin UI/test APIs to manage post-logout redirects
- extend unit and e2e coverage for post-logout flows

## Testing
- pnpm typecheck
- pnpm test
- pnpm test:e2e
- pnpm lint

Closes #167