### PR TITLE
feat(oidc): add refresh tokens for regular clients

### DIFF
--- a/prisma/migrations/20260412141020_add_refresh_tokens/migration.sql
+++ b/prisma/migrations/20260412141020_add_refresh_tokens/migration.sql
@@ -1,0 +1,44 @@
+-- CreateTable
+CREATE TABLE "RefreshToken" (
+    "id" TEXT NOT NULL,
+    "tenantId" TEXT NOT NULL,
+    "clientId" TEXT NOT NULL,
+    "apiResourceId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "loginStrategy" "LoginStrategy" NOT NULL,
+    "subject" TEXT NOT NULL,
+    "emailVerifiedOverride" BOOLEAN,
+    "familyId" TEXT NOT NULL,
+    "tokenHash" TEXT NOT NULL,
+    "scope" TEXT NOT NULL,
+    "rotatedAt" TIMESTAMP(3),
+    "revokedAt" TIMESTAMP(3),
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "RefreshToken_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RefreshToken_tokenHash_key" ON "RefreshToken"("tokenHash");
+
+-- CreateIndex
+CREATE INDEX "RefreshToken_tenantId_clientId_idx" ON "RefreshToken"("tenantId", "clientId");
+
+-- CreateIndex
+CREATE INDEX "RefreshToken_familyId_idx" ON "RefreshToken"("familyId");
+
+-- CreateIndex
+CREATE INDEX "RefreshToken_expiresAt_idx" ON "RefreshToken"("expiresAt");
+
+-- AddForeignKey
+ALTER TABLE "RefreshToken" ADD CONSTRAINT "RefreshToken_tenantId_fkey" FOREIGN KEY ("tenantId") REFERENCES "Tenant"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RefreshToken" ADD CONSTRAINT "RefreshToken_clientId_fkey" FOREIGN KEY ("clientId") REFERENCES "Client"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RefreshToken" ADD CONSTRAINT "RefreshToken_apiResourceId_fkey" FOREIGN KEY ("apiResourceId") REFERENCES "ApiResource"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RefreshToken" ADD CONSTRAINT "RefreshToken_userId_fkey" FOREIGN KEY ("userId") REFERENCES "MockUser"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -98,6 +98,7 @@ model Tenant {
   mockIdentities    MockIdentity[]
   authorizationCode AuthorizationCode[]
   accessTokens      AccessToken[]
+  refreshTokens     RefreshToken[]
   mockSessions      MockSession[]
   proxyAuthTransactions ProxyAuthTransaction[]
   proxyTokenExchanges   ProxyTokenExchange[]
@@ -119,6 +120,7 @@ model ApiResource {
   clients     Client[]
   authorizationCodes AuthorizationCode[]
   accessTokens AccessToken[]
+  refreshTokens RefreshToken[]
   defaultFor  Tenant?    @relation("TenantDefaultApiResource")
   proxyAuthTransactions ProxyAuthTransaction[]
   proxyTokenExchanges   ProxyTokenExchange[]
@@ -202,6 +204,7 @@ model Client {
   oauthTestSessions        OAuthTestSession[]
   authorizationCodes       AuthorizationCode[]
   accessTokens             AccessToken[]
+  refreshTokens            RefreshToken[]
   proxyConfig              ProxyProviderConfig?
   proxyAuthTransactions    ProxyAuthTransaction[]
   proxyTokenExchanges      ProxyTokenExchange[]
@@ -267,6 +270,7 @@ model MockUser {
   sessions      MockSession[]
   codes         AuthorizationCode[]
   accessTokens  AccessToken[]
+  refreshTokens RefreshToken[]
   @@unique([tenantId, username])
 }
 
@@ -518,6 +522,32 @@ model AccessToken {
   scope      String
   expiresAt  DateTime
   createdAt  DateTime @default(now())
+}
+
+model RefreshToken {
+  id           String      @id @default(uuid())
+  tenant       Tenant      @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  tenantId     String
+  client       Client      @relation(fields: [clientId], references: [id], onDelete: Cascade)
+  clientId     String
+  apiResource  ApiResource @relation(fields: [apiResourceId], references: [id], onDelete: Cascade)
+  apiResourceId String
+  user         MockUser    @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId       String
+  loginStrategy LoginStrategy
+  subject       String
+  emailVerifiedOverride Boolean?
+  familyId     String
+  tokenHash    String      @unique
+  scope        String
+  rotatedAt    DateTime?
+  revokedAt    DateTime?
+  expiresAt    DateTime
+  createdAt    DateTime    @default(now())
+
+  @@index([tenantId, clientId])
+  @@index([familyId])
+  @@index([expiresAt])
 }
 
 model AuditLog {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -9,6 +9,8 @@ const DEFAULT_TENANT_ID = "tenant_qa";
 const DEFAULT_TENANT_NAME = "QA Sandbox";
 const DEFAULT_CLIENT_ID = "qa-client";
 const DEFAULT_CLIENT_SECRET = "qa-secret";
+const REFRESH_CLIENT_ID = "qa-refresh-client";
+const REFRESH_CLIENT_SECRET = "qa-refresh-secret";
 const OWNER_EMAIL = "owner@example.test";
 const WRITER_EMAIL = "writer@example.test";
 const READER_EMAIL = "reader@example.test";
@@ -46,11 +48,32 @@ async function main() {
     },
   });
 
+  const refreshClient = await prisma.client.upsert({
+    where: { tenantId_clientId: { tenantId: tenant.id, clientId: REFRESH_CLIENT_ID } },
+    update: {},
+    create: {
+      tenantId: tenant.id,
+      name: "QA Refresh Client",
+      clientId: REFRESH_CLIENT_ID,
+      clientSecretHash: await hashSecret(REFRESH_CLIENT_SECRET),
+      clientSecretEncrypted: encrypt(REFRESH_CLIENT_SECRET),
+      allowedGrantTypes: ["authorization_code", "refresh_token"],
+      allowedScopes: ["openid", "profile", "email", "offline_access"],
+      tokenEndpointAuthMethods: ["client_secret_post"],
+    },
+  });
+
   const redirectMeta = classifyRedirect("https://client.example.test/callback");
   await prisma.redirectUri.upsert({
     where: { clientId_uri: { clientId: client.id, uri: redirectMeta.normalized } },
     update: {},
     create: { clientId: client.id, uri: redirectMeta.normalized, type: redirectMeta.type },
+  });
+
+  await prisma.redirectUri.upsert({
+    where: { clientId_uri: { clientId: refreshClient.id, uri: redirectMeta.normalized } },
+    update: {},
+    create: { clientId: refreshClient.id, uri: redirectMeta.normalized, type: redirectMeta.type },
   });
 
   await prisma.mockUser.upsert({

--- a/src/app/admin/actions.ts
+++ b/src/app/admin/actions.ts
@@ -74,7 +74,7 @@ import { buildOidcUrls } from "@/server/oidc/url-builder";
 import { resolveRedirectUri } from "@/server/oidc/redirect-uri";
 import { createOauthTestSession, resetOauthTestSessionsForClient } from "@/server/services/oauth-test-service";
 import { clearOauthTestSecretCookie, setOauthTestSecretCookie } from "@/server/oauth/test-cookie";
-import { isValidScopeValue, normalizeScopes, SUPPORTED_SCOPES } from "@/server/oidc/scopes";
+import { DEFAULT_ALLOWED_SCOPES, isValidScopeValue, normalizeScopes } from "@/server/oidc/scopes";
 import { SUPPORTED_JWT_SIGNING_ALGS } from "@/server/oidc/signing-alg";
 import { emitAuditEvent } from "@/server/services/audit-service";
 import { buildConfigChangedDetails, type ProxyProviderConfigSnapshot, type TokenAuthMethod } from "@/server/services/audit-event";
@@ -491,7 +491,9 @@ export const createClientAction = async (
     }
     const redirectEntries = parsed.redirects?.filter(Boolean);
     const postLogoutRedirectEntries = parsed.postLogoutRedirects?.filter(Boolean);
-    const normalizedScopes = parsed.scopes ? normalizeScopes(parsed.scopes) : Array.from(SUPPORTED_SCOPES);
+    const normalizedScopes = parsed.scopes
+      ? normalizeScopes(parsed.scopes)
+      : Array.from(DEFAULT_ALLOWED_SCOPES);
     if (!normalizedScopes.includes("openid")) {
       return { error: "Scopes must include openid" };
     }

--- a/src/app/admin/clients/_constants.ts
+++ b/src/app/admin/clients/_constants.ts
@@ -30,6 +30,6 @@ export const GRANT_TYPE_LABELS: Record<GrantTypeOption, { title: string; descrip
   },
   refresh_token: {
     title: "Refresh token",
-    description: "Allow refresh_token grants for proxy clients.",
+    description: "Allow refresh_token grants for regular clients with offline_access.",
   },
 };

--- a/src/app/r/[apiResourceId]/oidc/token/route.ts
+++ b/src/app/r/[apiResourceId]/oidc/token/route.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import { toResponse } from "@/server/errors";
 import { consumeAuthorizationCode } from "@/server/services/authorization-code-service";
 import { preflightResponse, withCorsHeaders } from "@/server/http/cors";
-import { issueTokensFromCode, issueTokensFromPassword } from "@/server/services/token-service";
+import { issueTokensFromCode, issueTokensFromPassword, issueTokensFromRefreshToken } from "@/server/services/token-service";
 import { resolveOrigin, resolveUrl } from "@/server/http/origin";
 import type { ApiResourceRouteContext } from "@/types/api-resource-route";
 import {
@@ -12,6 +12,8 @@ import {
   completeProxyAuthorizationCodeGrant,
   completeProxyRefreshGrant,
 } from "@/server/services/proxy-token-service";
+import { getApiResourceWithTenant } from "@/server/services/api-resource-service";
+import { getClientForTenant } from "@/server/services/client-service";
 import { createSecurityViolationReporter } from "@/server/services/security-violation";
 import { getRequestContextFromRequest } from "@/server/utils/request-context";
 import type { ProxyFlowRequestDetails } from "@/server/services/audit-event";
@@ -197,20 +199,45 @@ const handleTokenRequest = async (request: NextRequest, context: ApiResourceRout
       return Response.json({ error: "invalid_client" }, { status: 401 });
     }
 
-    const tokens = await completeProxyRefreshGrant({
+    const { tenant } = await getApiResourceWithTenant(apiResourceId);
+    const client = await getClientForTenant(tenant.id, clientId);
+
+    if (client.oauthClientMode === "proxy") {
+      const tokens = await completeProxyRefreshGrant({
+        apiResourceId,
+        clientId,
+        refreshToken: validation.data.refresh_token,
+        scope: validation.data.scope,
+        authMethod,
+        clientSecret,
+        auditContext: {
+          requestContext,
+          clientSecretInBody,
+          clientIdProvided,
+          includeAuthHeader,
+          requestParams: params,
+          request: requestDetails,
+        },
+      });
+
+      return Response.json(tokens);
+    }
+
+    const tokens = await issueTokensFromRefreshToken({
       apiResourceId,
       clientId,
       refreshToken: validation.data.refresh_token,
       scope: validation.data.scope,
+      origin,
       authMethod,
       clientSecret,
       auditContext: {
         requestContext,
+        authMethod,
         clientSecretInBody,
         clientIdProvided,
+        clientId: clientId ?? undefined,
         includeAuthHeader,
-        requestParams: params,
-        request: requestDetails,
       },
     });
 

--- a/src/server/oidc/__tests__/oidc-flow.test.ts
+++ b/src/server/oidc/__tests__/oidc-flow.test.ts
@@ -11,12 +11,14 @@ import { createFreshLoginCookieValue, createReauthCookieValue } from "@/server/o
 import { handleAuthorize } from "@/server/services/authorize-service";
 import { consumeAuthorizationCode } from "@/server/services/authorization-code-service";
 import { createSession, clearSession } from "@/server/services/mock-session-service";
-import { issueTokensFromCode } from "@/server/services/token-service";
+import { issueTokensFromCode, issueTokensFromRefreshToken } from "@/server/services/token-service";
 import { getUserInfo } from "@/server/services/userinfo-service";
 
 const DEFAULT_TENANT_ID = "tenant_qa";
 const CLIENT_ID = "qa-client";
 const CLIENT_SECRET = "qa-secret";
+const REFRESH_CLIENT_ID = "qa-refresh-client";
+const REFRESH_CLIENT_SECRET = "qa-refresh-secret";
 const DEFAULT_REAUTH_TTL_SECONDS = 600;
 
 describe("OIDC flow", () => {
@@ -25,8 +27,10 @@ describe("OIDC flow", () => {
   let sessionToken: string;
   let codeVerifier: string;
   let clientInternalId: string;
+  let refreshClientInternalId: string;
   let originalStrategies: Prisma.JsonValue;
   let originalReauthTtlSeconds: number;
+  let refreshClientOriginalReauthTtlSeconds: number;
   let originalAllowedScopes: string[];
   let originalIdTokenAlg: JwtSigningAlg | null | undefined;
   let originalAccessTokenAlg: JwtSigningAlg | null | undefined;
@@ -74,6 +78,16 @@ describe("OIDC flow", () => {
       where: { id: client.id },
       data: { reauthTtlSeconds: DEFAULT_REAUTH_TTL_SECONDS },
     });
+
+    const refreshClient = await prisma.client.findFirstOrThrow({
+      where: { tenantId: tenant.id, clientId: REFRESH_CLIENT_ID },
+    });
+    refreshClientInternalId = refreshClient.id;
+    refreshClientOriginalReauthTtlSeconds = refreshClient.reauthTtlSeconds;
+    await prisma.client.update({
+      where: { id: refreshClient.id },
+      data: { reauthTtlSeconds: DEFAULT_REAUTH_TTL_SECONDS },
+    });
   });
 
   beforeEach(async () => {
@@ -100,6 +114,13 @@ describe("OIDC flow", () => {
           idTokenSignedResponseAlg: originalIdTokenAlg ?? null,
           accessTokenSigningAlg: originalAccessTokenAlg ?? null,
         },
+      });
+    }
+
+    if (refreshClientInternalId) {
+      await prisma.client.update({
+        where: { id: refreshClientInternalId },
+        data: { reauthTtlSeconds: refreshClientOriginalReauthTtlSeconds },
       });
     }
   });
@@ -161,6 +182,53 @@ describe("OIDC flow", () => {
         "TOKEN_AUTHCODE_COMPLETED",
       ]),
     );
+  });
+
+  it("issues refresh tokens for offline access", async () => {
+    const challenge = computeS256Challenge(codeVerifier);
+    const authorize = await handleAuthorize(
+      {
+        apiResourceId,
+        clientId: REFRESH_CLIENT_ID,
+        redirectUri: "https://client.example.test/callback",
+        responseType: "code",
+        scope: "openid profile offline_access",
+        state: "refresh-flow",
+        codeChallenge: challenge,
+        codeChallengeMethod: "S256",
+        sessionToken,
+        reauthCookie: buildReauthCookie(sessionToken, DEFAULT_REAUTH_TTL_SECONDS, REFRESH_CLIENT_ID),
+      },
+      "https://mockauth.test",
+      `https://mockauth.test/r/${apiResourceId}/oidc/authorize?client_id=${REFRESH_CLIENT_ID}`,
+    );
+
+    expect(authorize.type).toBe("redirect");
+    const code = new URL(authorize.redirectTo).searchParams.get("code");
+    const consumed = await consumeAuthorizationCode(code!);
+    const tokenResponse = await issueTokensFromCode({
+      code: consumed,
+      codeVerifier,
+      redirectUri: "https://client.example.test/callback",
+      origin: "https://mockauth.test",
+      clientSecret: REFRESH_CLIENT_SECRET,
+    });
+    expect(tokenResponse.refresh_token).toBeTruthy();
+
+    const refreshed = await issueTokensFromRefreshToken({
+      apiResourceId,
+      clientId: REFRESH_CLIENT_ID,
+      refreshToken: tokenResponse.refresh_token!,
+      scope: "openid profile",
+      origin: "https://mockauth.test",
+      authMethod: "client_secret_post",
+      clientSecret: REFRESH_CLIENT_SECRET,
+    });
+
+    expect(refreshed.refresh_token).toBeTruthy();
+    expect(refreshed.refresh_token).not.toBe(tokenResponse.refresh_token);
+    const refreshedAccess = decodeJwt(refreshed.access_token!);
+    expect(refreshedAccess.scope).toBe("openid profile");
   });
 
   it("records security violations for PKCE mismatches", async () => {

--- a/src/server/oidc/__tests__/scopes.test.ts
+++ b/src/server/oidc/__tests__/scopes.test.ts
@@ -17,7 +17,7 @@ describe("OIDC scopes", () => {
     for (const scope of SUPPORTED_SCOPES) {
       expect(isSupportedScope(scope)).toBe(true);
     }
-    expect(isSupportedScope("offline_access")).toBe(false);
+    expect(isSupportedScope("offline_access")).toBe(true);
   });
 
   it("validates scope values", () => {

--- a/src/server/oidc/scopes.ts
+++ b/src/server/oidc/scopes.ts
@@ -1,4 +1,6 @@
-export const SUPPORTED_SCOPES = ["openid", "profile", "email"] as const;
+export const SUPPORTED_SCOPES = ["openid", "profile", "email", "offline_access"] as const;
+
+export const DEFAULT_ALLOWED_SCOPES = ["openid", "profile", "email"] as const;
 
 export type SupportedScope = (typeof SUPPORTED_SCOPES)[number];
 

--- a/src/server/services/__tests__/client-service.test.ts
+++ b/src/server/services/__tests__/client-service.test.ts
@@ -304,6 +304,21 @@ describe("client service", () => {
       },
     });
 
+    await prisma.refreshToken.create({
+      data: {
+        tenantId: tenant.id,
+        clientId: client.id,
+        apiResourceId: apiResource.id,
+        userId: mockUser.id,
+        loginStrategy: $Enums.LoginStrategy.USERNAME,
+        subject: mockUser.username,
+        familyId: randomUUID(),
+        tokenHash: randomUUID(),
+        scope: "openid",
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+      },
+    });
+
     const proxyAuth = await prisma.proxyAuthTransaction.create({
       data: {
         tenantId: tenant.id,
@@ -365,6 +380,7 @@ describe("client service", () => {
     expect(await prisma.oAuthTestSession.count({ where: { clientId: client.id } })).toBe(0);
     expect(await prisma.authorizationCode.count({ where: { clientId: client.id } })).toBe(0);
     expect(await prisma.accessToken.count({ where: { clientId: client.id } })).toBe(0);
+    expect(await prisma.refreshToken.count({ where: { clientId: client.id } })).toBe(0);
     expect(await prisma.proxyProviderConfig.count({ where: { clientId: client.id } })).toBe(0);
     expect(await prisma.proxyAuthTransaction.count({ where: { clientId: client.id } })).toBe(0);
     expect(await prisma.proxyTokenExchange.count({ where: { clientId: client.id } })).toBe(0);

--- a/src/server/services/__tests__/discovery-service.test.ts
+++ b/src/server/services/__tests__/discovery-service.test.ts
@@ -10,5 +10,7 @@ describe("discovery document", () => {
     expect(doc.end_session_endpoint).toBe("https://mockauth.test/r/resource_999/oidc/end-session");
     expect(doc.jwks_uri).toBe("https://mockauth.test/r/resource_999/oidc/jwks.json");
     expect(doc.id_token_signing_alg_values_supported).toEqual(["RS256", "PS256", "ES256", "ES384"]);
+    expect(doc.grant_types_supported).toContain("refresh_token");
+    expect(doc.scopes_supported).toContain("offline_access");
   });
 });

--- a/src/server/services/__tests__/end-session-service.test.ts
+++ b/src/server/services/__tests__/end-session-service.test.ts
@@ -3,7 +3,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mockGetApiResourceWithTenant = vi.hoisted(() => vi.fn());
 const mockGetClientForTenant = vi.hoisted(() => vi.fn());
 const mockResolveRedirectUri = vi.hoisted(() => vi.fn());
+const mockGetSessionUser = vi.hoisted(() => vi.fn());
 const mockClearSession = vi.hoisted(() => vi.fn());
+const mockRevokeRefreshTokensForUser = vi.hoisted(() => vi.fn());
 
 vi.mock("@/server/services/api-resource-service", () => ({
   getApiResourceWithTenant: mockGetApiResourceWithTenant,
@@ -19,6 +21,11 @@ vi.mock("@/server/oidc/redirect-uri", () => ({
 
 vi.mock("@/server/services/mock-session-service", () => ({
   clearSession: mockClearSession,
+  getSessionUser: mockGetSessionUser,
+}));
+
+vi.mock("@/server/services/refresh-token-service", () => ({
+  revokeRefreshTokensForUser: mockRevokeRefreshTokensForUser,
 }));
 
 import { handleEndSession } from "@/server/services/end-session-service";
@@ -50,6 +57,8 @@ describe("handleEndSession", () => {
     } as never);
     mockResolveRedirectUri.mockReturnValue(REDIRECT_URI);
     mockClearSession.mockResolvedValue(undefined);
+    mockGetSessionUser.mockResolvedValue(null);
+    mockRevokeRefreshTokensForUser.mockResolvedValue(undefined);
   });
 
   it("redirects when id_token_hint matches issuer", async () => {
@@ -134,6 +143,8 @@ describe("handleEndSession", () => {
   });
 
   it("clears session when a session token is present", async () => {
+    mockGetSessionUser.mockResolvedValue({ user: { id: "user-1" } });
+
     const result = await handleEndSession(
       {
         apiResourceId: API_RESOURCE_ID,
@@ -144,7 +155,13 @@ describe("handleEndSession", () => {
 
     expect(result.type).toBe("html");
     expect(result.clearSessionCookie).toBe(true);
+    expect(mockGetSessionUser).toHaveBeenCalledWith(TENANT_ID, "session-1");
     expect(mockClearSession).toHaveBeenCalledWith(TENANT_ID, "session-1");
+    expect(mockRevokeRefreshTokensForUser).toHaveBeenCalledWith({
+      tenantId: TENANT_ID,
+      userId: "user-1",
+      clientId: null,
+    });
   });
 
   it("rejects malformed JWT payloads", async () => {

--- a/src/server/services/__tests__/tenant-service.test.ts
+++ b/src/server/services/__tests__/tenant-service.test.ts
@@ -78,6 +78,20 @@ describe("tenant service", () => {
         expiresAt: new Date(Date.now() + 60 * 1000),
       },
     });
+    await prisma.refreshToken.create({
+      data: {
+        tenantId: tenant.id,
+        clientId: client.id,
+        apiResourceId: apiResource.id,
+        userId: mockUser.id,
+        loginStrategy: $Enums.LoginStrategy.USERNAME,
+        subject: mockUser.username,
+        familyId: randomUUID(),
+        tokenHash: randomUUID(),
+        scope: "openid",
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+      },
+    });
     await prisma.invite.create({
       data: {
         tenantId: tenant.id,
@@ -99,6 +113,7 @@ describe("tenant service", () => {
     expect(await prisma.invite.count({ where: { tenantId: tenant.id } })).toBe(0);
     expect(await prisma.authorizationCode.count({ where: { tenantId: tenant.id } })).toBe(0);
     expect(await prisma.accessToken.count({ where: { tenantId: tenant.id } })).toBe(0);
+    expect(await prisma.refreshToken.count({ where: { tenantId: tenant.id } })).toBe(0);
     expect(await prisma.mockUser.count({ where: { tenantId: tenant.id } })).toBe(0);
     expect(await prisma.mockSession.count({ where: { tenantId: tenant.id } })).toBe(0);
     expect(await prisma.mockIdentity.count({ where: { tenantId: tenant.id } })).toBe(0);

--- a/src/server/services/__tests__/token-service.test.ts
+++ b/src/server/services/__tests__/token-service.test.ts
@@ -566,6 +566,142 @@ describe("token service refresh grant", () => {
     expect(newRecord.scope).toContain("offline_access");
   });
 
+  it("rejects scope widening during refresh", async () => {
+    const { tenant, apiResource } = await createTenant();
+    const { client, clientSecret } = await createPasswordClient({
+      tenantId: tenant.id,
+      allowedGrantTypes: ["password", "refresh_token"],
+      allowedScopes: ["openid", "profile", "email", "offline_access"],
+    });
+
+    const initial = await issueTokensFromPassword({
+      apiResourceId: apiResource.id,
+      clientId: client.clientId,
+      username: "scope-user",
+      scope: "openid profile offline_access",
+      origin: ORIGIN,
+      authMethod: "client_secret_post",
+      clientSecret,
+    });
+
+    await expect(
+      issueTokensFromRefreshToken({
+        apiResourceId: apiResource.id,
+        clientId: client.clientId,
+        refreshToken: initial.refresh_token!,
+        scope: "openid profile email",
+        origin: ORIGIN,
+        authMethod: "client_secret_post",
+        clientSecret,
+      }),
+    ).rejects.toThrowError("Refresh token does not allow scopes: email");
+  });
+
+  it("rejects expired refresh tokens", async () => {
+    const { tenant, apiResource } = await createTenant();
+    const { client, clientSecret } = await createPasswordClient({
+      tenantId: tenant.id,
+      allowedGrantTypes: ["password", "refresh_token"],
+      allowedScopes: ["openid", "profile", "offline_access"],
+    });
+
+    const initial = await issueTokensFromPassword({
+      apiResourceId: apiResource.id,
+      clientId: client.clientId,
+      username: "expired-user",
+      scope: "openid profile offline_access",
+      origin: ORIGIN,
+      authMethod: "client_secret_post",
+      clientSecret,
+    });
+
+    await prisma.refreshToken.update({
+      where: { tokenHash: hashOpaqueToken(initial.refresh_token!) },
+      data: { expiresAt: new Date(Date.now() - 60 * 1000) },
+    });
+
+    await expect(
+      issueTokensFromRefreshToken({
+        apiResourceId: apiResource.id,
+        clientId: client.clientId,
+        refreshToken: initial.refresh_token!,
+        origin: ORIGIN,
+        authMethod: "client_secret_post",
+        clientSecret,
+      }),
+    ).rejects.toThrowError("Refresh token expired");
+  });
+
+  it("rejects refresh tokens issued to a different client", async () => {
+    const { tenant, apiResource } = await createTenant();
+    const { client, clientSecret } = await createPasswordClient({
+      tenantId: tenant.id,
+      allowedGrantTypes: ["password", "refresh_token"],
+      allowedScopes: ["openid", "profile", "offline_access"],
+    });
+    const { client: otherClient, clientSecret: otherSecret } = await createPasswordClient({
+      tenantId: tenant.id,
+      allowedGrantTypes: ["password", "refresh_token"],
+      allowedScopes: ["openid", "profile", "offline_access"],
+    });
+
+    const initial = await issueTokensFromPassword({
+      apiResourceId: apiResource.id,
+      clientId: client.clientId,
+      username: "mismatch-user",
+      scope: "openid profile offline_access",
+      origin: ORIGIN,
+      authMethod: "client_secret_post",
+      clientSecret,
+    });
+
+    await expect(
+      issueTokensFromRefreshToken({
+        apiResourceId: apiResource.id,
+        clientId: otherClient.clientId,
+        refreshToken: initial.refresh_token!,
+        origin: ORIGIN,
+        authMethod: "client_secret_post",
+        clientSecret: otherSecret,
+      }),
+    ).rejects.toThrowError("Invalid refresh token");
+  });
+
+  it("rejects revoked refresh tokens", async () => {
+    const { tenant, apiResource } = await createTenant();
+    const { client, clientSecret } = await createPasswordClient({
+      tenantId: tenant.id,
+      allowedGrantTypes: ["password", "refresh_token"],
+      allowedScopes: ["openid", "profile", "offline_access"],
+    });
+
+    const initial = await issueTokensFromPassword({
+      apiResourceId: apiResource.id,
+      clientId: client.clientId,
+      username: "revoked-user",
+      scope: "openid profile offline_access",
+      origin: ORIGIN,
+      authMethod: "client_secret_post",
+      clientSecret,
+    });
+
+    await prisma.refreshToken.update({
+      where: { tokenHash: hashOpaqueToken(initial.refresh_token!) },
+      data: { revokedAt: new Date() },
+    });
+
+    await expect(
+      issueTokensFromRefreshToken({
+        apiResourceId: apiResource.id,
+        clientId: client.clientId,
+        refreshToken: initial.refresh_token!,
+        origin: ORIGIN,
+        authMethod: "client_secret_post",
+        clientSecret,
+      }),
+    ).rejects.toThrowError("Refresh token reuse detected");
+  });
+
   it("revokes refresh tokens when reuse is detected", async () => {
     const { tenant, apiResource } = await createTenant();
     const { client, clientSecret } = await createPasswordClient({

--- a/src/server/services/__tests__/token-service.test.ts
+++ b/src/server/services/__tests__/token-service.test.ts
@@ -5,10 +5,11 @@ import { describe, expect, it } from "vitest";
 
 import { $Enums } from "@/generated/prisma/client";
 import { prisma } from "@/server/db/client";
+import { hashOpaqueToken } from "@/server/crypto/opaque-token";
 import { DEFAULT_CLIENT_AUTH_STRATEGIES, type ClientAuthStrategies } from "@/server/oidc/auth-strategy";
 import { DEFAULT_PROXY_AUTH_STRATEGIES, type ProxyAuthStrategies } from "@/server/oidc/proxy-auth-strategy";
 import { createClient } from "@/server/services/client-service";
-import { issueTokensFromPassword } from "@/server/services/token-service";
+import { issueTokensFromPassword, issueTokensFromRefreshToken } from "@/server/services/token-service";
 
 const ORIGIN = "https://mockauth.test";
 
@@ -491,5 +492,125 @@ describe("token service password grant", () => {
         clientSecret,
       }),
     ).rejects.toThrowError("Client is not configured for this issuer");
+  });
+});
+
+describe("token service refresh grant", () => {
+  it("issues refresh tokens for offline access scopes", async () => {
+    const { tenant, apiResource } = await createTenant();
+    const { client, clientSecret } = await createPasswordClient({
+      tenantId: tenant.id,
+      allowedGrantTypes: ["password", "refresh_token"],
+      allowedScopes: ["openid", "profile", "offline_access"],
+    });
+
+    const response = await issueTokensFromPassword({
+      apiResourceId: apiResource.id,
+      clientId: client.clientId,
+      username: "offline-user",
+      scope: "openid profile offline_access",
+      origin: ORIGIN,
+      authMethod: "client_secret_post",
+      clientSecret,
+    });
+
+    expect(response.refresh_token).toBeTruthy();
+    const record = await prisma.refreshToken.findFirstOrThrow({
+      where: { tokenHash: hashOpaqueToken(response.refresh_token!) },
+    });
+    expect(record.clientId).toBe(client.id);
+  });
+
+  it("rotates refresh tokens and narrows scopes", async () => {
+    const { tenant, apiResource } = await createTenant();
+    const { client, clientSecret } = await createPasswordClient({
+      tenantId: tenant.id,
+      allowedGrantTypes: ["password", "refresh_token"],
+      allowedScopes: ["openid", "profile", "offline_access"],
+    });
+
+    const initial = await issueTokensFromPassword({
+      apiResourceId: apiResource.id,
+      clientId: client.clientId,
+      username: "rotate-user",
+      scope: "openid profile offline_access",
+      origin: ORIGIN,
+      authMethod: "client_secret_post",
+      clientSecret,
+    });
+
+    const refreshed = await issueTokensFromRefreshToken({
+      apiResourceId: apiResource.id,
+      clientId: client.clientId,
+      refreshToken: initial.refresh_token!,
+      scope: "openid profile",
+      origin: ORIGIN,
+      authMethod: "client_secret_post",
+      clientSecret,
+    });
+
+    expect(refreshed.refresh_token).toBeTruthy();
+    expect(refreshed.refresh_token).not.toBe(initial.refresh_token);
+
+    const accessToken = decodeJwt(refreshed.access_token!);
+    expect(accessToken.scope).toBe("openid profile");
+
+    const previousRecord = await prisma.refreshToken.findFirstOrThrow({
+      where: { tokenHash: hashOpaqueToken(initial.refresh_token!) },
+    });
+    const newRecord = await prisma.refreshToken.findFirstOrThrow({
+      where: { tokenHash: hashOpaqueToken(refreshed.refresh_token!) },
+    });
+    expect(previousRecord.rotatedAt).not.toBeNull();
+    expect(newRecord.familyId).toBe(previousRecord.familyId);
+    expect(newRecord.scope).toContain("offline_access");
+  });
+
+  it("revokes refresh tokens when reuse is detected", async () => {
+    const { tenant, apiResource } = await createTenant();
+    const { client, clientSecret } = await createPasswordClient({
+      tenantId: tenant.id,
+      allowedGrantTypes: ["password", "refresh_token"],
+      allowedScopes: ["openid", "profile", "offline_access"],
+    });
+
+    const initial = await issueTokensFromPassword({
+      apiResourceId: apiResource.id,
+      clientId: client.clientId,
+      username: "reuse-user",
+      scope: "openid profile offline_access",
+      origin: ORIGIN,
+      authMethod: "client_secret_post",
+      clientSecret,
+    });
+
+    await issueTokensFromRefreshToken({
+      apiResourceId: apiResource.id,
+      clientId: client.clientId,
+      refreshToken: initial.refresh_token!,
+      origin: ORIGIN,
+      authMethod: "client_secret_post",
+      clientSecret,
+    });
+
+    await expect(
+      issueTokensFromRefreshToken({
+        apiResourceId: apiResource.id,
+        clientId: client.clientId,
+        refreshToken: initial.refresh_token!,
+        origin: ORIGIN,
+        authMethod: "client_secret_post",
+        clientSecret,
+      }),
+    ).rejects.toThrowError("Refresh token reuse detected");
+
+    const originalRecord = await prisma.refreshToken.findFirstOrThrow({
+      where: { tokenHash: hashOpaqueToken(initial.refresh_token!) },
+    });
+    const family = await prisma.refreshToken.findMany({
+      where: { familyId: originalRecord.familyId },
+    });
+    expect(family.length).toBeGreaterThan(0);
+    expect(family.every((token) => token.revokedAt !== null)).toBe(true);
   });
 });

--- a/src/server/services/audit-event.ts
+++ b/src/server/services/audit-event.ts
@@ -22,6 +22,7 @@ export type SecurityViolationReason =
   | "pkce_method_unsupported"
   | "pkce_mismatch"
   | "redirect_uri_mismatch"
+  | "refresh_token_reuse"
   | "state_mismatch"
   | "state_not_found"
   | "state_resource_mismatch";

--- a/src/server/services/client-service.ts
+++ b/src/server/services/client-service.ts
@@ -11,7 +11,7 @@ import type { ClientAuthStrategies } from "@/server/oidc/auth-strategy";
 import { DEFAULT_CLIENT_AUTH_STRATEGIES } from "@/server/oidc/auth-strategy";
 import type { ProxyAuthStrategies } from "@/server/oidc/proxy-auth-strategy";
 import { DEFAULT_PROXY_AUTH_STRATEGIES, hasEnabledProxyStrategy } from "@/server/oidc/proxy-auth-strategy";
-import { isValidScopeValue, normalizeScopes, SUPPORTED_SCOPES } from "@/server/oidc/scopes";
+import { DEFAULT_ALLOWED_SCOPES, isValidScopeValue, normalizeScopes } from "@/server/oidc/scopes";
 import {
   TOKEN_AUTH_METHODS,
   parseTokenAuthMethods,
@@ -21,7 +21,8 @@ import {
 import { z } from "zod";
 
 const canonicalizeAllowedScopes = (scopes?: string[]) => {
-  const normalized = scopes && scopes.length > 0 ? normalizeScopes(scopes) : Array.from(SUPPORTED_SCOPES);
+  const normalized =
+    scopes && scopes.length > 0 ? normalizeScopes(scopes) : Array.from(DEFAULT_ALLOWED_SCOPES);
   if (!normalized.includes("openid")) {
     throw new Error("Allowed scopes must include openid");
   }

--- a/src/server/services/discovery-service.ts
+++ b/src/server/services/discovery-service.ts
@@ -12,7 +12,7 @@ export const buildDiscoveryDocument = (origin: string, apiResourceId: string) =>
     jwks_uri: `${issuer}/jwks.json`,
     end_session_endpoint: `${issuer}/end-session`,
     response_types_supported: ["code"],
-    grant_types_supported: ["authorization_code", "password"],
+    grant_types_supported: ["authorization_code", "password", "refresh_token"],
     scopes_supported: SUPPORTED_SCOPES,
     code_challenge_methods_supported: ["S256"],
     token_endpoint_auth_methods_supported: ["client_secret_basic", "client_secret_post", "none"],

--- a/src/server/services/end-session-service.ts
+++ b/src/server/services/end-session-service.ts
@@ -2,8 +2,9 @@ import { DomainError } from "@/server/errors";
 import { issuerForResource } from "@/server/oidc/issuer";
 import { resolveRedirectUri } from "@/server/oidc/redirect-uri";
 import { getClientForTenant } from "@/server/services/client-service";
-import { clearSession } from "@/server/services/mock-session-service";
+import { clearSession, getSessionUser } from "@/server/services/mock-session-service";
 import { getApiResourceWithTenant } from "@/server/services/api-resource-service";
+import { revokeRefreshTokensForUser } from "@/server/services/refresh-token-service";
 
 type EndSessionParams = {
   apiResourceId: string;
@@ -91,7 +92,15 @@ export const handleEndSession = async (params: EndSessionParams, origin: string)
 
   const clearSessionCookie = Boolean(params.sessionToken);
   if (params.sessionToken) {
+    const session = await getSessionUser(tenant.id, params.sessionToken);
     await clearSession(tenant.id, params.sessionToken);
+    if (session?.user?.id) {
+      await revokeRefreshTokensForUser({
+        tenantId: tenant.id,
+        userId: session.user.id,
+        clientId: client?.id ?? null,
+      });
+    }
   }
 
   if (redirectUri) {

--- a/src/server/services/refresh-token-service.ts
+++ b/src/server/services/refresh-token-service.ts
@@ -28,9 +28,9 @@ export const createRefreshToken = async (
   const token = generateOpaqueToken();
   const familyId = input.familyId ?? randomUUID();
   const now = input.now ?? new Date();
-  const client = tx ?? prisma;
+  const db = tx ?? prisma;
 
-  await client.refreshToken.create({
+  await db.refreshToken.create({
     data: {
       tenantId: input.tenantId,
       clientId: input.clientId,
@@ -54,8 +54,8 @@ export const revokeRefreshTokenFamily = async (
   now: Date = new Date(),
   tx?: Prisma.TransactionClient,
 ) => {
-  const client = tx ?? prisma;
-  await client.refreshToken.updateMany({
+  const db = tx ?? prisma;
+  await db.refreshToken.updateMany({
     where: { familyId, revokedAt: null },
     data: { revokedAt: now },
   });

--- a/src/server/services/refresh-token-service.ts
+++ b/src/server/services/refresh-token-service.ts
@@ -1,0 +1,79 @@
+import { randomUUID } from "crypto";
+
+import { addHours } from "date-fns";
+
+import { Prisma, type LoginStrategy } from "@/generated/prisma/client";
+import { prisma } from "@/server/db/client";
+import { generateOpaqueToken, hashOpaqueToken } from "@/server/crypto/opaque-token";
+
+const REFRESH_TOKEN_TTL_HOURS = 24;
+
+type RefreshTokenCreateInput = {
+  tenantId: string;
+  clientId: string;
+  apiResourceId: string;
+  userId: string;
+  loginStrategy: LoginStrategy;
+  subject: string;
+  emailVerifiedOverride?: boolean | null;
+  scope: string;
+  familyId?: string;
+  now?: Date;
+};
+
+export const createRefreshToken = async (
+  input: RefreshTokenCreateInput,
+  tx?: Prisma.TransactionClient,
+): Promise<{ token: string; familyId: string }> => {
+  const token = generateOpaqueToken();
+  const familyId = input.familyId ?? randomUUID();
+  const now = input.now ?? new Date();
+  const client = tx ?? prisma;
+
+  await client.refreshToken.create({
+    data: {
+      tenantId: input.tenantId,
+      clientId: input.clientId,
+      apiResourceId: input.apiResourceId,
+      userId: input.userId,
+      loginStrategy: input.loginStrategy,
+      subject: input.subject,
+      emailVerifiedOverride: input.emailVerifiedOverride ?? null,
+      familyId,
+      tokenHash: hashOpaqueToken(token),
+      scope: input.scope,
+      expiresAt: addHours(now, REFRESH_TOKEN_TTL_HOURS),
+    },
+  });
+
+  return { token, familyId };
+};
+
+export const revokeRefreshTokenFamily = async (
+  familyId: string,
+  now: Date = new Date(),
+  tx?: Prisma.TransactionClient,
+) => {
+  const client = tx ?? prisma;
+  await client.refreshToken.updateMany({
+    where: { familyId, revokedAt: null },
+    data: { revokedAt: now },
+  });
+};
+
+export const revokeRefreshTokensForUser = async (params: {
+  tenantId: string;
+  userId: string;
+  clientId?: string | null;
+}) => {
+  const now = new Date();
+  await prisma.refreshToken.updateMany({
+    where: {
+      tenantId: params.tenantId,
+      userId: params.userId,
+      clientId: params.clientId ?? undefined,
+      revokedAt: null,
+    },
+    data: { revokedAt: now },
+  });
+};

--- a/src/server/services/tenant-service.ts
+++ b/src/server/services/tenant-service.ts
@@ -102,6 +102,7 @@ export const deleteTenant = async (tenantId: string) => {
     await tx.tenant.update({ where: { id: tenantId }, data: { defaultApiResourceId: null } });
     await tx.authorizationCode.deleteMany({ where: { tenantId } });
     await tx.accessToken.deleteMany({ where: { tenantId } });
+    await tx.refreshToken.deleteMany({ where: { tenantId } });
     await tx.mockSession.deleteMany({ where: { tenantId } });
     await tx.mockUser.deleteMany({ where: { tenantId } });
     await tx.redirectUri.deleteMany({ where: { client: { tenantId } } });

--- a/src/server/services/token-service.ts
+++ b/src/server/services/token-service.ts
@@ -148,8 +148,9 @@ const assertPkce = (code: PkceContext, verifier?: string | null) => {
   verifyPkce(code, verifier);
 };
 
-const normalizeRequestedScopes = (scope: string, allowedScopes: string[]) => {
-  const requested = normalizeScopes(scope.split(" ").filter(Boolean));
+const parseScopeList = (scope: string) => normalizeScopes(scope.split(" ").filter(Boolean));
+
+const validateRequestedScopes = (requested: string[], allowedScopes: string[]) => {
   if (requested.length === 0) {
     throw new DomainError("scope is required", { status: 400, code: "invalid_scope" });
   }
@@ -167,7 +168,8 @@ const normalizeRequestedScopes = (scope: string, allowedScopes: string[]) => {
   return requested;
 };
 
-const parseScopeList = (scope: string) => normalizeScopes(scope.split(" ").filter(Boolean));
+const normalizeRequestedScopes = (scope: string, allowedScopes: string[]) =>
+  validateRequestedScopes(parseScopeList(scope), allowedScopes);
 
 const shouldIssueRefreshToken = (scope: string, client: { oauthClientMode: string; allowedGrantTypes: string[] }) => {
   if (client.oauthClientMode !== "regular") {
@@ -183,24 +185,10 @@ const shouldIssueRefreshToken = (scope: string, client: { oauthClientMode: strin
 
 const resolveRefreshTokenScopes = (storedScope: string, requestedScope: string | undefined, allowedScopes: string[]) => {
   const original = parseScopeList(storedScope);
-  const requested = requestedScope ? parseScopeList(requestedScope) : original;
-
-  if (requested.length === 0) {
-    throw new DomainError("scope is required", { status: 400, code: "invalid_scope" });
-  }
-
-  if (!requested.includes("openid")) {
-    throw new DomainError("scope must include openid", { status: 400, code: "invalid_scope" });
-  }
-
-  const allowed = new Set(normalizeScopes(allowedScopes));
-  const notAllowed = requested.filter((value) => !allowed.has(value));
-  if (notAllowed.length > 0) {
-    throw new DomainError(`Client does not allow scopes: ${notAllowed.join(", ")}`, {
-      status: 400,
-      code: "invalid_scope",
-    });
-  }
+  const requested = validateRequestedScopes(
+    requestedScope ? parseScopeList(requestedScope) : original,
+    allowedScopes,
+  );
 
   const notGranted = requested.filter((value) => !original.includes(value));
   if (notGranted.length > 0) {

--- a/src/server/services/token-service.ts
+++ b/src/server/services/token-service.ts
@@ -6,6 +6,7 @@ import type { AuthorizationCodeWithRelations } from "@/server/services/authoriza
 import { prisma } from "@/server/db/client";
 import { decrypt } from "@/server/crypto/key-vault";
 import { verifySecret } from "@/server/crypto/hash";
+import { hashOpaqueToken } from "@/server/crypto/opaque-token";
 import { computeS256Challenge } from "@/server/crypto/pkce";
 import { DomainError } from "@/server/errors";
 import { claimsForScopes } from "@/server/oidc/claims";
@@ -13,13 +14,14 @@ import { issuerForResource } from "@/server/oidc/issuer";
 import { resolveRedirectUri } from "@/server/oidc/redirect-uri";
 import { ensureActiveKeyForAlg } from "@/server/services/key-service";
 import type { ClientAuthStrategy } from "@/server/oidc/auth-strategy";
-import { fromPrismaLoginStrategy, parseClientAuthStrategies } from "@/server/oidc/auth-strategy";
+import { fromPrismaLoginStrategy, parseClientAuthStrategies, toPrismaLoginStrategy } from "@/server/oidc/auth-strategy";
 import { normalizeScopes } from "@/server/oidc/scopes";
 import { parseTokenAuthMethods, type TokenAuthMethod } from "@/server/oidc/token-auth-method";
 import { DEFAULT_JWT_SIGNING_ALG } from "@/server/oidc/signing-alg";
 import { emitAuditEvent } from "@/server/services/audit-service";
 import {
   buildTokenAuthCodeReceivedDetails,
+  buildTokenRefreshReceivedDetails,
   type TokenResponsePayload,
 } from "@/server/services/audit-event";
 import { getApiResourceWithTenant } from "@/server/services/api-resource-service";
@@ -31,6 +33,7 @@ import {
   SecurityViolationError,
   withSecurityViolationAudit,
 } from "@/server/services/security-violation";
+import { createRefreshToken, revokeRefreshTokenFamily } from "@/server/services/refresh-token-service";
 import type { JwtSigningAlg, MockUser } from "@/generated/prisma/client";
 import type { RequestContext } from "@/server/utils/request-context";
 
@@ -164,6 +167,60 @@ const normalizeRequestedScopes = (scope: string, allowedScopes: string[]) => {
   return requested;
 };
 
+const parseScopeList = (scope: string) => normalizeScopes(scope.split(" ").filter(Boolean));
+
+const shouldIssueRefreshToken = (scope: string, client: { oauthClientMode: string; allowedGrantTypes: string[] }) => {
+  if (client.oauthClientMode !== "regular") {
+    return false;
+  }
+
+  if (!client.allowedGrantTypes.includes("refresh_token")) {
+    return false;
+  }
+
+  return parseScopeList(scope).includes("offline_access");
+};
+
+const resolveRefreshTokenScopes = (storedScope: string, requestedScope: string | undefined, allowedScopes: string[]) => {
+  const original = parseScopeList(storedScope);
+  const requested = requestedScope ? parseScopeList(requestedScope) : original;
+
+  if (requested.length === 0) {
+    throw new DomainError("scope is required", { status: 400, code: "invalid_scope" });
+  }
+
+  if (!requested.includes("openid")) {
+    throw new DomainError("scope must include openid", { status: 400, code: "invalid_scope" });
+  }
+
+  const allowed = new Set(normalizeScopes(allowedScopes));
+  const notAllowed = requested.filter((value) => !allowed.has(value));
+  if (notAllowed.length > 0) {
+    throw new DomainError(`Client does not allow scopes: ${notAllowed.join(", ")}`, {
+      status: 400,
+      code: "invalid_scope",
+    });
+  }
+
+  const notGranted = requested.filter((value) => !original.includes(value));
+  if (notGranted.length > 0) {
+    throw new DomainError(`Refresh token does not allow scopes: ${notGranted.join(", ")}`, {
+      status: 400,
+      code: "invalid_scope",
+    });
+  }
+
+  const refreshScopes =
+    original.includes("offline_access") && !requested.includes("offline_access")
+      ? [...requested, "offline_access"]
+      : requested;
+
+  return {
+    tokenScope: requested.join(" "),
+    refreshScope: refreshScopes.join(" "),
+  };
+};
+
 type TokenIssueContext = {
   tenantId: string;
   apiResourceId: string;
@@ -257,6 +314,34 @@ const issueTokens = async (params: TokenIssueContext): Promise<TokenResponsePayl
   };
 };
 
+const maybeIssueRefreshToken = async (params: {
+  tenantId: string;
+  apiResourceId: string;
+  client: { id: string; oauthClientMode: string; allowedGrantTypes: string[] };
+  user: MockUser;
+  subject: string;
+  loginStrategy: CodeContext["loginStrategy"];
+  emailVerifiedOverride?: boolean | null;
+  scope: string;
+}) => {
+  if (!shouldIssueRefreshToken(params.scope, params.client)) {
+    return null;
+  }
+
+  const { token } = await createRefreshToken({
+    tenantId: params.tenantId,
+    apiResourceId: params.apiResourceId,
+    clientId: params.client.id,
+    userId: params.user.id,
+    loginStrategy: params.loginStrategy,
+    subject: params.subject,
+    emailVerifiedOverride: params.emailVerifiedOverride ?? null,
+    scope: params.scope,
+  });
+
+  return token;
+};
+
 export const issueTokensFromCode = async (params: {
   code: CodeContext;
   codeVerifier?: string | null;
@@ -338,6 +423,19 @@ export const issueTokensFromCode = async (params: {
     nonce: code.nonce,
   });
 
+  const refreshToken = await maybeIssueRefreshToken({
+    tenantId: code.tenantId,
+    apiResourceId: code.apiResourceId,
+    client: code.client,
+    user: code.user,
+    subject: code.subject,
+    loginStrategy: code.loginStrategy,
+    emailVerifiedOverride: code.emailVerifiedOverride ?? null,
+    scope: code.scope,
+  });
+
+  const tokenResponse = refreshToken ? { ...response, refresh_token: refreshToken } : response;
+
   await emitAuditEvent({
     tenantId: code.tenantId,
     clientId: code.clientId,
@@ -346,11 +444,11 @@ export const issueTokensFromCode = async (params: {
     eventType: "TOKEN_AUTHCODE_COMPLETED",
     severity: "INFO",
     message: "Token response issued",
-    details: response,
+    details: tokenResponse,
     requestContext: auditContext?.requestContext ?? null,
   });
 
-  return response;
+  return tokenResponse;
 };
 
 export const issueTokensFromPassword = async (params: {
@@ -433,7 +531,7 @@ export const issueTokensFromPassword = async (params: {
     email: strategy === "email" ? trimmedIdentifier : null,
   });
 
-  return issueTokens({
+  const response = await issueTokens({
     tenantId: tenant.id,
     apiResourceId: resource.id,
     client,
@@ -444,4 +542,179 @@ export const issueTokensFromPassword = async (params: {
     strategy,
     emailVerifiedClaim,
   });
+
+  const refreshToken = await maybeIssueRefreshToken({
+    tenantId: tenant.id,
+    apiResourceId: resource.id,
+    client,
+    user,
+    subject,
+    loginStrategy: toPrismaLoginStrategy(strategy),
+    scope: normalizedScope,
+  });
+
+  return refreshToken ? { ...response, refresh_token: refreshToken } : response;
+};
+
+export const issueTokensFromRefreshToken = async (params: {
+  apiResourceId: string;
+  clientId: string;
+  refreshToken: string;
+  scope?: string;
+  origin: string;
+  authMethod: TokenAuthMethod;
+  clientSecret?: string | null;
+  auditContext?: TokenAuditContext | null;
+}) => {
+  const { apiResourceId, clientId, refreshToken, scope, origin, authMethod, clientSecret, auditContext } = params;
+  const { tenant, resource } = await getApiResourceWithTenant(apiResourceId);
+  const client = await getClientForTenant(tenant.id, clientId);
+  const violationContext = {
+    tenantId: tenant.id,
+    clientId: client.id,
+    traceId: null,
+    severity: "ERROR" as const,
+    authMethod,
+    clientSecretInBody: auditContext?.clientSecretInBody,
+    requestContext: auditContext?.requestContext ?? null,
+  };
+  const reportViolation = createSecurityViolationReporter(violationContext);
+
+  await emitAuditEvent({
+    tenantId: tenant.id,
+    clientId: client.id,
+    traceId: null,
+    actorId: null,
+    eventType: "TOKEN_REFRESH_RECEIVED",
+    severity: "INFO",
+    message: "Token refresh received",
+    details: buildTokenRefreshReceivedDetails({
+      authMethod,
+      clientSecretInBody: auditContext?.clientSecretInBody,
+      clientId: auditContext?.clientId ?? clientId,
+      clientSecret: clientSecret ?? null,
+      grantType: "refresh_token",
+      refreshToken,
+      includeAuthHeader: auditContext?.includeAuthHeader,
+      scope: scope ?? undefined,
+    }),
+    requestContext: auditContext?.requestContext ?? null,
+  });
+
+  const clientResourceId = client.apiResourceId ?? tenant.defaultApiResourceId;
+  if (clientResourceId !== resource.id) {
+    await reportViolation("issuer_mismatch", {
+      expectedApiResourceId: clientResourceId,
+      receivedApiResourceId: resource.id,
+    });
+    throw new DomainError("Client is not configured for this issuer", { status: 400, code: "invalid_client" });
+  }
+
+  if (client.oauthClientMode !== "regular") {
+    throw new DomainError("Client does not support refresh grant", { status: 400, code: "unsupported_grant_type" });
+  }
+
+  if (!client.allowedGrantTypes.includes("refresh_token")) {
+    throw new DomainError("Client does not support refresh grant", { status: 400, code: "unsupported_grant_type" });
+  }
+
+  await withSecurityViolationAudit(() => assertClientAuth(client, authMethod, clientSecret), violationContext);
+
+  const record = await prisma.refreshToken.findFirst({
+    where: {
+      tenantId: tenant.id,
+      clientId: client.id,
+      tokenHash: hashOpaqueToken(refreshToken),
+    },
+    include: { user: true },
+  });
+
+  if (!record || record.apiResourceId !== resource.id) {
+    throw new DomainError("Invalid refresh token", { status: 400, code: "invalid_grant" });
+  }
+
+  const now = new Date();
+  if (record.expiresAt <= now) {
+    throw new DomainError("Refresh token expired", { status: 400, code: "invalid_grant" });
+  }
+
+  if (record.revokedAt || record.rotatedAt) {
+    await revokeRefreshTokenFamily(record.familyId, now);
+    await reportViolation("refresh_token_reuse", "Refresh token reuse detected");
+    throw new DomainError("Refresh token reuse detected", { status: 400, code: "invalid_grant" });
+  }
+
+  const { tokenScope, refreshScope } = resolveRefreshTokenScopes(record.scope, scope, client.allowedScopes);
+
+  const nextRefreshToken = await prisma.$transaction(async (tx) => {
+    const updated = await tx.refreshToken.updateMany({
+      where: { id: record.id, rotatedAt: null, revokedAt: null },
+      data: { rotatedAt: now },
+    });
+
+    if (updated.count !== 1) {
+      await revokeRefreshTokenFamily(record.familyId, now, tx);
+      throw new DomainError("Refresh token reuse detected", { status: 400, code: "invalid_grant" });
+    }
+
+    const { token } = await createRefreshToken(
+      {
+        tenantId: tenant.id,
+        apiResourceId: resource.id,
+        clientId: client.id,
+        userId: record.userId,
+        loginStrategy: record.loginStrategy,
+        subject: record.subject,
+        emailVerifiedOverride: record.emailVerifiedOverride ?? null,
+        scope: refreshScope,
+        familyId: record.familyId,
+        now,
+      },
+      tx,
+    );
+
+    return token;
+  }).catch(async (error) => {
+    if (error instanceof DomainError && error.options.code === "invalid_grant") {
+      await reportViolation("refresh_token_reuse", "Refresh token reuse detected");
+    }
+    throw error;
+  });
+
+  const strategy = fromPrismaLoginStrategy(record.loginStrategy);
+  const strategies = parseClientAuthStrategies(client.authStrategies);
+  const emailVerifiedClaim =
+    strategy === "email"
+      ? strategies.email.emailVerifiedMode === "user_choice"
+        ? Boolean(record.emailVerifiedOverride)
+        : strategies.email.emailVerifiedMode === "true"
+      : undefined;
+
+  const response = await issueTokens({
+    tenantId: tenant.id,
+    apiResourceId: resource.id,
+    client,
+    user: record.user,
+    subject: record.subject,
+    scope: tokenScope,
+    origin,
+    strategy,
+    emailVerifiedClaim,
+  });
+
+  const tokenResponse = { ...response, refresh_token: nextRefreshToken };
+
+  await emitAuditEvent({
+    tenantId: tenant.id,
+    clientId: client.id,
+    traceId: null,
+    actorId: null,
+    eventType: "TOKEN_REFRESH_COMPLETED",
+    severity: "INFO",
+    message: "Token refresh completed",
+    details: tokenResponse,
+    requestContext: auditContext?.requestContext ?? null,
+  });
+
+  return tokenResponse;
 };

--- a/tests/e2e/oidc.spec.ts
+++ b/tests/e2e/oidc.spec.ts
@@ -16,6 +16,8 @@ import {
 const defaultResourceId = "tenant_qa_default_resource";
 const issuerBase = `http://127.0.0.1:3000/r/${defaultResourceId}/oidc`;
 const redirectUri = "https://client.example.test/callback";
+const refreshClientId = "qa-refresh-client";
+const refreshClientSecret = "qa-refresh-secret";
 
 const cookieJar = () => {
   const jar = new Map<string, string>();
@@ -107,6 +109,102 @@ test("completes Authorization Code + PKCE flow", async () => {
   expect(tokenSet.id_token).toBeTruthy();
   const userInfo = await fetchUserInfo(config, tokenSet.access_token!, skipSubjectCheck);
   expect(userInfo.sub).toBeDefined();
+});
+
+test("rotates refresh tokens for offline access", async () => {
+  const config = await discovery(new URL(issuerBase), refreshClientId, refreshClientSecret, undefined, {
+    execute: [allowInsecureRequests],
+  });
+
+  const codeVerifier = randomPKCECodeVerifier();
+  const codeChallenge = await calculatePKCECodeChallenge(codeVerifier);
+  const state = randomState();
+  const nonce = randomNonce();
+  const authUrl = buildAuthorizationUrl(config, {
+    scope: "openid profile offline_access",
+    code_challenge: codeChallenge,
+    code_challenge_method: "S256",
+    redirect_uri: redirectUri,
+    state,
+    nonce,
+  }).toString();
+
+  const jar = cookieJar();
+  const authorizeResponse = await fetch(authUrl, { redirect: "manual" });
+  jar.addFrom(authorizeResponse);
+  expect(authorizeResponse.status).toBe(302);
+  const loginLocation = authorizeResponse.headers.get("location");
+  expect(loginLocation).toContain("/login");
+
+  const loginUrl = new URL(loginLocation!, "http://127.0.0.1:3000");
+  loginUrl.pathname = loginUrl.pathname.replace(/\/oidc\/login$/, "/oidc/login/submit");
+  const loginResponse = await fetch(loginUrl, {
+    method: "POST",
+    redirect: "manual",
+    headers: {
+      "content-type": "application/x-www-form-urlencoded",
+      cookie: jar.header(),
+    },
+    body: new URLSearchParams({ username: "e2e-refresh", return_to: authUrl }).toString(),
+  });
+  jar.addFrom(loginResponse);
+  expect(loginResponse.status).toBe(303);
+  const authorizeAgain = await fetch(loginResponse.headers.get("location")!, {
+    redirect: "manual",
+    headers: { cookie: jar.header() },
+  });
+
+  expect(authorizeAgain.status).toBe(302);
+  const finalLocation = authorizeAgain.headers.get("location");
+  expect(finalLocation).toContain("code=");
+  const callbackUrl = new URL(finalLocation!);
+
+  const tokenSet = await authorizationCodeGrant(config, callbackUrl, {
+    pkceCodeVerifier: codeVerifier,
+    expectedState: state,
+    expectedNonce: nonce,
+  });
+  expect(tokenSet.refresh_token).toBeTruthy();
+
+  const tokenEndpoint = config.serverMetadata().token_endpoint;
+  if (!tokenEndpoint) {
+    throw new Error("Missing token endpoint in discovery");
+  }
+
+  const refreshResponse = await fetch(tokenEndpoint, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: tokenSet.refresh_token!,
+      scope: "openid profile",
+      client_id: refreshClientId,
+      client_secret: refreshClientSecret,
+    }).toString(),
+  });
+  expect(refreshResponse.ok).toBeTruthy();
+  const refreshedPayload = (await refreshResponse.json()) as {
+    access_token: string;
+    refresh_token: string;
+  };
+  expect(refreshedPayload.refresh_token).toBeTruthy();
+  expect(refreshedPayload.refresh_token).not.toBe(tokenSet.refresh_token);
+  const refreshedAccess = decodeJwt(refreshedPayload.access_token);
+  expect(refreshedAccess.scope).toBe("openid profile");
+
+  const reusedResponse = await fetch(tokenEndpoint, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: tokenSet.refresh_token!,
+      client_id: refreshClientId,
+      client_secret: refreshClientSecret,
+    }).toString(),
+  });
+  expect(reusedResponse.status).toBe(400);
+  const reusedPayload = (await reusedResponse.json()) as { error: string };
+  expect(reusedPayload.error).toBe("invalid_grant");
 });
 
 test("requires login when session strategy disallows client", async ({ request }) => {


### PR DESCRIPTION
## Summary
- add refresh token model plus rotation/reuse detection for regular OIDC clients
- support refresh_token grants in the token service/route and revoke refresh tokens on logout
- update admin UI copy/seed data and add coverage across unit/integration/e2e

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm exec dotenv -e .env.development -o -- pnpm build
- pnpm test:prepare
- LD_LIBRARY_PATH=/root/.nix-profile/lib:/workspace/mockauth/.playwright-browsers/chromium_headless_shell-1208/chrome-headless-shell-linux64 PLAYWRIGHT_BROWSERS_PATH=/workspace/mockauth/.playwright-browsers pnpm exec dotenv -e .env.test -o -- playwright test --workers=1 --reporter=line

## Issue
- #169