### PR TITLE
feat(admin): show scopes for proxy clients

### DIFF
--- a/src/app/admin/clients/[clientId]/page.tsx
+++ b/src/app/admin/clients/[clientId]/page.tsx
@@ -176,6 +176,7 @@ export default async function ClientDetailPage({ params }: { params: PageParams 
         }))
       : [];
   const showLocalClientSettings = client.oauthClientMode === "regular";
+  const showClientScopes = client.oauthClientMode === "regular" || client.oauthClientMode === "proxy";
   const showProxyProviderSection = client.oauthClientMode !== "regular";
   const proxyConfigMissing = showProxyProviderSection && !proxyConfigInitial;
   const modeLabel =
@@ -369,10 +370,10 @@ export default async function ClientDetailPage({ params }: { params: PageParams 
               </Alert>
             ) : null}
             <Alert data-testid="proxy-mode-note">
-              <AlertTitle>Scopes and claims come from upstream</AlertTitle>
+              <AlertTitle>Scope allowlist still applies</AlertTitle>
               <AlertDescription>
-                MockAuth will forward tokens from the provider as-is. Local scope toggles and token settings are disabled in
-                proxy mode.
+                MockAuth forwards upstream tokens as-is, but it still validates requested scopes against the allowlist. Use
+                the Scopes card to control what apps can request and the mappings below to translate them upstream.
               </AlertDescription>
             </Alert>
             {proxyConfigInitial ? (
@@ -411,7 +412,7 @@ export default async function ClientDetailPage({ params }: { params: PageParams 
         />
       ) : null}
 
-      {showLocalClientSettings ? (
+      {showClientScopes ? (
         <Card data-testid="client-scopes-card">
           <CardHeader>
             <CardTitle>Scopes</CardTitle>

--- a/src/app/admin/clients/__tests__/client-detail.proxy.test.tsx
+++ b/src/app/admin/clients/__tests__/client-detail.proxy.test.tsx
@@ -132,7 +132,7 @@ describe("ClientDetailPage proxy mode", () => {
     mockGetClientByIdForTenant.mockResolvedValue({ ...proxyClientBase });
   });
 
-  it("shows upstream configuration details and hides local settings", async () => {
+  it("shows upstream configuration details and allowed scopes", async () => {
     const page = await ClientDetailPage({ params: Promise.resolve({ clientId: "client_proxy" }) });
     render(page);
 
@@ -142,7 +142,8 @@ describe("ClientDetailPage proxy mode", () => {
     expect(screen.getByTestId("proxy-auth-strategies-card")).toBeInTheDocument();
     expect(screen.getByTestId("proxy-auth-strategy-form")).toBeInTheDocument();
 
-    expect(screen.queryByTestId("client-scopes-card")).not.toBeInTheDocument();
+    expect(screen.getByTestId("client-scopes-card")).toBeInTheDocument();
+    expect(screen.getByTestId("client-scopes-form")).toBeInTheDocument();
     expect(screen.queryByTestId("client-auth-strategies-card")).not.toBeInTheDocument();
     expect(screen.queryByTestId("client-signing-card")).not.toBeInTheDocument();
     expect(screen.queryByTestId("client-reauth-card")).not.toBeInTheDocument();

--- a/tests/e2e/proxy-clients.spec.ts
+++ b/tests/e2e/proxy-clients.spec.ts
@@ -105,7 +105,7 @@ test.describe("proxy clients", () => {
       await expect(page.getByRole("heading", { name: "Upstream provider" })).toBeVisible();
       await expect(page.getByTestId("provider-redirect-uri-redirect")).toContainText("/oidc/proxy/callback");
       await expect(page.getByTestId("proxy-mode-note")).toBeVisible();
-      await expect(page.locator('[data-testid="client-scopes-card"]')).toHaveCount(0);
+      await expect(page.locator('[data-testid="client-scopes-card"]')).toHaveCount(1);
       await expect(page.locator('[data-testid="client-auth-strategies-card"]')).toHaveCount(0);
       await expect(page.locator('[data-testid="client-signing-card"]')).toHaveCount(0);
       await expect(page.locator('[data-testid="client-reauth-card"]')).toHaveCount(0);


### PR DESCRIPTION
## Summary
- show the scopes editor for proxy-mode clients
- adjust proxy mode messaging around scope enforcement
- update proxy client detail coverage in unit and e2e tests

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm test:prepare
- PLAYWRIGHT_BROWSERS_PATH=.playwright-browsers pnpm exec dotenv -e .env.test -o -- playwright test --workers=1

Closes #171